### PR TITLE
Upgrade libp2p to version 0.1.4 with 2 fixes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
       eth_account
       hexbytes
       secp256k1
-      coincurve>=13.0.0
+      coincurve
       libp2p
       python-rocksdb
       pytz
@@ -64,7 +64,7 @@ install_requires =
       aiocache~=0.11.1
 
 dependency_links =
-    https://github.com/aleph-im/py-libp2p/tarball/master#egg=libp2p
+    https://github.com/aleph-im/py-libp2p/tarball/0.1.4-1-use-set#egg=libp2p
     git+https://github.com/aleph-im/nuls2-python.git@master
 
 # The usage of test_requires is discouraged, see `Dependency Management` docs


### PR DESCRIPTION
Include a fix to use sets instead of lists for peers, and fix a dependency issue when used with pyaleph.

This seems to work, and seems more reliable than merging all commits from 0.1.4 on top of the fork of PyAleph.

Closes #47