### PR TITLE
Problem: Dependencies not working out of the box

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ install_requires =
       aiohttp-session[secure]
       aiohttp-jinja2
       aiohttp_cors
-      base58
       configparser
       configmanager
       uvloop
@@ -47,7 +46,7 @@ install_requires =
       eth_account
       hexbytes
       secp256k1
-      coincurve
+      coincurve>=13.0.0
       libp2p
       python-rocksdb
       pytz
@@ -56,6 +55,13 @@ install_requires =
       python-socketio
       substrate-interface
       cosmospy
+      requests>=2.24.0
+      urllib3>=1.25.10
+      aleph-client @ git+https://github.com/aleph-im/aleph-client.git@0.1.1
+
+dependency_links =
+    https://github.com/aleph-im/py-libp2p/tarball/master#egg=libp2p
+    git+https://github.com/aleph-im/nuls2-python.git@master
 
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
@@ -80,11 +86,11 @@ testing =
 bnb =
     python-binance-chain
 nuls2 =
-    nuls2-python
+    nuls2-python @ git+https://github.com/aleph-im/nuls2-python.git
 neo =
     neo-python
 polkadot =
-    substrate-interface
+    substrate-interface>=0.9.27
 cosmos =
     cosmospy
 docs =


### PR DESCRIPTION
Some dependencies have version conflicts, and some dependencies are mentionned explicitely in the `README.md` instead of being in the setup.cfg

Solution: Fix the version of dependencies requiring a minimum version number, and use the forks of dependencies in setup.cfg where they are necessary. 