### PR TITLE
Feature: Add Sentry error tracking

### DIFF
--- a/docs/guides/docker-compose.rst
+++ b/docs/guides/docker-compose.rst
@@ -85,6 +85,21 @@ The endpoint should look be in the form:
 
 Edit the `config.yml` file to add the endpoint URL in the field [ethereum > api_url].
 
+----------
+Sentry DNS
+----------
+
+`Sentry https://sentry.io/`_ can be used to track errors and receive alerts if an issue
+occurs on the node.
+
+To enable Sentry, add the corresponding
+`DSN https://docs.sentry.io/product/sen=try-basics/dsn-explainer/`_ in the configuration.
+
+.. code-block:: yaml
+
+    sentry:
+        dsn: "https://<SECRET_ID>@<SENTRY_HOST>/<PROJECT_ID>"
+
 ---------------
 Node secret key
 ---------------


### PR DESCRIPTION
Sentry.io provides an easy way to track errors in processes without having to look at the serial output.
Errors can then be analyzed via a web interface and operators notified by email or other channels.

This adds the option to enable sending errors to Sentry, as well as a CLI argument to disable it.
