### PR TITLE
Add Prometheus /metrics entrypoint

### DIFF
--- a/src/aleph/web/controllers/metrics.py
+++ b/src/aleph/web/controllers/metrics.py
@@ -1,0 +1,64 @@
+import json
+import platform
+from dataclasses import dataclass, asdict
+from typing import Dict
+
+import aleph.model
+from aleph import __version__
+
+
+def format_dict_for_prometheus(values: Dict) -> str:
+    """Format a dict to a Prometheus tags string"""
+    values = (f"{key}={json.dumps(value)}"
+              for key, value in values.items())
+    return '{' + ','.join(values) + '}'
+
+
+def format_dataclass_for_prometheus(instance) -> str:
+    """Turn a dataclass into Prometheus text format"""
+
+    result = []
+    for key, value in asdict(instance).items():
+        if isinstance(value, dict):
+            # Use a constant value of 1 for version, as Prometheus does
+            result.append(f"{key}{format_dict_for_prometheus(value)} 1")
+        else:
+            result.append(f"{key} {json.dumps(value)}")
+    return '\n'.join(result)
+
+
+@dataclass
+class BuildInfo:
+    """Dataclass used to export aleph node build info."""
+    python_version: str
+    version: str
+    # branch: str
+    # revision: str
+
+
+@dataclass
+class Metrics:
+    """Dataclass used to expose aleph node metrics.
+    """
+    pyaleph_build_info: BuildInfo
+    pyaleph_status_sync_messages_total: int
+    pyaleph_status_sync_pending_messages_total: int
+
+
+pyaleph_build_info = BuildInfo(
+    python_version=platform.python_version(),
+    version=__version__,
+)
+
+
+async def get_metrics() -> Metrics:
+
+    return Metrics(
+        pyaleph_build_info=pyaleph_build_info,
+
+        pyaleph_status_sync_messages_total=
+        await aleph.model.db.messages.count_documents({}),
+
+        pyaleph_status_sync_pending_messages_total=
+        await aleph.model.db.pending_messages.count_documents({}),
+    )

--- a/src/aleph/web/templates/index.html
+++ b/src/aleph/web/templates/index.html
@@ -41,10 +41,14 @@
     <h2>Sync status</h2>
 
     <p>
-        Messages stored: <span id="messages">{{ messages }}</span>
+        Messages stored: <span id="pyaleph_status_sync_messages_total">
+            {{ pyaleph_status_sync_messages_total }}
+        </span>
     </p>
     <p>
-        Pending messages: <span id="pending_messages">{{ pending_messages }}</span>
+        Pending messages: <span id="pyaleph_status_sync_pending_messages_total">
+            {{ pyaleph_status_sync_pending_messages_total }}
+        </span>
     </p>
 </section>
 
@@ -60,8 +64,12 @@
 
         statusSocket.onmessage = function (event) {
             const data = JSON.parse(event.data)
-            document.getElementById('messages').innerText = data['messages'];
-            document.getElementById('pending_messages').innerText = data['pending_messages'];
+
+            document.getElementById('pyaleph_status_sync_messages_total')
+                .innerText = data['pyaleph_status_sync_messages_total'];
+
+            document.getElementById('pyaleph_status_sync_pending_messages_total')
+                .innerText = data['pyaleph_status_sync_pending_messages_total'];
         }
 
         statusSocket.onclose = function(e) {

--- a/tests/web/controllers/test_metrics.py
+++ b/tests/web/controllers/test_metrics.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+
+from aleph.web.controllers.metrics import format_dict_for_prometheus, \
+    format_dataclass_for_prometheus, Metrics, BuildInfo
+
+
+def test_format_dict_for_prometheus():
+    assert format_dict_for_prometheus(
+        {
+            'a': 1,
+            'b': 2.2,
+            'c': "3",
+        }
+    ) == '{a=1,b=2.2,c="3"}'
+
+
+def test_format_dataclass_for_prometheus():
+
+    @dataclass
+    class Simple:
+        a: int
+        b: float
+        c: str
+
+    assert format_dataclass_for_prometheus(
+        Simple(1, 2.2, "3")
+    ) == 'a 1\nb 2.2\nc "3"'
+
+    @dataclass
+    class Tagged:
+        d: Simple
+        e: str
+
+
+    assert format_dataclass_for_prometheus(
+        Tagged(Simple(1, 2.2, "3"), "e")
+    ) == 'd{a=1,b=2.2,c="3"} 1\ne "e"'
+
+
+def test_metrics():
+    metrics = Metrics(
+        pyaleph_build_info=BuildInfo(
+            python_version='3.8.0',
+            version='v999',
+        ),
+        pyaleph_status_sync_messages_total=123,
+        pyaleph_status_sync_pending_messages_total=456,
+    )
+
+    assert format_dataclass_for_prometheus(
+        metrics
+    ) == ('pyaleph_build_info{python_version="3.8.0",version="v999"} 1\n'
+          'pyaleph_status_sync_messages_total 123\n'
+          'pyaleph_status_sync_pending_messages_total 456')


### PR DESCRIPTION
Problem: Operator could not get metrics
Solution: Implement a Prometheus entrypoint on `/metrics` and expose aleph node metrics on it.

The following metrics are exposed:
```
pyaleph_build_info{python_version="3.8.5",version="unknown"} 1
pyaleph_status_sync_messages_total 71896
pyaleph_status_sync_pending_messages_total 421233
```