### PR TITLE
[P2P] Use the official P2P daemon in the P2P service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,7 +30,6 @@ tags
 *.eggs/
 .installed.cfg
 *.egg-info
-src/pyaleph.egg-info
 
 # Unittest and coverage
 htmlcov/*
@@ -49,9 +48,11 @@ docs/_rst/*
 docs/_build/*
 cover/*
 MANIFEST
+.github/
 
 # Per-project virtualenvs
 .venv*/
+venv*/
 
 # User configuration with secrets
 config.yml

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ MANIFEST
 # Secret files
 config.yml
 node-secret.key
+keys/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+Version 0.2
+===========
+
+- Replaced the P2P service by jsp2pd, an official libp2p daemon. This lifts the dependency on py-libp2p.
+- The `--gen-key` option is renamed to `--gen-keys`. It now stores the public key along with the private key,
+  and a serialized version of the private key for use by the P2P daemon.
+- The private key for the P2P host can no longer be provided through the config.yml file using the `p2p.key`
+  field. The key must be provided as a serialized file in the `keys` directory.
+
 Version 0.1
 ===========
 

--- a/deployment/docker-build/README.md
+++ b/deployment/docker-build/README.md
@@ -11,7 +11,7 @@ You can build the Docker image simply using:
 
 or by running the Docker build command from the root of the repository:
 ```shell script
-docker build -t alephim/pyaleph-node -f deployment/docker/Dockerfile .
+docker build -t alephim/pyaleph-node -f deployment/docker/pyaleph.dockerfile .
 ```
 
 ## Configure PyAleph
@@ -29,7 +29,7 @@ You can generate this key using the following commands after building the Docker
 ```shell script
 touch node-secret.key
 
-docker run --rm -ti --user root -v $(pwd)/node-secret.key:/opt/pyaleph/node-secret.key alephim/pyaleph-node:latest pyaleph --gen-key
+docker run --rm -ti --user root -v $(pwd)/node-secret.key:/opt/pyaleph/node-secret.key alephim/pyaleph-node:latest pyaleph --gen-keys
 ```
 
 ## Running with Docker Compose

--- a/deployment/docker-build/build.sh
+++ b/deployment/docker-build/build.sh
@@ -16,4 +16,4 @@ else
   DOCKER_COMMAND=docker
 fi
 
-$DOCKER_COMMAND  build -t alephim/pyaleph-node -f "$SCRIPT_DIR/Dockerfile" .
+$DOCKER_COMMAND  build -t alephim/pyaleph-node -f "$SCRIPT_DIR/pyaleph.dockerfile" .

--- a/deployment/docker-build/config.yml
+++ b/deployment/docker-build/config.yml
@@ -8,8 +8,8 @@ nuls2:
     token_contract: NULSd6Hh1FjbnAktH1FFvFnTzfgFnZtgAhYut
 
 ethereum:
-    enabled: True
-    api_url: {{ ALEPH_ETHEREUM_URL }}
+    enabled: False
+#    api_url: {{ ALEPH_ETHEREUM_URL }}
     chain_id: 1
     packing_node: False
     sync_contract: "0x166fd4299364B21c7567e163d85D78d2fb2f8Ad5"
@@ -22,7 +22,7 @@ binancechain:
     packing_node: False
 
 mongodb:
-    uri: "mongodb://mongodb:27017"
+    uri: "mongodb://localhost:27017"
     database: aleph
 
 storage:
@@ -31,7 +31,7 @@ storage:
 
 ipfs:
     enabled: True
-    host: ipfs
+    host: localhost
     port: 5001
     gateway_port: 8080
 
@@ -40,6 +40,8 @@ aleph:
 
 p2p:
     host: 0.0.0.0
+    control_port: 4020
+    listen_port: 4021
     port: 4025
     http_port: 4024
     reconnect_delay: 60

--- a/deployment/docker-build/docker-compose.yml
+++ b/deployment/docker-build/docker-compose.yml
@@ -1,3 +1,6 @@
+# Starts all the services used by pyaleph, minus pyaleph itself. This is used for local development.
+# Use the docker-compose/docker-compose.yml file for deployment.
+
 version: '2.2'
 
 volumes:
@@ -5,35 +8,31 @@ volumes:
   pyaleph-mongodb:
 
 services:
-  pyaleph:
+  p2pd:
     restart: always
-    image: alephim/pyaleph-node
-    command: pyaleph --config /opt/pyaleph/config.yml
-    build:
-      context: ../../.
-      dockerfile: "deployment/docker-build/Dockerfile"
-    ports:
-      - 127.0.0.1:8000:8000/tcp
-      - 4024:4024/tcp
-      - 4025:4025/tcp
-    volumes:
-      - ./config.yml:/opt/pyaleph/config.yml
-      - ../../node-secret.key:/opt/pyaleph/node-secret.key
-    depends_on:
-      - mongodb
-      - ipfs
+    image: alephim/jsp2pd:0.10.2-1.0.0
     networks:
       - pyaleph
-    logging:
-      options:
-        max-size: 50m
+    environment:
+      PRIVATE_KEY_FILE: "/etc/jsp2pd/keys/serialized-node-secret.key"
+      LISTEN_MADDR: "/ip4/0.0.0.0/tcp/4020"
+      HOST_MADDRS: "/ip4/0.0.0.0/tcp/4025"
+      PUBSUB: "true"
+      PUBSUB_ROUTER: "floodsub"
+    ports:
+      - "4020:4020"
+      - "4025:4025"
+    volumes:
+      - ../../keys:/etc/jsp2pd/keys
 
   ipfs:
     restart: always
     image: ipfs/go-ipfs:v0.10.0
     ports:
-      - 4001:4001
-      - 4001:4001/udp
+      - "4001:4001"
+      - "4001:4001/udp"
+      - "5001:5001"
+      - "8080:8080"
     volumes:
       - "pyaleph-ipfs:/data/ipfs"
     environment:
@@ -50,6 +49,8 @@ services:
     command: mongod --storageEngine wiredTiger
     networks:
       - pyaleph
+    ports:
+      - "27017:27017"
 
 networks:
   pyaleph:

--- a/deployment/docker-build/jsp2pd/build_jsp2pd.sh
+++ b/deployment/docker-build/jsp2pd/build_jsp2pd.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+JSP2PD_VERSION=0.10.2
+DOCKERFILE_VERSION=1.0.0
+
+docker build \
+  -f "${SCRIPT_DIR}/jsp2pd.dockerfile" \
+  --build-arg JSP2PD_VERSION=${JSP2PD_VERSION} \
+  -t alephim/jsp2pd:${JSP2PD_VERSION}-${DOCKERFILE_VERSION} \
+  "${SCRIPT_DIR}"

