### PR TITLE
Fix: Logs from subprocesses were not easy to access

### DIFF
--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -169,6 +169,8 @@ def run_server_coroutine(
     Used as target of multiprocessing.Process.
     """
     extra_web_config = extra_web_config or {}
+    logging.basicConfig(level=logging.DEBUG,
+                        filename=f'/tmp/run_server_coroutine-{port}.log')
     if enable_sentry:
         sentry_sdk.init(
             dsn=config_values["sentry"]["dsn"],

--- a/src/aleph/jobs.py
+++ b/src/aleph/jobs.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from logging import getLogger
 from multiprocessing import Process
 from multiprocessing.managers import SyncManager, RemoteError
@@ -377,11 +378,19 @@ def prepare_loop(config_values, manager=None, idx=1):
 
 
 def txs_task_loop(config_values, manager):
+    logging.basicConfig(
+        level=logging.DEBUG,
+        filename='/tmp/txs_task_loop.log',
+    )
     loop, tasks = prepare_loop(config_values, manager, idx=1)
     loop.run_until_complete(asyncio.gather(*tasks, handle_txs_task()))
 
 
 def messages_task_loop(config_values, manager, shared_stats: Optional[Dict]):
+    logging.basicConfig(
+        level=logging.DEBUG,
+        filename='/tmp/messages_task_loop.log',
+    )
     loop, tasks = prepare_loop(config_values, manager, idx=2)
     loop.run_until_complete(asyncio.gather(*tasks, retry_messages_task(shared_stats)))
 


### PR DESCRIPTION
This stores them on disk in /tmp