### PR TITLE
Change: Sort pending messages by number of retries in processing

### DIFF
--- a/src/aleph/model/pending.py
+++ b/src/aleph/model/pending.py
@@ -16,6 +16,8 @@ class PendingMessage(BaseClass):
         IndexModel([("source.chain_name", ASCENDING)]),
         #    IndexModel([("source.height", ASCENDING)]),
         IndexModel([("message.time", ASCENDING)]),
+        IndexModel([("retries", ASCENDING), ("message.time", ASCENDING)],
+                   partialFilterExpression={"retries": {"$gt": 0}}),
     ]
 
 


### PR DESCRIPTION
We observed that some messages fail being processed correctly many times. This could be due to temporary issues and the message should still be processed and not ignored.

In order to prevent these messages from obstructing other messages to be processed, this change sorts the pending messages during processing by the ascending number of retries, such that messages that have now or little been retried are processed first.

This should improve the responsiveness of the nodes when processing new messages.