### PR TITLE
Problem: Docker build fails after using for debug

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,6 +30,7 @@ tags
 *.eggs/
 .installed.cfg
 *.egg-info
+src/pyaleph.egg-info
 
 # Unittest and coverage
 htmlcov/*


### PR DESCRIPTION
The folder `src/pyaleph.egg-info` is copied on the build, at least using Podman, and the build fails as it should not be present yet.

Solution: Add the pattern to .gitignore