--- a/deployment/docker-build/jsp2pd/jsp2pd.dockerfile
+++ b/deployment/docker-build/jsp2pd/jsp2pd.dockerfile
@@ -1,0 +1,14 @@
+FROM node:17-alpine
+ARG JSP2PD_VERSION
+
+RUN npm install --global libp2p-daemon@${JSP2PD_VERSION}
+
+USER node
+
+ENV PRIVATE_KEY_FILE=""
+ENV LISTEN_MADDR=/ip4/0.0.0.0/tcp/4024
+ENV HOST_MADDRS=/ip4/0.0.0.0/tcp/4025
+ENV PUBSUB=false
+ENV PUBSUB_ROUTER=gossipsub
+
+ENTRYPOINT jsp2pd --id ${PRIVATE_KEY_FILE} --listen=${LISTEN_MADDR} --hostAddrs=${HOST_MADDRS} --pubsub=${PUBSUB} --pubsubRouter=${PUBSUB_ROUTER}

--- a/deployment/docker-build/pyaleph.dockerfile
+++ b/deployment/docker-build/pyaleph.dockerfile
@@ -75,13 +75,16 @@ COPY .git /opt/pyaleph/.git
 
 # Setup directories for `python setup.py develop`
 USER root
-RUN mkdir /opt/pyaleph/src/pyaleph.egg-info
+RUN mkdir -p /opt/pyaleph/src/pyaleph.egg-info
 RUN mkdir /opt/pyaleph/.eggs
 RUN chown -R source:source /opt/pyaleph/src /opt/pyaleph/.eggs /opt/pyaleph/.git
 
 # Install PyAleph source
 USER source
 WORKDIR /opt/pyaleph
+# TODO: replace by a proper install of p2pclient once the changes merged and released on the mainline repo
+RUN pip install -U --use-deprecated=legacy-resolver git+https://github.com/odesenfans/py-libp2p-daemon-bindings.git@c36b0262bf0b7581c0f9662c3f2fb4368e6b3c28
+
 RUN pip install -U --use-deprecated=legacy-resolver git+https://github.com/aleph-im/nuls2-python.git
 RUN pip install -U --use-deprecated=legacy-resolver cosmospy
 RUN pip install -U --use-deprecated=legacy-resolver substrate-interface 'eth-keys==0.3.3'
@@ -99,5 +102,3 @@ CMD ["pyaleph"]
 
 # PyAleph API
 EXPOSE 8000
-# PyAleph p2p network
-EXPOSE 4024 4025

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -7,30 +7,47 @@ volumes:
 services:
   pyaleph:
     restart: always
-    image: alephim/pyaleph-node:beta
-    command: pyaleph --config /opt/pyaleph/config.yml
+    image: pyaleph:test
+    command: pyaleph --config /opt/pyaleph/config.yml --key-dir /opt/pyaleph/keys -vv
     ports:
-      - 127.0.0.1:8000:8000/tcp
-      - 4024:4024/tcp
-      - 4025:4025/tcp
+      - "127.0.0.1:8000:8000/tcp"
+      - "4024:4024/tcp"
     volumes:
       - ./config.yml:/opt/pyaleph/config.yml
-      - ./node-secret.key:/opt/pyaleph/node-secret.key
+      - ./keys:/opt/pyaleph/keys
     depends_on:
       - mongodb
       - ipfs
+      - p2pd
     networks:
       - pyaleph
     logging:
       options:
         max-size: 50m
 
+  p2pd:
+    restart: always
+    image: alephim/jsp2pd:0.10.2-1.0.0
+    networks:
+      - pyaleph
+    environment:
+      PRIVATE_KEY_FILE: "/etc/jsp2pd/keys/serialized-node-secret.key"
+      LISTEN_MADDR: "/ip4/0.0.0.0/tcp/4020"
+      HOST_MADDRS: "/ip4/0.0.0.0/tcp/4025"
+      PUBSUB: "true"
+      PUBSUB_ROUTER: "floodsub"
+    ports:
+      - "4020:4020"
+      - "4025:4025"
+    volumes:
+      - ./keys:/etc/jsp2pd/keys
+
   ipfs:
     restart: always
-    image: ipfs/go-ipfs:v0.8.0
+    image: ipfs/go-ipfs:v0.10.0
     ports:
-      - 4001:4001
-      - 4001:4001/udp
+      - "4001:4001"
+      - "4001:4001/udp"
     volumes:
       - "pyaleph-ipfs:/data/ipfs"
     environment:

--- a/deployment/docker-monitoring/docker-compose.yml
+++ b/deployment/docker-monitoring/docker-compose.yml
@@ -9,23 +9,40 @@ volumes:
 services:
   pyaleph:
     restart: always
-    image: alephim/pyaleph-node:beta
-    command: pyaleph --config /opt/pyaleph/config.yml
+    image: pyaleph:test
+    command: pyaleph --config /opt/pyaleph/config.yml --key-dir /opt/pyaleph/keys -vv
     ports:
-      - 127.0.0.1:8000:8000/tcp
-      - 4024:4024/tcp
-      - 4025:4025/tcp
+      - "127.0.0.1:8000:8000/tcp"
+      - "4024:4024/tcp"
     volumes:
       - ./config.yml:/opt/pyaleph/config.yml
-      - ./node-secret.key:/opt/pyaleph/node-secret.key
+      - ./keys:/opt/pyaleph/keys
     depends_on:
       - mongodb
       - ipfs
+      - p2pd
     networks:
       - pyaleph
     logging:
       options:
         max-size: 50m
+
+  p2pd:
+    restart: always
+    image: alephim/jsp2pd:0.10.2-1.0.0
+    networks:
+      - pyaleph
+    environment:
+      PRIVATE_KEY_FILE: "/etc/jsp2pd/keys/serialized-node-secret.key"
+      LISTEN_MADDR: "/ip4/0.0.0.0/tcp/4020"
+      HOST_MADDRS: "/ip4/0.0.0.0/tcp/4025"
+      PUBSUB: "true"
+      PUBSUB_ROUTER: "floodsub"
+    ports:
+      - "4020:4020"
+      - "4025:4025"
+    volumes:
+      - ./keys:/etc/jsp2pd/keys
 
   ipfs:
     restart: always

