### PR TITLE
Problem: Different processes were hard to differentiate

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -162,3 +162,4 @@ websockets==8.1
 wrapt==1.11.2
 yarl==1.3.0
 zipp==3.1.0
+setproctitle~=1.1.10

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ install_requires =
       requests>=2.24.0
       urllib3>=1.25.10
       aleph-client @ git+https://github.com/aleph-im/aleph-client.git@0.1.1
+      setproctitle>=1.1.10
 
 dependency_links =
     https://github.com/aleph-im/py-libp2p/tarball/master#egg=libp2p

--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -27,6 +27,7 @@ from aleph.jobs import start_jobs, DBManager, prepare_loop, prepare_manager
 from aleph.services.p2p.manager import generate_keypair
 from aleph import model
 from aleph.services import p2p, filestore
+from setproctitle import setproctitle
 
 __author__ = "Moshe Malawach"
 __copyright__ = "Moshe Malawach"
@@ -113,6 +114,7 @@ def setup_logging(loglevel):
     
 
 def run_server(config_values, log_level, host, port, manager, idx):
+    setproctitle(f"pyaleph-server-{host}:{port}")
     LOGGER = logging.getLogger(__name__)
     setup_logging(log_level)
     LOGGER.debug("run_server...")


### PR DESCRIPTION
Solution: Use library `setproctitle` to rename multiprocessing processes in a meaningful way.