### PR TITLE
Feat: Use git tags for version numbers

### DIFF
--- a/.github/workflows/build-docker-demo.yml
+++ b/.github/workflows/build-docker-demo.yml
@@ -23,7 +23,9 @@ jobs:
       - run: docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache-demo || true
 
       - name: Build the Docker image
-        run: docker build . -t pyaleph-node-demo:${GITHUB_REF##*/} -f deployment/docker-demo/Dockerfile --cache-from=docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache-demo
+        run: |
+          git fetch --prune --unshallow --tags
+          docker build . -t pyaleph-node-demo:${GITHUB_REF##*/} -f deployment/docker-demo/Dockerfile --cache-from=docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache-demo
 
       - name: Push the image on GitHub's repository
         run: docker tag pyaleph-node-demo:${GITHUB_REF##*/} docker.pkg.github.com/$GITHUB_REPOSITORY/pyaleph-node-demo:${GITHUB_REF##*/} && docker push docker.pkg.github.com/$GITHUB_REPOSITORY/pyaleph-node-demo:${GITHUB_REF##*/} || true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -23,7 +23,9 @@ jobs:
       - run: docker pull docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache || true
 
       - name: Build the Docker image
-        run: docker build . -t pyaleph-node:${GITHUB_REF##*/} -f deployment/docker-build/Dockerfile --cache-from=docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache
+        run: |
+          git fetch --prune --unshallow --tags
+          docker build . -t pyaleph-node:${GITHUB_REF##*/} -f deployment/docker-build/Dockerfile --cache-from=docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache
 
       - name: Push the image on GitHub's repository
         run: docker tag pyaleph-node:${GITHUB_REF##*/} docker.pkg.github.com/$GITHUB_REPOSITORY/pyaleph-node:${GITHUB_REF##*/} && docker push docker.pkg.github.com/$GITHUB_REPOSITORY/pyaleph-node:${GITHUB_REF##*/} || true

--- a/src/aleph/__init__.py
+++ b/src/aleph/__init__.py
@@ -1,11 +1,19 @@
 # -*- coding: utf-8 -*-
+import subprocess
+
 from pkg_resources import get_distribution, DistributionNotFound
+
+
+def get_git_version():
+    output = subprocess.check_output(('git', 'describe', '--tags'))
+    return output.decode().strip()
+
 
 try:
     # Change here if project is renamed and does not equal the package name
     dist_name = __name__
     __version__ = get_distribution(dist_name).version
 except DistributionNotFound:
-    __version__ = 'unknown'
+    __version__ = get_git_version()
 finally:
     del get_distribution, DistributionNotFound


### PR DESCRIPTION
Command "git describe --tags" gives an output in the form "v0.0.1" or "v0.0.1-abcdefgh", where "v0.0.1" is the name of the last tag and "abcdefgh" is the start of the last commit id.

Related to #72