### PR TITLE
Chore: Install aleph-client from PyPI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ install_requires =
       cosmospy
       requests>=2.24.0
       urllib3>=1.25.10
-      aleph-client @ git+https://github.com/aleph-im/aleph-client.git@0.1.1
+      aleph-client>=0.1.5
       setproctitle>=1.1.10
       sentry-sdk>=0.19.4
       dataclasses_json>=0.5.2


### PR DESCRIPTION
Since aleph-client has been upgraded, there is no need to rely on GitHub for it anymore.