### PR TITLE
Store node private key in a file

### DIFF
--- a/deployment/docker-demo/debug.sh
+++ b/deployment/docker-demo/debug.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Use this script to run the Docker image of PyAleph
+
+set -euo pipefail
+
+#podman run --name pyaleph \
+#  -p 8081:8081 \
+#  -p 0.0.0.0:4024:4024 \
+#  -p 0.0.0.0:4025:4025 \
+#  -p 4001:4001 \
+#  -p 5001:5001 \
+#  -p 8080:8080 \
+#  --mount type=tmpfs,destination=/var/log \
+#  -v pyaleph-mongodb:/var/lib/mongodb \
+#  -v pyaleph-ipfs:/var/lib/ipfs \
+#  -v "$(pwd)/config.yml:/opt/pyaleph/config.yml" \
+#  -v "$(pwd)/src:/opt/pyaleph/src" \
+#  --user aleph \
+#  --rm -ti \
+#  aleph.im/pyaleph-demo "$@"
+
+if [ ! -f "$(pwd)/node-secret.key" ]; then
+    touch "$(pwd)/node-secret.key"
+fi
+
+podman run --rm --name pyaleph --user root \
+  -v "$(pwd)/node-secret.key:/opt/pyaleph/node-secret.key" \
+  aleph.im/pyaleph-demo chown aleph:aleph /opt/pyaleph/node-secret.key
+
+podman run --rm -ti --name pyaleph --user aleph \
+  -v "$(pwd)/src:/opt/pyaleph/src" \
+  -v "$(pwd)/node-secret.key:/opt/pyaleph/node-secret.key" \
+  aleph.im/pyaleph-demo "$@"

--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -83,6 +83,21 @@ def parse_args(args):
         help="Generate a node key and exit",
         action="store_true", 
         default=False)
+    parser.add_argument(
+        '--print-key',
+        dest="print_key",
+        help="Print the generated key",
+        action="store_true",
+        default=False)
+    parser.add_argument(
+        '-k',
+        '--key',
+        dest="key_path",
+        help="Path to the node private key",
+        action="store",
+        type=str,
+        default="node-secret.key",
+    )
     return parser.parse_args(args)
 
 
@@ -119,8 +134,8 @@ def main(args):
     # uvloop.install()
     args = parse_args(args)
     if args.generate_key:
-        setup_logging(logging.INFO)
-        generate_keypair(print_info=True)
+        # Generate an key pair and exit
+        generate_keypair(args.print_key, args.key_path)
         return
     
     setup_logging(args.loglevel)
@@ -128,6 +143,15 @@ def main(args):
 
     config = Config(schema=get_defaults())
     app['config'] = config
+
+    if args.key_path:
+        # Load key pair from file
+        with open(args.key_path, 'r') as key_file:
+            config.p2p.key.value = key_file.read()
+
+    if not config.p2p.key.value:
+        LOGGER.critical("Node key cannot be empty")
+        return
 
     config.aleph.port.value = args.port
     config.aleph.host.value = args.host

--- a/src/aleph/services/p2p/__init__.py
+++ b/src/aleph/services/p2p/__init__.py
@@ -5,14 +5,11 @@ from .peers import connect_peer
 from . import singleton
 
 async def init_p2p(config, listen=True, port_id=0, use_key=True):
-    if use_key:
-        pkey = config.p2p.key.value
-    else:
-        pkey = None
+    pkey = config.p2p.key.value
     port = config.p2p.port.value + port_id
     singleton.host, singleton.pubsub, singleton.streamer =\
-         await initialize_host(host=config.p2p.host.value,
-                               port=port, key=pkey, listen=listen,
+         await initialize_host(key=pkey, host=config.p2p.host.value,
+                               port=port, listen=listen,
                                protocol_active=('protocol' in config.p2p.clients.value))
     
 async def get_host():

--- a/src/aleph/services/p2p/manager.py
+++ b/src/aleph/services/p2p/manager.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from libp2p import new_node
 from libp2p.crypto.rsa import RSAPrivateKey, KeyPair, create_new_key_pair
 from Crypto.PublicKey.RSA import import_key
@@ -13,25 +15,34 @@ LOGGER = logging.getLogger('P2P.host')
 FLOODSUB_PROTOCOL_ID = floodsub.PROTOCOL_ID
 GOSSIPSUB_PROTOCOL_ID = gossipsub.PROTOCOL_ID
 
-def generate_keypair(print_info=False):
-    keypair = create_new_key_pair()
-    if print_info:
-        LOGGER.info("Generating new key, please save it to keep same host id.")
-        LOGGER.info(keypair.private_key.impl.export_key().decode('utf-8'))
-    return keypair
-    
 
-async def initialize_host(host='0.0.0.0', port=4025, key=None, listen=True, protocol_active=True):
+def generate_keypair(print_key: bool, key_path: Optional[str]):
+    """Generate an key pair and exit.
+    """
+    keypair = create_new_key_pair()
+    if print_key:
+        # Print the armored key pair for archiving
+        print(keypair.private_key.impl.export_key().decode('utf-8'))
+
+    if key_path:
+        # Save the armored key pair in a file
+        with open(args.key_path, 'wb') as key_file:
+            key_file.write(keypair.private_key.impl.export_key())
+
+    return keypair
+
+
+async def initialize_host(key, host='0.0.0.0', port=4025, listen=True, protocol_active=True):
     from .peers import publish_host, monitor_hosts
     from .protocol import PROTOCOL_ID, AlephProtocol
     from .jobs import reconnect_p2p_job, tidy_http_peers_job
-    if key is None:
-        keypair = generate_keypair(print_info=listen)
-    else:
-        priv = import_key(key)
-        private_key = RSAPrivateKey(priv)
-        public_key = private_key.get_public_key()
-        keypair = KeyPair(private_key, public_key)
+
+    assert key, "Host cannot be initialized without a key"
+
+    priv = import_key(key)
+    private_key = RSAPrivateKey(priv)
+    public_key = private_key.get_public_key()
+    keypair = KeyPair(private_key, public_key)
         
     transport_opt = f"/ip4/{host}/tcp/{port}"
     host = await new_node(transport_opt=[transport_opt],


### PR DESCRIPTION
Problem: Storing node private key the config is not always secure

Solution: Allow loading the node key pair from a dedicated file, and writing it to a file upon generation.

The main goal is to force persistence of the private key, so restarting a node will not change the key pair every time.