### PR TITLE
Feature: Publication errors were too vague

### DIFF
--- a/src/aleph/web/controllers/p2p.py
+++ b/src/aleph/web/controllers/p2p.py
@@ -13,27 +13,33 @@ async def pub_json(request):
     """ Forward the message to P2P host and IPFS server as a pubsub message
     """
     data = await request.json()
-    status = "success"
+    failed_publications = []
+
     try:
         if app['config'].ipfs.enabled.value:
             await asyncio.wait_for(
                 pub_ipfs(data.get('topic'), data.get('data')), .2)
     except Exception:
         LOGGER.exception("Can't publish on ipfs")
-        status = "warning"
-    
-    
+        failed_publications.append("ipfs")
+
     try:
         await asyncio.wait_for(
             pub_p2p(data.get('topic'), data.get('data')), .5)
     except Exception:
         LOGGER.exception("Can't publish on p2p")
-        status = "warning"
+        failed_publications.append("p2p")
 
-    output = {
-        'status': status
-    }
-    return web.json_response(output)
+    status = {
+        0: "success",
+        1: "warning",
+        2: "error",
+    }[len(failed_publications)]
+
+    return web.json_response({
+        "status": status,
+        "failed": failed_publications
+    }, status=500 if status == "error" else 200)
 
 app.router.add_post('/api/v0/ipfs/pubsub/pub', pub_json)
 app.router.add_post('/api/v0/p2p/pubsub/pub', pub_json)


### PR DESCRIPTION
A client was only receiving {status: failed} on pub errors of any kind.

This change lets the client know which pub mechanism failed, and returns an error 500 if both failed.