### PR TITLE
Monolithic Docker image for easy demo node setup 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,56 @@
+# Temporary and binary files
+*~
+*.py[cod]
+*.so
+*.cfg
+!.isort.cfg
+!setup.cfg
+*.orig
+*.log
+*.pot
+__pycache__/*
+.cache/*
+.*.swp
+*/.ipynb_checkpoints/*
+
+
+# data folder
+data*
+
+# Project files
+.ropeproject
+.project
+.pydevproject
+.settings
+.idea
+tags
+
+# Package files
+*.egg
+*.eggs/
+.installed.cfg
+*.egg-info
+
+# Unittest and coverage
+htmlcov/*
+.coverage
+.tox
+junit.xml
+coverage.xml
+.pytest_cache/
+
+# Build and docs folder/files
+build/*
+dist/*
+sdist/*
+docs/api/*
+docs/_rst/*
+docs/_build/*
+cover/*
+MANIFEST
+
+# Per-project virtualenvs
+.venv*/
+
+# User configuration with secrets
+config.yml

--- a/deployment/docker-demo/Dockerfile
+++ b/deployment/docker-demo/Dockerfile
@@ -1,0 +1,127 @@
+# Monolithic Docker image for easy setup of an Aleph.im node in demo scenarios.
+
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install Python dependencies
+RUN apt-get update && apt-get -y upgrade && apt-get install -y \
+     python3 \
+     python3-dev \
+     python3-pip \
+     python3-virtualenv \
+     virtualenv \
+     build-essential \
+     git
+
+# Install system dependencies
+RUN apt-get install -y \
+     libsnappy-dev \
+     zlib1g-dev \
+     libbz2-dev \
+     libgflags-dev \
+     liblz4-dev \
+     librocksdb-dev \
+     libgmp-dev \
+     libsecp256k1-dev \
+     pkg-config \
+     libssl-dev \
+     libleveldb-dev \
+     libyaml-dev
+
+
+# === Install MongoDB, IPFS and Supervisord ===
+
+# Install MongoDB
+RUN apt-get install -y mongodb
+RUN mkdir /run/mongodb
+RUN chown mongodb:mongodb /run/mongodb
+
+# Install IPFS
+RUN apt-get install -y wget
+RUN wget https://ipfs.io/ipns/dist.ipfs.io/go-ipfs/v0.7.0/go-ipfs_v0.7.0_linux-amd64.tar.gz
+RUN tar -xvzf go-ipfs_v0.7.0_linux-amd64.tar.gz -C /opt/
+RUN ln -s /opt/go-ipfs/ipfs /usr/local/bin/
+RUN /opt/go-ipfs/ipfs init
+RUN mkdir /var/lib/ipfs
+# - User 'ipfs' to run IPFS -
+RUN useradd -s /bin/bash ipfs
+RUN chown -R ipfs:ipfs /var/lib/ipfs
+
+# Install Supervisord
+RUN apt-get install -y supervisor
+
+
+# ===  Create an unprivileged user to install Python dependencies ===
+
+# - User 'source' to install code and dependencies -
+RUN useradd -s /bin/bash source
+RUN mkdir /opt/venv
+RUN chown source:source /opt/venv
+
+# - User 'aleph' to run the code itself
+RUN useradd -s /bin/bash aleph
+RUN mkdir /opt/pyaleph
+RUN chown aleph:aleph /opt/pyaleph
+USER aleph
+# ENV is user-specific
+ENV IPFS_PATH /var/lib/ipfs
+
+
+# === Install Python environment and dependencies ===
+USER source
+
+# Create virtualenv
+RUN virtualenv -p python3 /opt/venv
+
+# Install pip
+ENV PIP_NO_CACHE_DIR yes
+RUN /opt/venv/bin/python3 -m pip install --upgrade pip
+ENV PATH="/opt/venv/bin:${PATH}"
+
+# === Copy source code ===
+COPY ../../setup.py /opt/pyaleph/
+COPY ../../setup.cfg /opt/pyaleph/
+COPY ../../src /opt/pyaleph/src
+
+COPY ../../tests /opt/pyaleph/tests
+
+COPY .git /opt/pyaleph/.git
+
+
+# === Install the application and dependencies ===
+
+# Setup directories for `python setup.py develop`
+USER root
+RUN mkdir /opt/pyaleph/src/pyaleph.egg-info
+RUN mkdir /opt/pyaleph/.eggs
+RUN chown -R source:source /opt/pyaleph/src /opt/pyaleph/.eggs
+
+# Install PyAleph source
+USER source
+WORKDIR /opt/pyaleph
+RUN python setup.py develop
+RUN /opt/venv/bin/pip install --use-feature=2020-resolver -e ".[nuls2,testing]"
+
+
+# === Run PyAleph,MongoDB and IPFS using supervisord ===
+USER root
+COPY deployment/docker-demo/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+# Entrypoint script used to initialize IPFS and launch supervisord
+COPY deployment/docker-demo/entrypoint.sh /entrypoint.sh
+CMD ["/entrypoint.sh"]
+
+# IPFS Swarm
+EXPOSE 4001
+# IPFS WebUI
+EXPOSE 5001
+# IPFS Gateway
+EXPOSE 8080
+
+# PyAleph API
+EXPOSE 8081
+# PyAleph p2p network
+EXPOSE 4024 4025
+
+VOLUME /var/lib/mongodb
+VOLUME /var/lib/ipfs

