### PR TITLE
Infinite loop when IPFS not available

### DIFF
--- a/src/aleph/services/ipfs/pubsub.py
+++ b/src/aleph/services/ipfs/pubsub.py
@@ -74,5 +74,6 @@ async def incoming_channel(config, topic):
                     tasks = []
                     i = 0
 
-        except Exception:
-            LOGGER.exception("Exception in IPFS pubsub, reconnecting.")
+        except ConnectionRefusedError:
+            LOGGER.exception("Exception in IPFS pubsub, reconnecting in 2 seconds...")
+            await asyncio.sleep(2)


### PR DESCRIPTION
Problem: Infinite loop filled logs when IPFS not available

PyAleph tried to connect to IPFS in an infinite loop with
no delay when connection failed, resulting of high CPU
and log usage.

Solution: Add a 2 seconds delay on reconnection and only catch ConnectionRefusedError.