### PR TITLE
[P2P] Access singletons higher in the call stack

### DIFF
--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -199,13 +199,13 @@ def main(args):
 
         # handler = app.make_handler(loop=loop)
         LOGGER.debug("Initializing p2p")
-        f = p2p.init_p2p(config)
-        p2p_tasks = loop.run_until_complete(f)
+        p2p_init_task = p2p.init_p2p(config)
+        p2p_client, p2p_tasks = loop.run_until_complete(p2p_init_task)
         tasks += p2p_tasks
         LOGGER.debug("Initialized p2p")
 
         LOGGER.debug("Initializing listeners")
-        tasks += listener_tasks(config)
+        tasks += listener_tasks(config, p2p_client)
         tasks += connector_tasks(config, outgoing=(not args.no_commit))
         LOGGER.debug("Initialized listeners")
 

--- a/src/aleph/jobs.py
+++ b/src/aleph/jobs.py
@@ -353,7 +353,7 @@ def prepare_loop(config_values, idx=1):
 
     init_db(config, ensure_indexes=False)
     loop.run_until_complete(get_ipfs_api(timeout=2, reset=True))
-    tasks = loop.run_until_complete(init_p2p(config, listen=False, port_id=idx))
+    _, tasks = loop.run_until_complete(init_p2p(config, listen=False, port_id=idx))
     return loop, tasks
 
 

--- a/src/aleph/network.py
+++ b/src/aleph/network.py
@@ -4,6 +4,8 @@ import logging
 from typing import Coroutine, Dict, List, Optional
 from urllib.parse import unquote
 
+from p2pclient import Client as P2PClient
+
 from aleph.register_chain import VERIFIER_REGISTER
 from aleph.services.ipfs.pubsub import incoming_channel as incoming_ipfs_channel
 from aleph.types import ItemType, InvalidMessageError
@@ -144,11 +146,11 @@ async def check_message(
         return None
 
 
-def listener_tasks(config) -> List[Coroutine]:
+def listener_tasks(config, p2p_client: P2PClient) -> List[Coroutine]:
     from aleph.services.p2p.protocol import incoming_channel as incoming_p2p_channel
 
     # for now (1st milestone), we only listen on a single global topic...
-    tasks: List[Coroutine] = [incoming_p2p_channel(config.aleph.queue_topic.value)]
+    tasks: List[Coroutine] = [incoming_p2p_channel(p2p_client, config.aleph.queue_topic.value)]
     if config.ipfs.enabled.value:
         tasks.append(incoming_ipfs_channel(config.aleph.queue_topic.value))
     return tasks

--- a/src/aleph/services/p2p/__init__.py
+++ b/src/aleph/services/p2p/__init__.py
@@ -1,14 +1,15 @@
-from typing import Coroutine, List
+import socket
+from typing import Coroutine, List, Tuple
 
+from configmanager import Config
 from multiaddr import Multiaddr
 from p2pclient import Client as P2PClient
 
 from . import singleton
 from .manager import initialize_host
-import socket
 
 
-def init_p2p_client(config) -> P2PClient:
+def init_p2p_client(config: Config) -> P2PClient:
     host = config.p2p.host.value
     host_ip_addr = socket.gethostbyname(host)
 
@@ -16,17 +17,24 @@ def init_p2p_client(config) -> P2PClient:
     listen_port = config.p2p.listen_port.value
     control_maddr = Multiaddr(f"/ip4/{host_ip_addr}/tcp/{control_port}")
     listen_maddr = Multiaddr(f"/ip4/0.0.0.0/tcp/{listen_port}")
-    return P2PClient(control_maddr=control_maddr, listen_maddr=listen_maddr)
+    p2p_client = P2PClient(control_maddr=control_maddr, listen_maddr=listen_maddr)
+
+    return p2p_client
 
 
-async def init_p2p(config, listen: bool = True, port_id: int = 0) -> List[Coroutine]:
-    singleton.client = init_p2p_client(config)
+async def init_p2p(config: Config, listen: bool = True, port_id: int = 0) -> Tuple[P2PClient, List[Coroutine]]:
+    p2p_client = init_p2p_client(config)
+    # This singleton will not be required anymore once the API is in its own separate program.
+    singleton.client = p2p_client
+
     port = config.p2p.port.value + port_id
     singleton.streamer, tasks = await initialize_host(
-        p2p_client=singleton.client,
+        config=config,
+        p2p_client=p2p_client,
         host=config.p2p.host.value,
         port=port,
         listen=listen,
+        protocol_active=("protocol" in config.p2p.clients.value),
     )
 
-    return tasks
+    return p2p_client, tasks

--- a/src/aleph/services/p2p/jobs.py
+++ b/src/aleph/services/p2p/jobs.py
@@ -3,19 +3,17 @@ import logging
 from typing import List, Optional
 
 from configmanager import Config
+from p2pclient import Client as P2PClient
 
 from aleph.model.p2p import get_peers
 from .http import api_get_request
 from .peers import connect_peer
+from .protocol import AlephProtocol
 
 LOGGER = logging.getLogger("P2P.jobs")
 
 
-async def reconnect_p2p_job(config: Optional[Config] = None) -> None:
-    from aleph.web import app
-
-    if config is None:
-        config = app["config"]
+async def reconnect_p2p_job(config: Config, p2p_client: P2PClient, streamer: Optional[AlephProtocol]) -> None:
     await asyncio.sleep(2)
     while True:
         try:
@@ -24,7 +22,7 @@ async def reconnect_p2p_job(config: Optional[Config] = None) -> None:
             )
             for peer in peers:
                 try:
