### PR TITLE
Problem: CLI arg -h conflicts with --help

### DIFF
--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -54,7 +54,7 @@ def parse_args(args):
     parser.add_argument('-c', '--config', action="store", dest="config_file")
     parser.add_argument('-p', '--port', action="store", type=int, dest="port",
                         default=8080)
-    parser.add_argument('--host', '-h', action="store", type=str, dest="host",
+    parser.add_argument('--bind', '-b', action="store", type=str, dest="host",
                         default="127.0.0.1")
     parser.add_argument('--debug', action="store_true", dest="debug",
                         default=False)


### PR DESCRIPTION
pyaleph raises the following error when launched:
`argparse.ArgumentError: argument --host/-h: conflicting option string: -h`

Solution: Rename -h and --host to -b and --bind

Issue introduced by #19 