### PR TITLE
Problem: asynciocreate_task is hard to understand

### DIFF
--- a/src/aleph/chains/__init__.py
+++ b/src/aleph/chains/__init__.py
@@ -1,5 +1,6 @@
-import asyncio
 import logging
+from typing import Coroutine, List
+
 from aleph.chains.register import OUTGOING_WORKERS, INCOMING_WORKERS
 
 logger = logging.getLogger(__name__)
@@ -36,12 +37,12 @@ except ModuleNotFoundError as error:
     logger.warning("Can't load CSDK: %s", error.msg)
 
 
-def start_connector(config, outgoing=True):
-    loop = asyncio.get_event_loop()
-
+def connector_tasks(config, outgoing=True) -> List[Coroutine]:
+    tasks: List[Coroutine] = []
     for worker in INCOMING_WORKERS.values():
-        loop.create_task(worker(config))
+        tasks.append(worker(config))
 
     if outgoing:
         for worker in OUTGOING_WORKERS.values():
-            loop.create_task(worker(config))
+            tasks.append(worker(config))
+    return tasks

--- a/src/aleph/services/ipfs/pubsub.py
+++ b/src/aleph/services/ipfs/pubsub.py
@@ -1,3 +1,5 @@
+from typing import Coroutine, List
+
 import aioipfs
 import aiohttp
 import asyncio
@@ -56,13 +58,12 @@ async def incoming_channel(config, topic):
         try:
             i = 0
             #seen_ids = []
-            tasks = []
+            tasks: List[Coroutine] = []
             async for message in sub(topic,
                                      base_url=await get_base_url(config)):
                 LOGGER.debug("New message %r" % message)
                 i += 1
-                tasks.append(
-                    loop.create_task(incoming(message)))
+                tasks.append(incoming(message))
 
                 # await incoming(message, seen_ids=seen_ids)
                 if (i > 1000):

--- a/src/aleph/services/p2p/__init__.py
+++ b/src/aleph/services/p2p/__init__.py
@@ -1,16 +1,20 @@
+from typing import Coroutine, List
+
 from .manager import initialize_host
 from .protocol import incoming_channel
 from .pubsub import pub, sub
 from .peers import connect_peer
 from . import singleton
 
-async def init_p2p(config, listen=True, port_id=0, use_key=True):
+
+async def init_p2p(config, listen=True, port_id=0) -> List[Coroutine]:
     pkey = config.p2p.key.value
     port = config.p2p.port.value + port_id
-    singleton.host, singleton.pubsub, singleton.streamer =\
-         await initialize_host(key=pkey, host=config.p2p.host.value,
-                               port=port, listen=listen,
-                               protocol_active=('protocol' in config.p2p.clients.value))
+    singleton.host, singleton.pubsub, singleton.streamer, tasks =\
+        await initialize_host(key=pkey, host=config.p2p.host.value,
+                              port=port, listen=listen,
+                              protocol_active=('protocol' in config.p2p.clients.value))
+    return tasks
     
 async def get_host():
     return singleton.host

--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -1,5 +1,7 @@
 import logging
 import asyncio
+from typing import Coroutine, List
+
 from libp2p.network.exceptions import SwarmException
 from libp2p.network.stream.exceptions import StreamEOF, StreamReset
 from libp2p.network.stream.net_stream_interface import INetStream
@@ -198,7 +200,7 @@ async def incoming_channel(config, topic):
     while True:
         try:
             i = 0
-            tasks = []
+            tasks: List[Coroutine] = []
             async for mvalue in sub(topic):
                 try:
                     message = json.loads(mvalue['data'])
@@ -211,8 +213,7 @@ async def incoming_channel(config, topic):
                     
                     LOGGER.debug("New message %r" % message)
                     i += 1
-                    tasks.append(
-                        loop.create_task(incoming(message)))
+                    tasks.append(incoming(message))
 
                     # await incoming(message, seen_ids=seen_ids)
                     if (i > 1000):


### PR DESCRIPTION
It is recommended to use asyncio.run_until_complete(asyncio.gather(coroutines)) instead of creating tasks on the loop singleton and then running it _forever_.

Solution: Put coroutines to execute in lists, gather them together and run them all at once.