### PR TITLE
Problem: Config requires changing port for MongoDB

### DIFF
--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -62,7 +62,7 @@ def get_defaults():
             'commit_delay': 35
         },
         'mongodb': {
-            'uri': 'mongodb://127.0.0.1:27006',
+            'uri': 'mongodb://127.0.0.1:27017',
             'database': 'aleph'
         },
         'mail': {


### PR DESCRIPTION
The default port for MongoDB is 27017, not 27006.
https://docs.mongodb.com/manual/reference/default-mongodb-port/

Solution: Use the default port 27017