### PR TITLE
Allow docker-compose format 2.2

### DIFF
--- a/deployment/docker-build/docker-compose.yml
+++ b/deployment/docker-build/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.4'
+version: '2.2'
 
 volumes:
   pyaleph-ipfs:

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.4'
+version: '2.2'
 
 volumes:
   pyaleph-ipfs:


### PR DESCRIPTION
Version 2.4 was not needed, and prevents operators to deploy nodes on Ubuntu 18.04.

Fixes #54