--- a/deployment/scripts/migrate_key_file_for_p2pd.py
+++ b/deployment/scripts/migrate_key_file_for_p2pd.py
@@ -1,0 +1,38 @@
+import argparse
+from p2pclient.libp2p_stubs.crypto.rsa import KeyPair, RSAPrivateKey
+from aleph.services.keys import save_keys
+from Crypto.PublicKey import RSA
+
+
+def cli_parse() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Extracts dependencies from setup.cfg into a requirements.txt file."
+    )
+    parser.add_argument(
+        "--key-file", "-k", action="store", required=True, type=str, help="Path to the key file of the node."
+    )
+    parser.add_argument(
+        "--output-dir",
+        "-o",
+        action="store",
+        default="keys",
+        type=str,
+        help="Path to the directory where the new keys must be saved.",
+    )
+    return parser.parse_args()
+
+
+def main(args: argparse.Namespace):
+    key_file = args.key_file
+    output_dir = args.output_dir
+
+    with open(key_file) as f:
+        private_key_str = f.read()
+
+    private_key = RSAPrivateKey(RSA.import_key(private_key_str))
+    key_pair = KeyPair(private_key=private_key, public_key=private_key.get_public_key())
+    save_keys(key_pair, output_dir)
+
+
+if __name__ == "__main__":
+    main(cli_parse())

--- a/docs/guides/docker-compose.rst
+++ b/docs/guides/docker-compose.rst
@@ -114,33 +114,36 @@ To enable Sentry, add the corresponding
     sentry:
         dsn: "https://<SECRET_ID>@<SENTRY_HOST>/<PROJECT_ID>"
 
----------------
-Node secret key
----------------
+----------------
+Node secret keys
+----------------
 
 An Aleph.im node should have a persistent public-private keypair to authenticate to the network.
+
+These keys can be created using the Docker image
 
 Create a file that will be used by the Aleph.im node to store it's private key.
 
 .. code-block:: bash
 
-    touch node-secret.key
+    mkdir keys
 
+# TODO review: I don't think this code block does anything, since it's executed in a container and the container is disposed
+#              once the container exits.
+.. code-block:: bash
+
+    docker run --rm -ti --user root -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:beta chown aleph:aleph /opt/pyaleph/keys
 
 .. code-block:: bash
 
-    docker run --rm -ti --user root -v $(pwd)/node-secret.key:/opt/pyaleph/node-secret.key alephim/pyaleph-node:beta chown aleph:aleph /opt/pyaleph/node-secret.key
-
-.. code-block:: bash
-
-    docker run --rm -ti -v $(pwd)/node-secret.key:/opt/pyaleph/node-secret.key alephim/pyaleph-node:beta pyaleph --gen-key
+    docker run --rm -ti -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:beta pyaleph --gen-keys --key-dir keys
 
 
 Optional: Check that the key file is not empty and make a backup of the key:
 
 .. code-block:: bash
 
-    cat node-secret.key
+    cat keys/node-secret.key
 
 
 ..

