### PR TITLE
Deploy Aleph Nodes using Docker and build Docker images in GitHub Actions

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,7 +1,7 @@
 
 # This is a basic workflow to help you get started with Actions
 
-name: Build-Docker-Demo
+name: Build-Docker
 
 # Controls when the action will run. Triggers the workflow on any push
 on: push
@@ -20,17 +20,17 @@ jobs:
 
       # Use GitHub's Docker registry to cache intermediate layers
       - run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
-      - run: docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache-demo || true
+      - run: docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache || true
 
       - name: Build the Docker image
-        run: docker build . -t pyaleph-node-demo:${GITHUB_REF##*/} -f deployment/docker-demo/Dockerfile --cache-from=docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache-demo
+        run: docker build . -t pyaleph-node:${GITHUB_REF##*/} -f deployment/docker-build/Dockerfile --cache-from=docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache
 
       - name: Push the image on GitHub's repository
-        run: docker tag pyaleph-node-demo:${GITHUB_REF##*/} docker.pkg.github.com/$GITHUB_REPOSITORY/pyaleph-node-demo:${GITHUB_REF##*/} && docker push docker.pkg.github.com/$GITHUB_REPOSITORY/pyaleph-node-demo:${GITHUB_REF##*/} || true
+        run: docker tag pyaleph-node:${GITHUB_REF##*/} docker.pkg.github.com/$GITHUB_REPOSITORY/pyaleph-node:${GITHUB_REF##*/} && docker push docker.pkg.github.com/$GITHUB_REPOSITORY/pyaleph-node:${GITHUB_REF##*/} || true
 
       - name: Cache the image on GitHub's repository
-        run: docker tag pyaleph-node-demo:${GITHUB_REF##*/} docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache-demo && docker push docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache-demo || true
+        run: docker tag pyaleph-node:${GITHUB_REF##*/} docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache && docker push docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache || true
 
       - name: Test the Docker image
         run: |
-          docker run --name pyaleph --user aleph pyaleph-node-demo:${GITHUB_REF##*/} pyaleph --help
+          docker run --name pyaleph --user aleph pyaleph-node:${GITHUB_REF##*/} pyaleph --help

--- a/deployment/docker-build/Dockerfile
+++ b/deployment/docker-build/Dockerfile
@@ -75,6 +75,7 @@ RUN chown -R source:source /opt/pyaleph/src /opt/pyaleph/.eggs
 # Install PyAleph source
 USER source
 WORKDIR /opt/pyaleph
+RUN pip install --upgrade --use-feature=2020-resolver requests
 RUN python setup.py develop
 RUN /opt/venv/bin/pip install --use-feature=2020-resolver -e ".[nuls2,testing]"
 

--- a/deployment/docker-build/README.md
+++ b/deployment/docker-build/README.md
@@ -1,6 +1,6 @@
 # PyAleph Docker (Beta)
 
-This directory contains the `Dockerfile` to run PyAleph in production.
+This directory contains the `Dockerfile` to build and run PyAleph in production.
 
 ## Build the Docker image
 
@@ -11,7 +11,7 @@ You can build the Docker image simply using:
 
 or by running the Docker build command from the root of the repository:
 ```shell script
-docker build -t aleph.im/pyaleph -f deployment/docker/Dockerfile .
+docker build -t alephim/pyaleph-node -f deployment/docker/Dockerfile .
 ```
 
 ## Configure PyAleph
@@ -29,7 +29,7 @@ You can generate this key using the following commands after building the Docker
 ```shell script
 touch node-secret.key
 
-docker run --rm -ti --user root -v $(pwd)/node-secret.key:/opt/pyaleph/node-secret.key aleph.im/pyaleph:latest pyaleph --gen-key
+docker run --rm -ti --user root -v $(pwd)/node-secret.key:/opt/pyaleph/node-secret.key alephim/pyaleph-node:latest pyaleph --gen-key
 ```
 
 ## Running with Docker Compose

--- a/deployment/docker-build/build.sh
+++ b/deployment/docker-build/build.sh
@@ -11,7 +11,9 @@ cd "$SCRIPT_DIR/../.."
 # Use Podman if installed, else use Docker
 if hash podman 2> /dev/null
 then
-  podman build -t aleph.im/pyaleph -f "$SCRIPT_DIR/Dockerfile" .
+  DOCKER_COMMAND=podman
 else
-  docker build -t aleph.im/pyaleph -f "$SCRIPT_DIR/Dockerfile" .
+  DOCKER_COMMAND=docker
 fi
+
+$DOCKER_COMMAND  build -t alephim/pyaleph-node -f "$SCRIPT_DIR/Dockerfile" .

--- a/deployment/docker-build/config.yml
+++ b/deployment/docker-build/config.yml
@@ -9,7 +9,7 @@ nuls2:
 
 ethereum:
     enabled: True
-    api_url: {{ ALEPH_ETHEREUM_URL } }
+    api_url: {{ ALEPH_ETHEREUM_URL }}
     chain_id: 4
     packing_node: False
     sync_contract: "0x6aDF64fC26D495445A3CAB545aC808d66932aC15"
@@ -35,7 +35,7 @@ ipfs:
     gateway_port: 8080
 
 aleph:
-    queue_topic: ALEPH
+    queue_topic: ALEPH-TEST
 
 p2p:
     host: 0.0.0.0

--- a/deployment/docker-build/docker-compose.yml
+++ b/deployment/docker-build/docker-compose.yml
@@ -1,0 +1,63 @@
+version: '2.4'
+
+volumes:
+  pyaleph-ipfs:
+  pyaleph-mongodb:
+
+services:
+  pyaleph:
+    restart: always
+    image: alephim/pyaleph-node
+    command: pyaleph --config /opt/pyaleph/config.yml
+    build:
+      context: ../../.
+      dockerfile: "Dockerfile"
+    ports:
+      - 80:8080/tcp
+      - 4024:4024/tcp
+      - 4025:4025/tcp
+    volumes:
+      - ./config.yml:/opt/pyaleph/config.yml
+      - ../../node-secret.key:/opt/pyaleph/node-secret.key
+    depends_on:
+      - mongodb
+      - ipfs
+    networks:
+      - pyaleph
+      - reverse-proxy
+    logging:
+      options:
+        max-size: 50m
+#    Enable the following for debugging
+#    stdin_open: true
+#    tty: true
+
+  ipfs:
+    restart: always
+    image: ipfs/go-ipfs
+    ports:
+      - 4001:4001
+      - 4001:4001/udp
+    volumes:
+      - "pyaleph-ipfs:/data/ipfs"
+    environment:
+      - IPFS_PROFILE=server
+    networks:
+      - pyaleph
+      - reverse-proxy
+    command: ["daemon", "--enable-pubsub-experiment"]
+
+  mongodb:
+    restart: always
+    image: mongo:3.6
+    volumes:
+      - pyaleph-mongodb:/data/db
+    command: mongod --storageEngine wiredTiger
+    networks:
+      - pyaleph
+
+networks:
+  pyaleph:
+  reverse-proxy:
+    external:
+      name: reverse-proxy

--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -1,0 +1,9 @@
+# PyAleph Deployment
+
+This directory contains the [Docker Compose](https://docs.docker.com/compose/) file
+to run an Aleph Node in production using the official Docker images on [Docker Hub](https://hub.docker.com/).
+
+See the [Docker-Compose documentation on readthedocs.io](https://pyaleph.readthedocs.io/en/latest/guides/docker-compose.html)
+for the documentation.
+
+See [../docker-build](../docker-build) to build your own image of PyAleph and run it with Docker-Compose.

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '2.4'
 
 volumes:
   pyaleph-ipfs:
@@ -7,24 +7,20 @@ volumes:
 services:
   pyaleph:
     restart: always
-    image: aleph.im/pyaleph
-    command: pyaleph --config /opt/pyaleph/config.yml
-    build:
-      context: ../../.
-      dockerfile: ./deployment/docker/Dockerfile
+    image: alephim/pyaleph-node:beta
+    command: pyaleph --config /opt/pyaleph/config.yml --very-verbose
     ports:
       - 8081:8080/tcp
       - 4024:4024/tcp
       - 4025:4025/tcp
     volumes:
       - ./config.yml:/opt/pyaleph/config.yml
-      - ../../node-secret.key:/opt/pyaleph/node-secret.key
+      - ./node-secret.key:/opt/pyaleph/node-secret.key
     depends_on:
       - mongodb
       - ipfs
     networks:
       - pyaleph
-      - reverse-proxy
     logging:
       options:
         max-size: 50m
@@ -44,8 +40,9 @@ services:
       - IPFS_PROFILE=server
     networks:
       - pyaleph
-      - reverse-proxy
     command: ["daemon", "--enable-pubsub-experiment"]
+    cpus: "0.3"
+    mem_limit: 1500m
 
   mongodb:
     restart: always
@@ -55,9 +52,8 @@ services:
     command: mongod --storageEngine wiredTiger
     networks:
       - pyaleph
+    cpus: "0.3"
+    mem_limit: 500m
 
 networks:
   pyaleph:
-  reverse-proxy:
-    external:
-      name: reverse-proxy

--- a/deployment/docker-demo/build.sh
+++ b/deployment/docker-demo/build.sh
@@ -16,4 +16,4 @@ else
   DOCKER_COMMAND=docker
 fi
 
-$DOCKER_COMMAND build -t aleph.im/pyaleph-demo -f "$SCRIPT_DIR/Dockerfile" .
+$DOCKER_COMMAND build -t alephim/pyaleph-node-demo -f "$SCRIPT_DIR/Dockerfile" .

--- a/deployment/docker-demo/debug.sh
+++ b/deployment/docker-demo/debug.sh
@@ -23,11 +23,11 @@ fi
 # Set container user podman as owner of the key
 $DOCKER_COMMAND run --name pyaleph --rm --user root \
   -v "$(pwd)/node-secret.key:/opt/pyaleph/node-secret.key" \
-  aleph.im/pyaleph-demo chown aleph:aleph /opt/pyaleph/node-secret.key
+  alephim/pyaleph-node-demo chown aleph:aleph /opt/pyaleph/node-secret.key
 
 $DOCKER_COMMAND run --name pyaleph --rm --user ipfs \
   -v "$(pwd)/node-secret.key:/opt/pyaleph/node-secret.key" \
-  aleph.im/pyaleph-demo ipfs init
+  alephim/pyaleph-node-demo ipfs init
 
 # Run with source mounted in the container
 $DOCKER_COMMAND run --name pyaleph \
@@ -44,4 +44,4 @@ $DOCKER_COMMAND run --name pyaleph \
   -v "$(pwd)/config.yml:/opt/pyaleph/config.yml" \
   -v "$(pwd)/node-secret.key:/opt/pyaleph/node-secret.key" \
   -v "$(pwd)/src:/opt/pyaleph/src" \
-  aleph.im/pyaleph-demo "$@"
+  alephim/pyaleph-node-demo "$@"

--- a/deployment/docker-demo/run.sh
+++ b/deployment/docker-demo/run.sh
@@ -23,11 +23,11 @@ fi
 # Set container user podman as owner of the key
 $DOCKER_COMMAND run --name pyaleph --rm --user root \
   -v "$(pwd)/node-secret.key:/opt/pyaleph/node-secret.key" \
-  aleph.im/pyaleph-demo chown aleph:aleph /opt/pyaleph/node-secret.key
+  alephim/pyaleph-node-demo chown aleph:aleph /opt/pyaleph/node-secret.key
 
 $DOCKER_COMMAND run --name pyaleph --rm --user ipfs \
   -v "$(pwd)/node-secret.key:/opt/pyaleph/node-secret.key" \
-  aleph.im/pyaleph-demo ipfs init
+  alephim/pyaleph-node-demo ipfs init
 
 $DOCKER_COMMAND run --name pyaleph \
   -p 8081:8081 \
@@ -42,4 +42,4 @@ $DOCKER_COMMAND run --name pyaleph \
   -v "$(pwd)/config.yml:/opt/pyaleph/config.yml" \
   -v "$(pwd)/node-secret.key:/opt/pyaleph/node-secret.key" \
   --rm -ti \
-  aleph.im/pyaleph-demo "$@"
+  alephim/pyaleph-node-demo "$@"

--- a/docs/guides/docker-compose.rst
+++ b/docs/guides/docker-compose.rst
@@ -1,0 +1,172 @@
+====================================
+Easy deployment using Docker-Compose
+====================================
+
+Introduction
+------------
+
+This tutorial is aimed at people wanting to run an Aleph node with little experience in system administration.
+
+----------
+Components
+----------
+
+- `PyAleph <https://github.com/aleph-im/pyaleph>`_ is the official Aleph.im node software
+- `Docker <https://www.docker.com>`_ is used to pack and deploy PyAleph and sotfware it relies upon
+- `Docker Compose <https://docs.docker.com/compose/>`_ is used to run multiple software together using Docker
+- `MongoDB <https://www.mongodb.com>`_ is the database used by PyAleph to store it's data
+- `IPFS <https://ipfs.io/>`_ is used by PyAleph to store large files
+
+The procedure below explains how to install and run PyAleph, with MongoDB and IPFS on a Linux server using
+Docker and Docker Compose.
+
+0. Requirements
+---------------
+
+A Linux server with the following requirements:
+ - Ability to install Docker and Docker Compose (eg: recent Debian or Ubuntu)
+ - Public IP address
+ - Shell with `sudo` access
+ - A text editor
+
+1. Server setup
+---------------
+
+Install Docker.
+
+On a Debian-based system (Debian, Ubuntu, Linux Mint, ...), you can use the following commands:
+
+.. code-block:: bash
+
+    sudo apt update
+    sudo apt upgrade
+    sudo apt install docker.io docker-compose gnupg2 pass
+
+.. note::
+    gnupg2 and pass are required for `docker login` below.
+
+Add your user to the Docker group
+
+.. code-block:: bash
+
+    sudo usermod -a -G docker $(whoami)
+
+Logout, and login again to apply the new group membership.
+
+2. Configuration files
+----------------------
+
+Create and customize the PyAleph configuration file.
+
+Download the PyAleph configuration template:
+
+.. code-block:: bash
+
+    wget "https://raw.githubusercontent.com/aleph-im/pyaleph/master/deployment/docker/config.yml"
+
+
+----------------
+Ethereum API URL
+----------------
+
+Register on `infura.io <https://infura.io/`_, then create a new Ethereum project.
+In the settings, get the hosted https:// endpoint URL for your project.
+
+The endpoint should look be in the form:
+`https://rinkeby.infura.io/v3/<project-id>` for the test network or
+`https://mainnet.infura.io/v3/<project-id>` for production.
+
+Edit the `config.yml` file to add the endpoint URL in the field [ethereum > api_url].
+
+---------------
+Node secret key
+---------------
+
+An Aleph.im node should have a persistent public-private keypair to authenticate to the network.
+
+Create a file that will be used by the Aleph.im node to store it's private key.
+
+.. code-block:: bash
+
+    touch node-secret.key
+
+
+.. code-block:: bash
+
+    docker run --rm -ti --user root -v $(pwd)/node-secret.key:/opt/pyaleph/node-secret.key alephim/pyaleph-node:beta chown aleph:aleph /opt/pyaleph/node-secret.key
+
+.. code-block:: bash
+
+    docker run --rm -ti -v $(pwd)/node-secret.key:/opt/pyaleph/node-secret.key alephim/pyaleph-node:beta pyaleph --gen-key
+
+
+Optional: Check that the key file is not empty and make a backup of the key:
+
+.. code-block:: bash
+
+    cat node-secret.key
+
+
+..
+    ## Docker setup
+
+    ### Create a personal access token on GitHub:
+    - https://github.com/settings/tokens/new
+    - Select `read:packages` then the button "Generate token"
+
+    Login within Docker using the above access token:
+    ```shell script
+    docker login https://docker.pkg.github.com
+    ```
+    -->
+
+3. Run the node with Docker Compose
+-----------------------------------
+
+Download the Docker Compose file that defines how to run PyAleph, MongoDB and IPFS together.
+
+.. code-block:: bash
+
+    wget "https://raw.githubusercontent.com/aleph-im/pyaleph/master/deployment/docker-compose/docker-compose.yml"
+
+The start running the node:
+
+.. code-block:: bash
+
+    docker-compose up
+
+4. Check that everything is working well
+----------------------------------------
+
+--------------
+Check the logs
+--------------
+
+Make sure that no error is displayed in the logs.
+
+----------
+Check IPFS
+----------
+
+IPFS Web UI: http://localhost:5001/webui
+
+------------------------------
+Check PyAleph data via MongoDB
+------------------------------
+
+MongoDB message counts
+
+.. code-block:: bash
+
+    docker exec -ti --user mongodb debian_mongodb_1 bash
+    $ mongo
+    > use aleph
+    > show collections
+    > db.messages.count()
+    1468900
+    > db.pending_messages.count()
+    63
+    > db.pending_messages.count()
+    4
+
+

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -5,5 +5,6 @@ Guides
 .. toctree::
    :maxdepth: 2
 
+   docker-compose
    installing
    private_net

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,22 +7,8 @@ This is the documentation of **pyaleph**.
 
 .. note::
 
-    This is the main page of your project's `Sphinx`_ documentation.
-    It is formatted in `reStructuredText`_. Add additional pages
-    by creating rst-files in ``docs`` and adding them to the `toctree`_ below.
-    Use then `references`_ in order to link them from this page, e.g.
-    :ref:`authors` and :ref:`changes`.
-
-    It is also possible to refer to the documentation of other Python packages
-    with the `Python domain syntax`_. By default you can reference the
-    documentation of `Sphinx`_, `Python`_, `NumPy`_, `SciPy`_, `matplotlib`_,
-    `Pandas`_, `Scikit-Learn`_. You can add more by extending the
-    ``intersphinx_mapping`` in your Sphinx's ``conf.py``.
-
-    The pretty useful extension `autodoc`_ is activated by default and lets
-    you include documentation from docstrings. Docstrings can be written in
-    `Google style`_ (recommended!), `NumPy style`_ and `classical style`_.
-
+    This documentation is under construction. Please get in touch if you find
+    any with the documentation or of you would like to contribute.
 
 Contents
 ========
@@ -31,8 +17,8 @@ Contents
    :maxdepth: 2
 
    architecture
-   protocol/index
    guides/index
+   protocol/index
 
    License <license>
    Authors <authors>


### PR DESCRIPTION
This is a proposal for the deployment of official Aleph Nodes using PyAleph, using Docker and Docker-Compose.

The file `docs/guides/docker-compose.rst` documents how to install, setup and run an Aleph Node using official Docker images published by Aleph.im on the Docker Hub.

The Docker tag documented is currently `alephim/pyaleph-node:beta` to indicate that it is not considered ready for prime time yet.

This proposal also adds GitHub Actions workflows to build Docker images of PyAleph. These builds will be used for CI, but cannot be pulled by end users yet as this will require [migrating to GitHub Container Registry for Docker images](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images).
