### PR TITLE
Fix: Process smaller groups of tasks (gtasks)

### DIFF
--- a/src/aleph/jobs.py
+++ b/src/aleph/jobs.py
@@ -102,7 +102,7 @@ async def retry_messages_job(shared_stats):
 
             tasks.append(handle_pending_message(pending, seen_ids, actions, messages_actions))
 
-            if (j >= 20000):
+            if (j >= 2000):
                 # Group tasks using asyncio.gather in `gtasks`.
                 # await join_pending_message_tasks(tasks, actions_list=actions, messages_actions_list=messages_actions)
                 gtasks.append(


### PR DESCRIPTION
The queue `gtasks` used to grow so much that it was not processed before the memory of the node was exhausted.

This fixes the issue by using smaller batches.

Related to #71