--- a/docs/guides/private_net.rst
+++ b/docs/guides/private_net.rst
@@ -54,90 +54,31 @@ Example of config file at this point (I disabled IPFS but you can leave it enabl
 
     p2p:
         host: 0.0.0.0
-        port: 4025
+        control_port: 4020
+        listen_port: 4021
         http_port: 4024
+        port: 4025
         peers: []
         reconnect_delay: 60
         key: null
 
-You can now run the PyAleph daemon for the first time:
+You then need to generate a private key to identify the node.
+PyAleph provides a command-line option to do so.
 
 .. code-block:: bash
 
-    pyaleph -c privatenet.yml
+    pyaleph --gen-keys --gen-key <your-key-dir>
 
-You will soon see in the logs something like this appear:
+This command creates a new directory that contains 3 keys: the private and public keys in PEM format,
+as well as the key serialized for compatibility with the P2P daemon.
 
-.. code-block:: 
+.. code-block:: bash
 
-    2020-04-01 12:26:56 [INFO] P2P.host: -----BEGIN RSA PRIVATE KEY-----
-    MIIEowIBAAKCAQEAg45OZHmQqllE895YRuI+Qk+h+4VULuHRfwvR2v0qf3qI+ZAC
-    LpmUYjIm7E5ia5Nj99cBumsCpG0+SAGZlMQi7lzWEiYwNV7jhrrUh6wV+4k9BESr
-    vwhe59rtueKopZZJTvukBTAkIA99oyfHD8fq2fUf4RxzC3dd/2rm2EdqsGshAcHS
-    UJHutu946+SfxyUvxQIk5jX+uupcClF37/gUia82sGkm6uTPCjhdrHqI/DTh17l/
-    va1ptjSnTqgKY9HA8j761wVaHdkwgw632C2GhMCn1UokG2yvRqJsOq6EIp9c/fuH
-    s6ggWJbbXkaqefdYB8ljhE0p5+C/oB1BbJ18vwIDAQABAoIBADoUKE25UYGzOXrE
-    bYqVtVDHIUcOfLTZ4whIqpQYcpum+DPdPOlfyh9z7rUigdbmUhsHo+6t8ZOv2vAl
-    LK19zcIX4DZQ/7WAN8iyUMO42FedJf/tZTlIM8X+ZDdNdpDsAV9KPwY/U6OH0zql
-    g/9Wjjs9OZ7DVZL5Vtk9U76mANbzQqpTjfvCV1tB6wT7JQUjXIwlMyHxtTsvDlKo
-    0KHfohuTxJAugDcAaVCmt1QnVUZdEkizJdusPPvWxA1Rmparx2IRVazNHKKjDToZ
-    cc/IytGnblMjdL6staPuqnavr2ZEVlpAgfl0jcxx4a1XcNNh4Fw+jaatqN5xIEQX
-    x1Xn5ukCgYEAtcCRPCH07wr3rmB/QfLPB+mBprugD7tff81BJ7IHKQFIp9jvl8VP
-    z+XfnHlghlshTJZ3hL4yXuvPyBIvKaL7toFMAXSB6S0LyZ99RdzksZ85U5ithPX3
-    0WO+oWEm9gaqfeT4EJKtRSMaF2m79lMDNTNRRtkxJJIKQABNZn2KWgUCgYEAuUxD
-    /NWJjLsGXIduO3PNGj6jMT2FmTw4O6GzMbgRbYj3zlOlwqoX6MYLTJn4xfYBcpup
-    vsViNXI+S6sFwc8s7Y3Cw3a3Iuc7RyZUVSudrcsP3PgafGPd0bt11Z1aTjfP/McS
-    vCuaCfZA2rggXdvhelO46DKR7MEsYUzVsO0eAvMCgYAZXJKnmnFsPdKMAakgUbpz
-    9zCBTKMsLtBHrCOQX3ZCUYyK52mfewgFEaWfVwySEvtVjZWF72hl+G/ZEjiEjdqj
-    /+zUMybBm+iOLPQ1IHrFElvUf3SPHieDj3CVYlImeI2n3aCD54PIJvrIE5gH6lOD
-    Q/LuePYzjTFi9ufWCmSY5QKBgBy+PdWccifIYyY7Q9gpEGm/yaS7vFuWwcpOPPO7
-    b8ij9Hym8RGPPQI4pkwNnk9m57aVevFCwQc1X4BxWQVFU9zNnqafZa0eXU2eHnrP
-    tzfcReuq+MDO5PvBrneiXv2/Hp5BayCRSuW8sza6VRr6HrHRBt/N6GDnXjEBsCwv
-    u/YNAoGBAJGykosSP6R4kmff8ZB+tCbB5eHR/O6Da7U5JTolYiU0N2zlrbgCG/Im
-    0ZLGdCBOUO2EXOojAo+Y+Abxmc7QszT9azS8XRDnKp6R0AhjuR8QvjiqjB4bfVFr
-    pLi4ta+YG2JtnHIJXFpmnTpful2sx0ioZbDq8fAYLZXQ7n8VDceA
-    -----END RSA PRIVATE KEY-----
+    ls <your-key-dir>
+        node-pub.key  node-secret.key  serialized-node-secret.key
 
-This is your private key, now add it to your config file like this:
-
-.. code-block:: yaml
-
-    p2p:
-        host: 0.0.0.0
-        port: 4025
-        http_port: 4024
-        peers: []
-        reconnect_delay: 60
-        key: |
-            -----BEGIN RSA PRIVATE KEY-----
-            MIIEowIBAAKCAQEAg45OZHmQqllE895YRuI+Qk+h+4VULuHRfwvR2v0qf3qI+ZAC
-            LpmUYjIm7E5ia5Nj99cBumsCpG0+SAGZlMQi7lzWEiYwNV7jhrrUh6wV+4k9BESr
-            vwhe59rtueKopZZJTvukBTAkIA99oyfHD8fq2fUf4RxzC3dd/2rm2EdqsGshAcHS
-            UJHutu946+SfxyUvxQIk5jX+uupcClF37/gUia82sGkm6uTPCjhdrHqI/DTh17l/
-            va1ptjSnTqgKY9HA8j761wVaHdkwgw632C2GhMCn1UokG2yvRqJsOq6EIp9c/fuH
-            s6ggWJbbXkaqefdYB8ljhE0p5+C/oB1BbJ18vwIDAQABAoIBADoUKE25UYGzOXrE
-            bYqVtVDHIUcOfLTZ4whIqpQYcpum+DPdPOlfyh9z7rUigdbmUhsHo+6t8ZOv2vAl
-            LK19zcIX4DZQ/7WAN8iyUMO42FedJf/tZTlIM8X+ZDdNdpDsAV9KPwY/U6OH0zql
-            g/9Wjjs9OZ7DVZL5Vtk9U76mANbzQqpTjfvCV1tB6wT7JQUjXIwlMyHxtTsvDlKo
-            0KHfohuTxJAugDcAaVCmt1QnVUZdEkizJdusPPvWxA1Rmparx2IRVazNHKKjDToZ
-            cc/IytGnblMjdL6staPuqnavr2ZEVlpAgfl0jcxx4a1XcNNh4Fw+jaatqN5xIEQX
-            x1Xn5ukCgYEAtcCRPCH07wr3rmB/QfLPB+mBprugD7tff81BJ7IHKQFIp9jvl8VP
-            z+XfnHlghlshTJZ3hL4yXuvPyBIvKaL7toFMAXSB6S0LyZ99RdzksZ85U5ithPX3
-            0WO+oWEm9gaqfeT4EJKtRSMaF2m79lMDNTNRRtkxJJIKQABNZn2KWgUCgYEAuUxD
-            /NWJjLsGXIduO3PNGj6jMT2FmTw4O6GzMbgRbYj3zlOlwqoX6MYLTJn4xfYBcpup
-            vsViNXI+S6sFwc8s7Y3Cw3a3Iuc7RyZUVSudrcsP3PgafGPd0bt11Z1aTjfP/McS
-            vCuaCfZA2rggXdvhelO46DKR7MEsYUzVsO0eAvMCgYAZXJKnmnFsPdKMAakgUbpz
-            9zCBTKMsLtBHrCOQX3ZCUYyK52mfewgFEaWfVwySEvtVjZWF72hl+G/ZEjiEjdqj
-            /+zUMybBm+iOLPQ1IHrFElvUf3SPHieDj3CVYlImeI2n3aCD54PIJvrIE5gH6lOD
-            Q/LuePYzjTFi9ufWCmSY5QKBgBy+PdWccifIYyY7Q9gpEGm/yaS7vFuWwcpOPPO7
-            b8ij9Hym8RGPPQI4pkwNnk9m57aVevFCwQc1X4BxWQVFU9zNnqafZa0eXU2eHnrP
-            tzfcReuq+MDO5PvBrneiXv2/Hp5BayCRSuW8sza6VRr6HrHRBt/N6GDnXjEBsCwv
-            u/YNAoGBAJGykosSP6R4kmff8ZB+tCbB5eHR/O6Da7U5JTolYiU0N2zlrbgCG/Im
-            0ZLGdCBOUO2EXOojAo+Y+Abxmc7QszT9azS8XRDnKp6R0AhjuR8QvjiqjB4bfVFr
-            pLi4ta+YG2JtnHIJXFpmnTpful2sx0ioZbDq8fAYLZXQ7n8VDceA
-            -----END RSA PRIVATE KEY-----
-
-In YAML the pipe symbol shows a multiline string will follow.
+This key directory must be provided to the PyAleph daemon on startup using the `--key-dir <your-key-dir>` option.
+It must also be passed to the P2P daemon using the `--id <your-key-dir>/serialized-node-secret.key` option.
 
 Your seed node will need to have the 4025 and 4024 ports open (those ports are
 configurable and you can change them).
@@ -164,7 +105,7 @@ Other nodes will need to have this string in the peers section to be able to fin
         peers:
             - /ip4/x.x.x.x/tcp/4025/p2p/QmesN1F17tkEUx8bQY7Sayxmq8GXHZm9cXV7QpE1gt4n3D
 
-For q heqlthy network it is recommended to have at least 2 seed nodes connected between each others,
+For a healthy network it is recommended to have at least 2 seed nodes connected between each others,
 and all other clients having them in their peer lists.
 
 IPFS

--- a/sample-config.yml
+++ b/sample-config.yml
@@ -37,7 +37,8 @@ aleph:
 
 p2p:
   host: 0.0.0.0
+  control_port: 4020
+  listen_port: 4021
   port: 4025
   http_port: 4024
-  key: null
   reconnect_delay: 60

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,37 +31,37 @@ setup_requires =
       pytest-runner>=2.0,<3dev
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
-      pymongo~=3.12.2
-      motor>=2.0
       aiocache
-      aioipfs>=0.4.7
-      aiohttp>=3.3.2,<4.0.0a1
-      aiohttp-session[secure]
+      aiocache~=0.11.1
       aiohttp-jinja2
+      aiohttp-session[secure]
+      aiohttp>=3.3.2,<4.0.0a1
       aiohttp_cors
-      configparser
+      aioipfs>=0.4.7
+      aleph-client>=0.4.1
+      coincurve<16.0.0
       configmanager
+      configparser
+      cosmospy
+      dataclasses_json>=0.5.2
+      eth_account<0.6.0
+      eth-rlp==0.2.1
+      hexbytes
+      motor>=2.0
+      pymongo~=3.12.2
+      python-dateutil
+      python-rocksdb
+      python-socketio
+      pytz
+      pyyaml
+      requests>=2.24.0
+      secp256k1
+      sentry-sdk>=0.19.4
+      setproctitle>=1.1.10
+      substrate-interface
+      urllib3>=1.25.10
       uvloop
       web3
-      eth_account
-      hexbytes
-      secp256k1
-      coincurve<16.0.0
-      libp2p
-      python-rocksdb
-      pytz
-      python-dateutil
-      pyyaml
-      python-socketio
-      substrate-interface
-      cosmospy
-      requests>=2.24.0
-      urllib3>=1.25.10
-      aleph-client>=0.4.1
-      setproctitle>=1.1.10
-      sentry-sdk>=0.19.4
-      dataclasses_json>=0.5.2
-      aiocache~=0.11.1
 
 dependency_links =
     https://github.com/aleph-im/py-libp2p/tarball/0.1.4-1-use-set#egg=libp2p

--- a/src/aleph/cli/args.py
+++ b/src/aleph/cli/args.py
@@ -48,8 +48,8 @@ def parse_args(args):
     )
     parser.add_argument(
         "-g",
-        "--gen-key",
-        dest="generate_key",
+        "--gen-keys",
+        dest="generate_keys",
         help="Generate a node key and exit",
         action="store_true",
         default=False,
@@ -57,18 +57,18 @@ def parse_args(args):
     parser.add_argument(
         "--print-key",
         dest="print_key",
-        help="Print the generated key",
+        help="Print the generated private key",
         action="store_true",
         default=False,
     )
     parser.add_argument(
         "-k",
-        "--key",
-        dest="key_path",
-        help="Path to the node private key",
+        "--key-dir",
+        dest="key_dir",
+        help="Path to the keys directory. Only used in combination with --gen-keys.",
         action="store",
         type=str,
-        default="node-secret.key",
+        default="keys",
     )
     parser.add_argument(
         "--disable-sentry",

--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -13,10 +13,11 @@ def get_defaults():
             "reference_node_url": None,
         },
         "p2p": {
+            "control_port": 4020,
+            "listen_port": 4021,
             "port": 4025,
             "http_port": 4024,
             "host": "0.0.0.0",
-            "key": None,
             "reconnect_delay": 60,
             "clients": ["http"],
             "peers": [

--- a/src/aleph/exceptions.py
+++ b/src/aleph/exceptions.py
@@ -1,0 +1,6 @@
+class AlephException(Exception):
+    ...
+
+
+class PrivateKeyNotFoundException(AlephException):
+    pass

--- a/src/aleph/model/p2p.py
+++ b/src/aleph/model/p2p.py
@@ -2,11 +2,12 @@
 """
 
 from datetime import datetime, timedelta
+from typing import AsyncIterator, Optional
 
 from pymongo import ASCENDING, DESCENDING, IndexModel
 
-from aleph.types import Protocol
 from aleph.model.base import BaseClass
+from aleph.types import Protocol
 
 
 class Peer(BaseClass):
@@ -21,7 +22,7 @@ class Peer(BaseClass):
     ]
 
 
-async def get_peers(peer_type=None, hours=2):
+async def get_peers(peer_type: Optional[str] = None, hours: int = 2) -> AsyncIterator[str]:
     """Returns current peers.
     TODO: handle the last seen, channel preferences, and better way of avoiding "bad contacts".
     NOTE: Currently used in jobs.

--- a/src/aleph/network.py
+++ b/src/aleph/network.py
@@ -8,6 +8,7 @@ from aleph.chains.register import VERIFIER_REGISTER
 from aleph.services.ipfs.pubsub import incoming_channel as incoming_ipfs_channel
 from aleph.types import ItemType, InvalidMessageError
 from aleph.utils import get_sha256
+from p2pclient import Client as P2PClient
 
 LOGGER = logging.getLogger("NETWORK")
 

--- a/src/aleph/services/ipfs/pubsub.py
+++ b/src/aleph/services/ipfs/pubsub.py
@@ -1,11 +1,11 @@
 import asyncio
 import base64
 import logging
+
 import base58
 
-from .common import get_ipfs_api
 from aleph.types import InvalidMessageError
-
+from .common import get_ipfs_api
 
 LOGGER = logging.getLogger("IPFS.PUBSUB")
 
@@ -34,7 +34,7 @@ async def sub(topic: str):
             LOGGER.exception("Error handling message")
 
 
-async def pub(topic, message):
+async def pub(topic: str, message: bytes):
     api = await get_ipfs_api()
     await api.pubsub.pub(topic, message)
 

--- a/src/aleph/services/keys.py
+++ b/src/aleph/services/keys.py
@@ -1,0 +1,47 @@
+import os.path
+
+from p2pclient.libp2p_stubs.crypto.rsa import (
+    KeyPair,
+    create_new_key_pair,
+)
+
+
+def generate_keypair(print_key: bool) -> KeyPair:
+    """
+    Generates a new key pair for the node.
+    """
+    key_pair = create_new_key_pair()
+    if print_key:
+        # Print the armored key pair for archiving
+        print(key_pair.private_key.impl.export_key().decode("utf-8"))
+
+    return key_pair
+
+
+def save_keys(key_pair: KeyPair, key_dir: str) -> None:
+    """
+    Saves the private and public keys to the specified directory. The keys are stored in 3 formats:
+    * The private key is stored in PEM format for ease of use, and in a serialized format compatible with the P2P
+      daemon (DER + protobuf encoding).
+    * The public key is stored in PEM format.
+    """
+    # Create the key directory if it does not exist
+    if os.path.exists(key_dir):
+        if not os.path.isdir(key_dir):
+            raise NotADirectoryError(f"Key directory ({key_dir}) is not a directory")
+    else:
+        os.makedirs(key_dir)
+
+    # Save the private and public keys in the key directory, as well as the serialized private key for p2pd.
+    private_key_path = os.path.join(key_dir, "node-secret.key")
+    public_key_path = os.path.join(key_dir, "node-pub.key")
+    serialized_key_path = os.path.join(key_dir, "serialized-node-secret.key")
+
+    with open(private_key_path, "wb") as key_file:
+        key_file.write(key_pair.private_key.impl.export_key())
+
+    with open(public_key_path, "wb") as key_file:
+        key_file.write(key_pair.public_key.impl.export_key())
+
+    with open(serialized_key_path, "wb") as f:
+        f.write(key_pair.private_key.serialize())

--- a/src/aleph/services/p2p/jobs.py
+++ b/src/aleph/services/p2p/jobs.py
@@ -1,5 +1,8 @@
 import asyncio
 import logging
+from typing import List, Optional
+
+from configmanager import Config
 
 from aleph.model.p2p import get_peers
 from .http import api_get_request
@@ -8,7 +11,7 @@ from .peers import connect_peer
 LOGGER = logging.getLogger("P2P.jobs")
 
 
-async def reconnect_p2p_job(config=None):
+async def reconnect_p2p_job(config: Optional[Config] = None) -> None:
     from aleph.web import app
 
     if config is None:
@@ -22,7 +25,7 @@ async def reconnect_p2p_job(config=None):
             for peer in peers:
                 try:
                     await connect_peer(config, peer)
-                except:
+                except Exception:
                     LOGGER.debug("Can't reconnect to %s" % peer)
 
         except Exception:
@@ -31,7 +34,7 @@ async def reconnect_p2p_job(config=None):
         await asyncio.sleep(config.p2p.reconnect_delay.value)
 
 
-async def check_peer(peers, peer_uri, timeout=1):
+async def check_peer(peers: List[str], peer_uri: str, timeout: int = 1) -> None:
     try:
         version_info = await api_get_request(peer_uri, "version", timeout=timeout)
         if version_info is not None:
@@ -40,8 +43,8 @@ async def check_peer(peers, peer_uri, timeout=1):
         LOGGER.exception("Can't contact peer %r" % peer_uri)
 
 
-async def tidy_http_peers_job(config=None):
-    """Check that HTTP peers are reacheable, else remove them from the list"""
+async def tidy_http_peers_job(config: Optional[Config] = None) -> None:
+    """Check that HTTP peers are reachable, else remove them from the list"""
     from aleph.web import app
     from aleph.services.p2p import singleton
     from aleph.services.utils import get_IP

--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -3,13 +3,13 @@ import base64
 import json
 import logging
 import random
-from typing import Coroutine, List
+from typing import Any, Dict, Optional, Tuple
 
-from libp2p.network.exceptions import SwarmException
-from libp2p.network.notifee_interface import INotifee
-from libp2p.network.stream.exceptions import StreamError
-from libp2p.network.stream.net_stream_interface import INetStream
-from libp2p.typing import TProtocol
+from anyio.abc import SocketStream
+from p2pclient import Client as P2PClient
+from p2pclient.datastructures import StreamInfo
+from p2pclient.exceptions import ControlFailure
+from p2pclient.libp2p_stubs.peer.id import ID
 
 from aleph import __version__
 from aleph.network import incoming_check
@@ -17,7 +17,6 @@ from aleph.types import InvalidMessageError
 from . import singleton
 from .pubsub import sub
 
-PROTOCOL_ID = TProtocol("/aleph/p2p/0.1.0")
 MAX_READ_LEN = 2 ** 32 - 1
 
 LOGGER = logging.getLogger("P2P.protocol")
@@ -29,100 +28,84 @@ HELLO_PACKET = {"command": "hello"}
 CONNECT_LOCK = asyncio.Lock()
 
 
-class AlephProtocol(INotifee):
-    def __init__(self, host, streams_per_host=5):
-        self.host = host
+class AlephProtocol:
+    p2p_client: P2PClient
+    PROTOCOL_ID = "/aleph/p2p/0.1.0"
+
+    def __init__(self, p2p_client: P2PClient, streams_per_host: int = 5):
+        self.p2p_client = p2p_client
         self.streams_per_host = streams_per_host
-        self.host.get_network().register_notifee(self)
-        self.host.set_stream_handler(PROTOCOL_ID, self.stream_handler)
-        self.peers = dict()
+        self.peers: Dict[ID, Tuple[SocketStream, asyncio.Semaphore]] = dict()
+        p2p_client.stream_handler(self.PROTOCOL_ID, self.stream_request_handler)
 
-    async def stream_handler(self, stream: INetStream) -> None:
-        asyncio.ensure_future(self.read_data(stream))
+    async def stream_request_handler(self, stream_info: StreamInfo, stream: SocketStream) -> None:
+        """
+        Handles the reception of a message from another peer under the aleph protocol.
 
-    async def read_data(self, stream: INetStream) -> None:
+        Receives a message, performs the corresponding action and returns a result message to the sender.
+        """
+
         from aleph.storage import get_hash_content
 
-        while True:
-            read_bytes = await stream.read(MAX_READ_LEN)
-            if read_bytes is not None:
-                result = {"status": "error", "reason": "unknown"}
-                try:
-                    read_string = read_bytes.decode("utf-8")
-                    message_json = json.loads(read_string)
-                    if message_json["command"] == "hash_content":
-                        value = await get_hash_content(
-                            message_json["hash"], use_network=False, timeout=1
-                        )
-                        if value is not None and value != -1:
-                            result = {
-                                "status": "success",
-                                "hash": message_json["hash"],
-                                "content": base64.encodebytes(value).decode("utf-8"),
-                            }
-                        else:
-                            result = {"status": "success", "content": None}
-                    elif message_json["command"] == "get_message":
-                        result = {"status": "error", "reason": "not implemented"}
-                    elif message_json["command"] == "publish_message":
-                        result = {"status": "error", "reason": "not implemented"}
-                    elif message_json["command"] == "hello":
-                        result = {
-                            "status": "success",
-                            "content": {"version": __version__},
-                        }
-                    else:
-                        result = {"status": "error", "reason": "unknown command"}
-                    LOGGER.debug(f"received {read_string}")
-                except Exception as e:
-                    result = {"status": "error", "reason": repr(e)}
-                    LOGGER.exception("Error while reading data")
-                await stream.write(json.dumps(result).encode("utf-8"))
+        read_bytes = await stream.receive_some(MAX_READ_LEN)
+        if read_bytes is None:
+            return
 
-    async def make_request(self, request_structure):
-        streams = [
-            (peer, item) for peer, sublist in self.peers.items() for item in sublist
-        ]
-        random.shuffle(streams)
-        while True:
-            for i, (peer, (stream, semaphore)) in enumerate(streams):
-                if not semaphore.locked():
-                    async with semaphore:
-                        try:
-                            # stream = await asyncio.wait_for(singleton.host.new_stream(peer_id, [PROTOCOL_ID]), connect_timeout)
-                            await stream.write(
-                                json.dumps(request_structure).encode("utf-8")
-                            )
-                            value = await stream.read(MAX_READ_LEN)
-                            # # await stream.close()
-                            try:
-                                value = json.loads(value)
-                            except json.JSONDecodeError:
-                                value = None
-                                continue
+        try:
+            read_string = read_bytes.decode("utf-8")
+            message_json = json.loads(read_string)
+            if message_json["command"] == "hash_content":
+                value = await get_hash_content(
+                    message_json["hash"], use_network=False, timeout=1
+                )
+                if value is not None and value != -1:
+                    result = {
+                        "status": "success",
+                        "hash": message_json["hash"],
+                        "content": base64.encodebytes(value).decode("utf-8"),
+                    }
+                else:
+                    result = {"status": "success", "content": None}
+            elif message_json["command"] == "get_message":
+                result = {"status": "error", "reason": "not implemented"}
+            elif message_json["command"] == "publish_message":
+                result = {"status": "error", "reason": "not implemented"}
+            elif message_json["command"] == "hello":
+                result = {
+                    "status": "success",
+                    "content": {"version": __version__},
+                }
+            else:
+                result = {"status": "error", "reason": "unknown command"}
+            LOGGER.debug(f"received {read_string}")
+        except Exception as e:
+            result = {"status": "error", "reason": repr(e)}
+            LOGGER.exception("Error while reading data")
 
-                            if value.get("content") is None:
-                                # remove all streams from that peer, ask to the others.
-                                for speer, info in list(streams):
-                                    if speer == peer:
-                                        streams.remove((speer, info))
-                                break
+        await stream.send_all(json.dumps(result).encode("utf-8"))
 
-                            return value
-                        except (StreamError):
-                            # let's delete this stream so it gets recreated next time
-                            # await stream.close()
-                            await stream.reset()
-                            streams.remove((peer, (stream, semaphore)))
-                            try:
-                                self.peers[peer].remove((stream, semaphore))
-                            except ValueError:
-                                pass
-                            LOGGER.debug("Can't request hash...")
-                await asyncio.sleep(0)
+    async def make_request(self, request_structure: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        peers = [peer for peer in self.peers]
+        # Randomize the list of peers to contact to distribute the load evenly
+        random.shuffle(peers)
 
-            if not len(streams):
-                return
+        for peer in peers:
+            stream_info, stream = self.p2p_client.stream_open(peer, (self.PROTOCOL_ID,))
+            msg = json.dumps(request_structure).encode("UTF-8")
+            await stream.send_all(msg)
+
+            response = await stream.receive_some(MAX_READ_LEN)
+            try:
+                value = json.loads(response.decode("UTF-8"))
+            except json.JSONDecodeError:
+                logging.warning("Could not decode response from %s", peer)
+                continue
+
+            if value.get("content") is not None:
+                return value
+
+        logging.info("Could not retrieve content from any peer")
+        return None
 
     async def request_hash(self, item_hash):
         # this should be done better, finding best peers to query from.
@@ -138,28 +121,29 @@ class AlephProtocol(INotifee):
         else:
             LOGGER.debug(f"can't get hash {item_hash}")
 
-    async def _handle_new_peer(self, peer_id) -> None:
+    async def _handle_new_peer(self, peer_id: ID) -> None:
         await self.create_connections(peer_id)
         LOGGER.debug("added new peer %s", peer_id)
 
-    async def create_connections(self, peer_id):
+    async def create_connections(self, peer_id: ID) -> None:
         peer_streams = self.peers.get(peer_id, list())
         for i in range(self.streams_per_host - len(peer_streams)):
             try:
-                stream: INetStream = await self.host.new_stream(peer_id, [PROTOCOL_ID])
-            except SwarmException as error:
-                LOGGER.debug("fail to add new peer %s, error %s", peer_id, error)
+                stream_info, stream = await self.p2p_client.stream_open(
+                    peer_id, [self.PROTOCOL_ID]
+                )
+            except ControlFailure as error:
+                LOGGER.debug("failed to add new peer %s, error %s", peer_id, error)
                 return
 
             try:
-                await stream.write(json.dumps(HELLO_PACKET).encode("utf-8"))
-                await stream.read(MAX_READ_LEN)
+                await stream.send_all(json.dumps(HELLO_PACKET).encode("utf-8"))
+                _ = await stream.receive_some(MAX_READ_LEN)
             except Exception as error:
-                LOGGER.debug("fail to add new peer %s, error %s", peer_id, error)
+                LOGGER.debug("failed to add new peer %s, error %s", peer_id, error)
                 return
 
             peer_streams.append((stream, asyncio.Semaphore(1)))
-            # await asyncio.sleep(.1)
 
         self.peers[peer_id] = peer_streams
 

--- a/src/aleph/services/p2p/singleton.py
+++ b/src/aleph/services/p2p/singleton.py
@@ -1,8 +1,13 @@
 from typing import Optional
 
-from libp2p.pubsub.pubsub import Pubsub
+from p2pclient import Client as P2PClient
 
-host = None
-pubsub: Optional[Pubsub] = None
+client: Optional[P2PClient] = None
 streamer = None
 api_servers = None
+
+
+def get_p2p_client() -> P2PClient:
+    if client is None:
+        raise ValueError("Client is null!")
+    return client

--- a/src/aleph/services/peers/monitor.py
+++ b/src/aleph/services/peers/monitor.py
@@ -1,25 +1,30 @@
 import json
-
-from urllib.parse import unquote
-from aleph.services.peers.common import ALIVE_TOPIC, IPFS_ALIVE_TOPIC
-from aleph.services.p2p.pubsub import decode_msg
-from aleph.services.ipfs.common import get_base_url
-from aleph.services.ipfs.pubsub import sub as sub_ipfs
-
 import logging
+from typing import Any, Dict, Union
+from urllib.parse import unquote
 
-from aleph.types import ItemType, Protocol
+from p2pclient import Client as P2PClient
+from p2pclient.pb.p2pd_pb2 import PSMessage
+from p2pclient.utils import read_pbmsg_safe
+
+from aleph.services.ipfs.pubsub import sub as sub_ipfs
+from aleph.services.peers.common import ALIVE_TOPIC, IPFS_ALIVE_TOPIC
+from aleph.types import Protocol
 
 LOGGER = logging.getLogger("P2P.peers")
 
 
-async def handle_incoming_host(mvalue, source: Protocol=Protocol.P2P):
+async def handle_incoming_host(pubsub_msg: Dict[str, Any], source: Protocol = Protocol.P2P):
     from aleph.model.p2p import add_peer
 
+    sender = pubsub_msg["from"]
+
     try:
-        LOGGER.debug("New message received %r" % mvalue)
-        message_data = mvalue.get("data", b"").decode("utf-8")
+        LOGGER.debug("New message received %r" % pubsub_msg)
+        message_data = pubsub_msg.get("data", b"").decode("utf-8")
         content = json.loads(unquote(message_data))
+
+        # TODO: replace this validation by marshaling (ex: Pydantic)
         peer_type = content.get("peer_type", "P2P")
         if not isinstance(content["address"], str):
             raise ValueError("Bad address")
@@ -35,33 +40,46 @@ async def handle_incoming_host(mvalue, source: Protocol=Protocol.P2P):
             address=content["address"],
             peer_type=peer_type,
             source=source,
-            sender=mvalue["from"],
+            sender=sender,
         )
     except Exception as e:
-        if isinstance(e, ValueError) and mvalue.get("from"):
-            LOGGER.info(
-                "Received a bad peer info %s from %s" % (e.args[0], mvalue["from"])
-            )
+        if isinstance(e, ValueError):
+            LOGGER.info("Received a bad peer info %s from %s" % (e.args[0], sender))
         else:
             LOGGER.exception("Exception in pubsub peers monitoring")
 
 
-async def monitor_hosts_p2p(psub):
+def pubsub_msg_to_dict(pubsub_msg: PSMessage) -> Dict[str, Any]:
+    """
+    A compatibility method that translates a p2pd pubsub message to the equivalent dictionary.
+    The returned value is then passed to `handle_incoming_host`.
+
+    TODO: use a better system than a dict to pass these parameters around.
+    """
+    return {
+        "from": getattr(pubsub_msg, "from"),
+        "data": pubsub_msg.data,
+        "seqno": pubsub_msg.seqno,
+        "topicIDs": pubsub_msg.topicIDs,
+    }
+
+
+async def monitor_hosts_p2p(p2p_client: P2PClient) -> None:
+
     try:
-        alive_sub = await psub.subscribe(ALIVE_TOPIC)
+        stream = await p2p_client.pubsub_subscribe(ALIVE_TOPIC)
         while True:
-            mvalue = await alive_sub.get()
-            mvalue = await decode_msg(mvalue)
-            await handle_incoming_host(mvalue, source=Protocol.P2P)
+            pubsub_msg = PSMessage()
+            await read_pbmsg_safe(stream, pubsub_msg)
+            msg_dict = pubsub_msg_to_dict(pubsub_msg)
+            await handle_incoming_host(msg_dict, source=Protocol.P2P)
     except Exception:
         LOGGER.exception("Exception in pubsub peers monitoring, resubscribing")
 
 
 async def monitor_hosts_ipfs(config):
     try:
-        async for mvalue in sub_ipfs(
-            IPFS_ALIVE_TOPIC, base_url=await get_base_url(config)
-        ):
+        async for mvalue in sub_ipfs(IPFS_ALIVE_TOPIC):
             await handle_incoming_host(mvalue, source=Protocol.IPFS)
     except Exception:
         LOGGER.exception("Exception in pubsub peers monitoring, resubscribing")

--- a/src/aleph/services/peers/publish.py
+++ b/src/aleph/services/peers/publish.py
@@ -5,11 +5,19 @@ import logging
 from aleph.services.peers.common import ALIVE_TOPIC, IPFS_ALIVE_TOPIC
 from aleph.services.ipfs.pubsub import pub as pub_ipfs
 
+from p2pclient import Client as P2PClient
+from typing import List, Optional
+
 LOGGER = logging.getLogger("peers.publish")
 
 
 async def publish_host(
-    address, psub, interests=None, delay=120, peer_type="P2P", use_ipfs=True
+    address: str,
+    p2p_client: P2PClient,
+    interests: Optional[List[str]] = None,
+    delay: int = 120,
+    peer_type: str = "P2P",
+    use_ipfs: bool = True,
 ):
     """Publish our multiaddress regularly, saying we are alive."""
     await asyncio.sleep(2)
@@ -34,7 +42,7 @@ async def publish_host(
 
         try:
             LOGGER.debug("Publishing alive message on p2p pubsub")
-            await asyncio.wait_for(psub.publish(ALIVE_TOPIC, msg), 1)
+            await asyncio.wait_for(p2p_client.pubsub_publish(ALIVE_TOPIC, msg), 1)
         except Exception:
             LOGGER.warning("Can't publish alive message on p2p")
 


### PR DESCRIPTION
Updated the codebase to remove the dependency to py-libp2p and
use the official JavaScript P2P daemon (jsp2pd) instead.
This includes the following changes:

* Replace all calls to libp2p by RPC calls to jsp2pd. This is
  achieved using `p2pclient`, aka a client library for the P2P
  daemon.
* Remove all dependencies to libp2pd by equivalent functionalities
  provided by p2pclient.
* Change the private/public key generation system for compatibility
  with jsp2pd.
* Provide a Dockerfile for jsp2pd and use it in the docker-compose
  flow.

Breaking changes:
* `pyaleph --gen-key` was renamed to `--gen-keys`. It now creates
  a directory containing the private key in PEM format, the public
  key in PEM format and the private key in a serialized protobuf
  + DER format required by jsp2pd.
* Similarly, the `--key-path` option was renamed to `--key-dir`.
* pyaleph now looks for the serialized key file instead of
  the PEM file. It now exits with exit code 1 (instead of 0)
  if the file does not exist.
* Providing the private key by specifying it as a string in
  the config file (config.p2p.key) is not possible anymore.

# Todo
- [x] Update the "official" docker-compose file in deployment/docker-compose
- [x] Provide a migration script to generate the serialized key file from a PEM key
- [ ] Push the new Docker images and use them in the docker-compose files