### PR TITLE
Add Docker and Docker Compose files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,3 +54,4 @@ MANIFEST
 
 # User configuration with secrets
 config.yml
+node-secret.key

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ MANIFEST
 
 # Per-project virtualenvs
 .venv*/
+
+# Secret files
+config.yml
+node-secret.key

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -1,0 +1,87 @@
+# Monolithic Docker image for easy setup of an Aleph.im node in demo scenarios.
+
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install Python dependencies
+RUN apt-get update && apt-get -y upgrade && apt-get install -y \
+     python3 \
+     python3-dev \
+     python3-pip \
+     python3-venv \
+     build-essential \
+     git && \
+     rm -rf /var/lib/apt/lists/*
+
+# Install system dependencies
+RUN apt-get update && apt-get -y upgrade && apt-get install -y \
+     libsnappy-dev \
+     zlib1g-dev \
+     libbz2-dev \
+     libgflags-dev \
+     liblz4-dev \
+     librocksdb-dev \
+     libgmp-dev \
+     libsecp256k1-dev \
+     pkg-config \
+     libssl-dev \
+     libleveldb-dev \
+     libyaml-dev && \
+     rm -rf /var/lib/apt/lists/*
+
+# ===  Create unprivileged users ===
+
+# - User 'source' to install code and dependencies -
+RUN useradd -s /bin/bash source
+RUN mkdir /opt/venv
+RUN chown source:source /opt/venv
+
+# - User 'aleph' to run the code itself
+RUN useradd -s /bin/bash aleph
+RUN mkdir /opt/pyaleph
+RUN chown aleph:aleph /opt/pyaleph
+
+# === Install Python environment and dependencies ===
+USER source
+
+# Create virtualenv
+RUN python3 -m venv /opt/venv
+
+# Install pip
+ENV PIP_NO_CACHE_DIR yes
+RUN /opt/venv/bin/python3 -m pip install --upgrade pip wheel
+ENV PATH="/opt/venv/bin:${PATH}"
+
+# === Copy source code ===
+COPY setup.py /opt/pyaleph/
+COPY setup.cfg /opt/pyaleph/
+COPY src /opt/pyaleph/src
+
+COPY tests /opt/pyaleph/tests
+
+# Git data is used to determine PyAleph's version
+COPY .git /opt/pyaleph/.git
+
+
+# === Install the application and dependencies ===
+
+# Setup directories for `python setup.py develop`
+USER root
+RUN mkdir /opt/pyaleph/src/pyaleph.egg-info
+RUN mkdir /opt/pyaleph/.eggs
+RUN chown -R source:source /opt/pyaleph/src /opt/pyaleph/.eggs
+
+# Install PyAleph source
+USER source
+WORKDIR /opt/pyaleph
+RUN python setup.py develop
+RUN /opt/venv/bin/pip install --use-feature=2020-resolver -e ".[nuls2,testing]"
+
+USER aleph
+CMD ["pyaleph"]
+
+# PyAleph API
+EXPOSE 8081
+# PyAleph p2p network
+EXPOSE 4024 4025

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -1,0 +1,54 @@
+# PyAleph Docker (Beta)
+
+This directory contains the `Dockerfile` to run PyAleph in production.
+
+## Build the Docker image
+
+You can build the Docker image simply using:
+```shell script
+./deployment/docker/build.sh
+```
+
+or by running the Docker build command from the root of the repository:
+```shell script
+docker build -t aleph.im/pyaleph -f deployment/docker/Dockerfile .
+```
+
+## Configure PyAleph
+
+We provide a template configuration in the file `deployment/docker/config.yml`,
+which you will want to customize for your system.
+
+Change the Ethereum API URL to the endpoint you want PyAleph to use.
+
+### Generate your node's private key
+
+An Aleph node needs an asymmetric key pair to communicate with other nodes on the network.
+
+You can generate this key using the following commands after building the Docker image:
+```shell script
+touch node-secret.key
+
+docker run --rm -ti --user root -v $(pwd)/node-secret.key:/opt/pyaleph/node-secret.key aleph.im/pyaleph:latest pyaleph --gen-key
+```
+
+## Running with Docker Compose
+
+You can run PyAleph and it's dependencies MongoDB and IPFS using Docker Compose.
+
+The configuration we provide allows you to run a reverse-proxy for HTTPS termination
+on a docker network named `reverse-proxy`, so you will need to create it first:
+ 
+```shell script
+docker network create reverse-proxy
+```
+
+You can then run PyAleph using Docker Compose:
+```shell script
+docker-compose -f deployment/docker/docker-compose.yml up
+```
+
+## Running with another infrastructure
+
+Have a look at the `docker-compose.yml` configuration to understand how PyAleph
+can be run.

--- a/deployment/docker/build.sh
+++ b/deployment/docker/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Use this script to build the Docker image of PyAleph
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd "$SCRIPT_DIR/../.."
+
+# Use Podman if installed, else use Docker
+if hash podman 2> /dev/null
+then
+  podman build -t aleph.im/pyaleph -f "$SCRIPT_DIR/Dockerfile" .
+else
+  docker build -t aleph.im/pyaleph -f "$SCRIPT_DIR/Dockerfile" .
+fi

--- a/deployment/docker/config.yml
+++ b/deployment/docker/config.yml
@@ -1,0 +1,44 @@
+nuls2:
+    chain_id: 1
+    enabled: False
+    packing_node: False
+    sync_address: NULSd6HgUkssMi6oSjwEn3puNSijLKnyiRV7H
+    api_url: https://apiserver.nuls.io/
+    explorer_url: https://nuls.world/
+    token_contract: NULSd6Hh1FjbnAktH1FFvFnTzfgFnZtgAhYut
+
+ethereum:
+    enabled: True
+    api_url: {{ ALEPH_ETHEREUM_URL } }
+    chain_id: 4
+    packing_node: False
+    sync_contract: "0x6aDF64fC26D495445A3CAB545aC808d66932aC15"
+    start_height: 5042280
+    token_contract: "0xc0134b5b924c2fca106efb33c45446c466fbe03e"
+
+binancechain:
+    enabled: False
+    packing_node: False
+
+mongodb:
+    uri: "mongodb://mongodb:27017"
+    database: aleph
+
+storage:
+    store_files: true
+    engine: mongodb
+
+ipfs:
+    enabled: True
+    host: ipfs
+    port: 5001
+    gateway_port: 8080
+
+aleph:
+    queue_topic: ALEPH
+
+p2p:
+    host: 0.0.0.0
+    port: 4025
+    http_port: 4024
+    reconnect_delay: 60

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -1,0 +1,63 @@
+version: '3.1'
+
+volumes:
+  pyaleph-ipfs:
+  pyaleph-mongodb:
+
+services:
+  pyaleph:
+    restart: always
+    image: aleph.im/pyaleph
+    command: pyaleph --config /opt/pyaleph/config.yml
+    build:
+      context: ../../.
+      dockerfile: ./deployment/docker/Dockerfile
+    ports:
+      - 8081:8080/tcp
+      - 4024:4024/tcp
+      - 4025:4025/tcp
+    volumes:
+      - ./config.yml:/opt/pyaleph/config.yml
+      - ../../node-secret.key:/opt/pyaleph/node-secret.key
+    depends_on:
+      - mongodb
+      - ipfs
+    networks:
+      - pyaleph
+      - reverse-proxy
+    logging:
+      options:
+        max-size: 50m
+#    Enable the following for debugging
+#    stdin_open: true
+#    tty: true
+
+  ipfs:
+    restart: always
+    image: ipfs/go-ipfs
+    ports:
+      - 4001:4001
+      - 4001:4001/udp
+    volumes:
+      - "pyaleph-ipfs:/data/ipfs"
+    environment:
+      - IPFS_PROFILE=server
+    networks:
+      - pyaleph
+      - reverse-proxy
+    command: ["daemon", "--enable-pubsub-experiment"]
+
+  mongodb:
+    restart: always
+    image: mongo:3.6
+    volumes:
+      - pyaleph-mongodb:/data/db
+    command: mongod --storageEngine wiredTiger
+    networks:
+      - pyaleph
+
+networks:
+  pyaleph:
+  reverse-proxy:
+    external:
+      name: reverse-proxy


### PR DESCRIPTION
**Problem**: Dockerfile was absent to run PyAleph for production mode

**Solution**: Add a Dockerfile to run PyAleph in a production mode, as well as a docker-compose.yml file to document how to run it and allow running the node with Docker Compose.