-                    await connect_peer(config, peer)
+                    await connect_peer(config=config, p2p_client=p2p_client, streamer=streamer, peer=peer)
                 except Exception:
                     LOGGER.debug("Can't reconnect to %s" % peer)
 

--- a/src/aleph/services/p2p/peers.py
+++ b/src/aleph/services/p2p/peers.py
@@ -1,12 +1,14 @@
+from typing import Optional
+
 from configmanager import Config
 from multiaddr import Multiaddr
+from p2pclient import Client as P2PClient
 from p2pclient.libp2p_stubs.peer.peerinfo import info_from_p2p_addr
 
-from .singleton import get_p2p_client, streamer
+from .protocol import AlephProtocol
 
 
-async def connect_peer(config: Config, peer: str) -> None:
-    p2p_client = get_p2p_client()
+async def connect_peer(config: Config, p2p_client: P2PClient, streamer: Optional[AlephProtocol], peer: str) -> None:
     peer_info = info_from_p2p_addr(Multiaddr(peer))
     peer_id, _ = await p2p_client.identify()
 

--- a/src/aleph/services/p2p/pubsub.py
+++ b/src/aleph/services/p2p/pubsub.py
@@ -1,16 +1,15 @@
 import logging
 from typing import AsyncIterator
 
+from p2pclient import Client as P2PClient
 from p2pclient.pb.p2pd_pb2 import PSMessage
 from p2pclient.utils import read_pbmsg_safe
 
-from .singleton import get_p2p_client
 
 LOGGER = logging.getLogger("P2P.pubsub")
 
 
-async def sub(topic: str) -> AsyncIterator[PSMessage]:
-    p2p_client = get_p2p_client()
+async def sub(p2p_client: P2PClient, topic: str) -> AsyncIterator[PSMessage]:
     stream = await p2p_client.pubsub_subscribe(topic)
     while True:
         pubsub_msg = PSMessage()
@@ -20,6 +19,5 @@ async def sub(topic: str) -> AsyncIterator[PSMessage]:
         yield pubsub_msg
 
 
-async def pub(topic: str, message: str) -> None:
-    p2p_client = get_p2p_client()
+async def pub(p2p_client: P2PClient, topic: str, message: str) -> None:
     await p2p_client.pubsub_publish(topic, message.encode("utf-8"))

--- a/src/aleph/services/p2p/singleton.py
+++ b/src/aleph/services/p2p/singleton.py
@@ -1,14 +1,25 @@
-from typing import Any, List, Optional
+from typing import List, Optional, TypeVar
 
 from p2pclient import Client as P2PClient
 
+from .protocol import AlephProtocol
+
 client: Optional[P2PClient] = None
-# TODO: use the correct type once the circular dependency is resolved (next PR)
-streamer: Optional[Any] = None
+streamer: Optional[AlephProtocol] = None
 api_servers: Optional[List[str]] = None
+
+T = TypeVar("T")
+
+
+def _get_singleton(singleton: Optional[T], name: str) -> T:
+    if singleton is None:
+        raise ValueError(f"{name} is null!")
+    return singleton
 
 
 def get_p2p_client() -> P2PClient:
-    if client is None:
-        raise ValueError("Client is null!")
-    return client
+    return _get_singleton(client, "P2P client")
+
+
+def get_streamer() -> AlephProtocol:
+    return _get_singleton(streamer, "Streamer")

--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -14,7 +14,7 @@ from aleph.services.ipfs.storage import add_file as ipfs_add_file
 from aleph.services.ipfs.storage import get_ipfs_content
 from aleph.services.ipfs.storage import pin_add as ipfs_pin_add
 from aleph.services.p2p.http import request_hash as p2p_http_request_hash
-from aleph.services.p2p.protocol import request_hash as p2p_protocol_request_hash
+from aleph.services.p2p.singleton import get_streamer
 from aleph.types import ItemType
 from aleph.utils import run_in_executor, get_sha256
 from aleph.web import app
@@ -68,7 +68,8 @@ async def get_hash_content(
     if content is None:
         if use_network:
             if "protocol" in enabled_clients:
-                content = await p2p_protocol_request_hash(hash)
+                streamer = get_streamer()
+                content = await streamer.request_hash(hash)
 
             if "http" in enabled_clients and content is None:
                 content = await p2p_http_request_hash(hash, timeout=timeout)

--- a/src/aleph/web/controllers/p2p.py
+++ b/src/aleph/web/controllers/p2p.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 from aiohttp import web
+from aleph.services.p2p.singleton import get_p2p_client
 
 from aleph.services.ipfs.pubsub import pub as pub_ipfs
 from aleph.services.p2p.pubsub import pub as pub_p2p
@@ -24,7 +25,8 @@ async def pub_json(request):
         failed_publications.append(Protocol.IPFS)
 
     try:
-        await asyncio.wait_for(pub_p2p(data.get("topic"), data.get("data")), 0.5)
+        p2p_client = get_p2p_client()
+        await asyncio.wait_for(pub_p2p(p2p_client, data.get("topic"), data.get("data")), 0.5)
     except Exception:
         LOGGER.exception("Can't publish on p2p")
         failed_publications.append(Protocol.P2P)


### PR DESCRIPTION
Moved most calls to singleton variables higher in the call stack
to improve the testability of the P2P functions. These singletons
will be completely eliminated in future PRs.