### PR TITLE
Problem: Could not easily list installed Python packages

### DIFF
--- a/deployment/docker-build/Dockerfile
+++ b/deployment/docker-build/Dockerfile
@@ -36,6 +36,9 @@ RUN apt-get update && apt-get -y upgrade && apt-get install -y \
 RUN useradd -s /bin/bash source
 RUN mkdir /opt/venv
 RUN chown source:source /opt/venv
+# - Installed Python libraries will be save in this file
+RUN touch /opt/build-frozen-requirements.txt
+RUN chown source:source /opt/build-frozen-requirements.txt
 
 # - User 'aleph' to run the code itself
 RUN useradd -s /bin/bash aleph
@@ -85,6 +88,9 @@ RUN /opt/venv/bin/pip install --use-deprecated=legacy-resolver -e ".[testing]"
 
 # Fix an issue with Aiohttp not working
 # RUN /opt/venv/bin/pip install aiohttp==3.7.2
+
+# Save installed Python requirements for debugging
+RUN /opt/venv/bin/pip freeze > /opt/build-frozen-requirements.txt
 
 USER aleph
 CMD ["pyaleph"]

--- a/deployment/docker-demo/Dockerfile
+++ b/deployment/docker-demo/Dockerfile
@@ -56,6 +56,9 @@ RUN apt-get install -y supervisor
 RUN useradd -s /bin/bash source
 RUN mkdir /opt/venv
 RUN chown source:source /opt/venv
+# - Installed Python libraries will be save in this file
+RUN touch /opt/build-frozen-requirements.txt
+RUN chown source:source /opt/build-frozen-requirements.txt
 
 # - User 'aleph' to run the code itself
 RUN useradd -s /bin/bash aleph
@@ -106,6 +109,8 @@ RUN pip install -U --use-deprecated=legacy-resolver substrate-interface
 RUN pip install -U --use-deprecated=legacy-resolver aioipfs
 RUN python setup.py develop
 RUN /opt/venv/bin/pip install --use-deprecated=legacy-resolver -e ".[testing]"
+
+RUN /opt/venv/bin/pip freeze > /opt/build-frozen-requirements.txt
 
 # === Run PyAleph,MongoDB and IPFS using supervisord ===
 USER root


### PR DESCRIPTION
It required executing the container to run `pip freeze` in it.

Solution: Run `pip freeze` during build and save the output in a file.

In the future, this it will be possible to compare this with a list of frozen requirements to find issues due to upgrades in dependencies.