### PR TITLE
Problem: CLI not backward compatible due to key path

### DIFF
--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -96,7 +96,7 @@ def parse_args(args):
         help="Path to the node private key",
         action="store",
         type=str,
-        default="node-secret.key",
+        default="",
     )
     return parser.parse_args(args)
 


### PR DESCRIPTION
Solution: Disable the use of a key path by default.