### PR TITLE
Problem: Aiohttp ports 4024 and 8080 are not working.

### DIFF
--- a/deployment/docker-build/Dockerfile
+++ b/deployment/docker-build/Dockerfile
@@ -79,6 +79,9 @@ RUN pip install --upgrade --use-feature=2020-resolver requests
 RUN python setup.py develop
 RUN /opt/venv/bin/pip install --use-feature=2020-resolver -e ".[nuls2,testing]"
 
+# Fix an issue with Aiohttp not working
+RUN /opt/venv/bin/pip install aiohttp==3.7.2
+
 USER aleph
 CMD ["pyaleph"]
 

--- a/deployment/docker-demo/Dockerfile
+++ b/deployment/docker-demo/Dockerfile
@@ -103,6 +103,8 @@ WORKDIR /opt/pyaleph
 RUN python setup.py develop
 RUN /opt/venv/bin/pip install --use-feature=2020-resolver -e ".[nuls2,testing]"
 
+# Fix an issue with Aiohttp not working
+RUN /opt/venv/bin/pip install aiohttp==3.7.2
 
 # === Run PyAleph,MongoDB and IPFS using supervisord ===
 USER root


### PR DESCRIPTION
Solution: Reinstall aiohttp with pip after installing requirements.

This appears to solve the issue, but the reason is not known.