--- a/deployment/docker-demo/README.md
+++ b/deployment/docker-demo/README.md
@@ -1,0 +1,63 @@
+# PyAleph Docker Demo
+
+This directory contains deployment configuration to run PyAleph 
+in a monolithic Docker image for easy setup in demo scenarios. 
+
+The image runs [Supervisord](http://supervisord.org/), which in turn
+starts and supervises PyAleph, MongoDB and IPFS.  
+
+All scripts below are expecting to run from the root of the repository, 
+not from this directory.
+
+## Initial setup
+
+You will need an initial configuration file to run the node.
+See `sample-config.yml` for an example of configuration file. 
+This configuration can then be mounted on `/opt/pyaleph/config.yml`
+when starting the Docker image.
+
+### Ethereum
+
+Ethereum is one of the blockchains that can be used with Aleph.
+
+To connect to Ethereum, you can either use an access provider or 
+host your own Ethereum node.
+
+https://infura.io/ provides an easy access to Ethereum with a free plan.
+
+[Geth](https://geth.ethereum.org/) can be used to run an Ethereum node.
+
+Update your `config.yml`, section `ethereum` adequately.
+
+## Operations
+
+### Building the Docker image
+
+```
+./deployment/docker-demo/build.sh
+```  
+
+### Running with Docker
+
+```
+./deployment/docker-demo/run.sh
+```
+
+This script will persist data from IPFS and MongoDB in Docker volumes
+named `pyaleph-mongodb` and `pyaleph-ipfs`. Logs are written in a 
+tmpfs (RAM) to lower disk wear.
+
+## Debugging
+
+### Logs
+
+Logs for PyAleph and IPFS can be found in `/var/log/supervisor`, 
+and for MongoDB in `/var/log/mongodb/`.
+
+### Process control
+
+The command `supervisorctl` can be used to start/stop processes.
+See [supervisord.org](http://supervisord.org/).
+
+The file [supervisord.conf](supervisord.conf) describes how the services
+are launched. 

--- a/deployment/docker-demo/build.sh
+++ b/deployment/docker-demo/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Use this script to build the Docker image of PyAleph
+
+set -euo pipefail
+
+podman build -t aleph.im/pyaleph-demo -f deployment/docker-demo/Dockerfile .

--- a/deployment/docker-demo/entrypoint.sh
+++ b/deployment/docker-demo/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Initialize IPFS if it has not been done yet
+if [ ! -f /var/lib/ipfs/config ]; then
+  ipfs init
+fi
+
+/usr/bin/supervisord -c /etc/supervisor/supervisord.conf

--- a/deployment/docker-demo/run.sh
+++ b/deployment/docker-demo/run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Use this script to run the Docker image of PyAleph
+
+set -euo pipefail
+
+podman run --name pyaleph \
+  -p 8081:8081 \
+  -p 0.0.0.0:4024:4024 \
+  -p 0.0.0.0:4025:4025 \
+  -p 4001:4001 \
+  -p 5001:5001 \
+  -p 8080:8080 \
+  --mount type=tmpfs,destination=/var/log \
+  -v pyaleph-mongodb:/var/lib/mongodb \
+  -v pyaleph-ipfs:/var/lib/ipfs \
+  -v "$(pwd)/config.yml:/opt/pyaleph/config.yml" \
+  --rm -ti \
+  aleph.im/pyaleph-demo "$@"

--- a/deployment/docker-demo/supervisord.conf
+++ b/deployment/docker-demo/supervisord.conf
@@ -1,0 +1,19 @@
+[supervisord]
+user=root
+nodaemon=true
+
+[program:ipfs]
+user=ipfs
+autostart=true
+environment=IPFS_PATH=/var/lib/ipfs
+command=/opt/go-ipfs/ipfs daemon --enable-pubsub-experiment
+
+[program:mongodb]
+user=mongodb
+autostart=true
+command=/usr/bin/mongod --verbose --unixSocketPrefix=/run/mongodb --config /etc/mongodb.conf
+
+[program:pyaleph]
+user=aleph
+autostart=true
+command=/opt/venv/bin/pyaleph -vv -c config.yml -p 8081 --host 0.0.0.0


### PR DESCRIPTION
This adds a `Dockerfile` with helper scripts and a README to run PyAleph as a monolothic Docker image for demo purposes.

To run this image, you will need a PyAleph configuration file, as that file contains private keys.
Nothing else should be required to run a node.