### PR TITLE
[Setup] Install dependencies early in Dockerfile

### DIFF
--- a/deployment/scripts/extract_requirements.py
+++ b/deployment/scripts/extract_requirements.py
@@ -1,0 +1,36 @@
+import argparse
+from configparser import ConfigParser
+
+
+def cli_parse() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Extracts dependencies from setup.cfg into a requirements.txt file."
+    )
+    parser.add_argument(
+        "config_file", action="store", nargs=1, type=str, help="Path to setup.cfg."
+    )
+    parser.add_argument(
+        "--output-file",
+        "-o",
+        action="store",
+        default="requirements.txt",
+        type=str,
+        help="Path to the requirements file to create.",
+    )
+    return parser.parse_args()
+
+
+def main(args: argparse.Namespace):
+    config_file = args.config_file
+    output_file = args.output_file
+
+    parser = ConfigParser()
+    parser.read(config_file)
+
+    requirements = parser["options"]["install_requires"]
+    with open(output_file, "w") as f:
+        f.write(requirements.strip())
+
+
+if __name__ == "__main__":
+    main(cli_parse())


### PR DESCRIPTION
Modified the PyAleph Dockerfile to separate the install of
the dependencies from PyAleph itself. This way, we can install
the requirements once and cache them in a layer of the image,
avoiding to fetch them each time.

A new script, `extract_requirements.py`, is used to read
the install requirements from setup.cfg into a temporary
requirements.txt file.

Removed the install of pytest from the Docker image as it is
not relevant to a Docker image.