### PR TITLE
Enh docker demo

### DIFF
--- a/.github/workflows/build-docker-demo.yml
+++ b/.github/workflows/build-docker-demo.yml
@@ -1,0 +1,36 @@
+
+# This is a basic workflow to help you get started with Actions
+
+name: Build-Docker-Demo
+
+# Controls when the action will run. Triggers the workflow on any push
+on: push
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-20.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Use GitHub's Docker registry to cache intermediate layers
+      - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
+      - run: docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache-demo || true
+
+      - name: Build the Docker image
+        run: docker build . -t pyaleph-demo:${GITHUB_REF##*/} -f deployment/docker-demo/Dockerfile --cache-from=docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache-demo
+
+      - name: Push the image on GitHub's repository
+        run: docker tag pyaleph-demo:${GITHUB_REF##*/} docker.pkg.github.com/$GITHUB_REPOSITORY/pyaleph-demo:${GITHUB_REF##*/} && docker push docker.pkg.github.com/$GITHUB_REPOSITORY/pyaleph-demo:${GITHUB_REF##*/} || true
+
+      - name: Cache the image on GitHub's repository
+        run: docker tag pyaleph-demo:${GITHUB_REF##*/} docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache-demo && docker push docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache-demo || true
+
+      - name: Test the Docker image
+        run: |
+          docker run --name pyaleph --user aleph pyaleph-demo:${GITHUB_REF##*/} pyaleph --help

--- a/deployment/docker-demo/Dockerfile
+++ b/deployment/docker-demo/Dockerfile
@@ -80,11 +80,11 @@ RUN /opt/venv/bin/python3 -m pip install --upgrade pip
 ENV PATH="/opt/venv/bin:${PATH}"
 
 # === Copy source code ===
-COPY ../../setup.py /opt/pyaleph/
-COPY ../../setup.cfg /opt/pyaleph/
-COPY ../../src /opt/pyaleph/src
+COPY setup.py /opt/pyaleph/
+COPY setup.cfg /opt/pyaleph/
+COPY src /opt/pyaleph/src
 
-COPY ../../tests /opt/pyaleph/tests
+COPY tests /opt/pyaleph/tests
 
 COPY .git /opt/pyaleph/.git
 

--- a/deployment/docker-demo/README.md
+++ b/deployment/docker-demo/README.md
@@ -12,7 +12,7 @@ not from this directory.
 ## Initial setup
 
 You will need an initial configuration file to run the node.
-See `sample-config.yml` for an example of configuration file. 
+See `deployment/docker-demo/config.yml` for an example of configuration file. 
 This configuration can then be mounted on `/opt/pyaleph/config.yml`
 when starting the Docker image.
 
@@ -25,7 +25,7 @@ host your own Ethereum node.
 
 https://infura.io/ provides an easy access to Ethereum with a free plan.
 
-[Geth](https://geth.ethereum.org/) can be used to run an Ethereum node.
+[Geth](https://geth.ethereum.org/) can be used to run an Ethereum node yourself.
 
 Update your `config.yml`, section `ethereum` adequately.
 

--- a/deployment/docker-demo/build.sh
+++ b/deployment/docker-demo/build.sh
@@ -4,4 +4,16 @@
 
 set -euo pipefail
 
-podman build -t aleph.im/pyaleph-demo -f deployment/docker-demo/Dockerfile .
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd "$SCRIPT_DIR/../.."
+
+# Use Podman if installed, else use Docker
+if hash podman 2> /dev/null
+then
+  DOCKER_COMMAND=podman
+else
+  DOCKER_COMMAND=docker
+fi
+
+$DOCKER_COMMAND build -t aleph.im/pyaleph-demo -f "$SCRIPT_DIR/Dockerfile" .

--- a/deployment/docker-demo/config.yml
+++ b/deployment/docker-demo/config.yml
@@ -1,0 +1,44 @@
+nuls2:
+    chain_id: 1
+    enabled: False
+    packing_node: False
+    sync_address: NULSd6HgUkssMi6oSjwEn3puNSijLKnyiRV7H
+    api_url: https://apiserver.nuls.io/
+    explorer_url: https://nuls.world/
+    token_contract: NULSd6Hh1FjbnAktH1FFvFnTzfgFnZtgAhYut
+
+ethereum:
+    enabled: True
+    api_url: {{ ALEPH_ETHEREUM_URL }}
+    chain_id: 4
+    packing_node: False
+    sync_contract: "0x6aDF64fC26D495445A3CAB545aC808d66932aC15"
+    start_height: 5042280
+    token_contract: "0xc0134b5b924c2fca106efb33c45446c466fbe03e"
+
+binancechain:
+    enabled: False
+    packing_node: False
+
+mongodb:
+    uri: "mongodb://127.0.0.1"
+    database: alephtest
+
+storage:
+    store_files: true
+    engine: mongodb
+
+ipfs:
+    enabled: True
+    host: 127.0.0.1
+    port: 5001
+    gateway_port: 8080
+
+aleph:
+    queue_topic: ALEPH-TEST
+
+p2p:
+    host: 0.0.0.0
+    port: 4025
+    http_port: 4024
+    reconnect_delay: 60

--- a/deployment/docker-demo/debug.sh
+++ b/deployment/docker-demo/debug.sh
@@ -4,31 +4,44 @@
 
 set -euo pipefail
 
-#podman run --name pyaleph \
-#  -p 8081:8081 \
-#  -p 0.0.0.0:4024:4024 \
-#  -p 0.0.0.0:4025:4025 \
-#  -p 4001:4001 \
-#  -p 5001:5001 \
-#  -p 8080:8080 \
-#  --mount type=tmpfs,destination=/var/log \
-#  -v pyaleph-mongodb:/var/lib/mongodb \
-#  -v pyaleph-ipfs:/var/lib/ipfs \
-#  -v "$(pwd)/config.yml:/opt/pyaleph/config.yml" \
-#  -v "$(pwd)/src:/opt/pyaleph/src" \
-#  --user aleph \
-#  --rm -ti \
-#  aleph.im/pyaleph-demo "$@"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd "$SCRIPT_DIR/../.."
+
+# Use Podman if installed, else use Docker
+if hash podman 2> /dev/null
+then
+  DOCKER_COMMAND=podman
+else
+  DOCKER_COMMAND=docker
+fi
 
 if [ ! -f "$(pwd)/node-secret.key" ]; then
     touch "$(pwd)/node-secret.key"
 fi
 
-podman run --rm --name pyaleph --user root \
+# Set container user podman as owner of the key
+$DOCKER_COMMAND run --name pyaleph --rm --user root \
   -v "$(pwd)/node-secret.key:/opt/pyaleph/node-secret.key" \
   aleph.im/pyaleph-demo chown aleph:aleph /opt/pyaleph/node-secret.key
 
-podman run --rm -ti --name pyaleph --user aleph \
-  -v "$(pwd)/src:/opt/pyaleph/src" \
+$DOCKER_COMMAND run --name pyaleph --rm --user ipfs \
   -v "$(pwd)/node-secret.key:/opt/pyaleph/node-secret.key" \
+  aleph.im/pyaleph-demo ipfs init
+
+# Run with source mounted in the container
+$DOCKER_COMMAND run --name pyaleph \
+  --rm -ti \
+  -p 8081:8081 \
+  -p 0.0.0.0:4024:4024 \
+  -p 0.0.0.0:4025:4025 \
+  -p 4001:4001 \
+  -p 5001:5001 \
+  -p 8080:8080 \
+  --mount type=tmpfs,destination=/var/log \
+  -v pyaleph-mongodb:/var/lib/mongodb \
+  -v pyaleph-ipfs:/var/lib/ipfs \
+  -v "$(pwd)/config.yml:/opt/pyaleph/config.yml" \
+  -v "$(pwd)/node-secret.key:/opt/pyaleph/node-secret.key" \
+  -v "$(pwd)/src:/opt/pyaleph/src" \
   aleph.im/pyaleph-demo "$@"

--- a/deployment/docker-demo/supervisord.conf
+++ b/deployment/docker-demo/supervisord.conf
@@ -16,4 +16,4 @@ command=/usr/bin/mongod --verbose --unixSocketPrefix=/run/mongodb --config /etc/
 [program:pyaleph]
 user=aleph
 autostart=true
-command=/opt/venv/bin/pyaleph -vv -c config.yml -p 8081 --host 0.0.0.0
+command=/opt/venv/bin/pyaleph -vv -c config.yml -p 8081 --bind 0.0.0.0


### PR DESCRIPTION
Remove the hardcoded use of Podman to allow use of Docker.

Fix issues in various files.

Add Docker build in GitHub Actions so the image will be easy to run without cloning this repo.