### PR TITLE
[P2P] Added tests and fixed issues

### DIFF
--- a/.github/workflows/pyaleph-ci.yml
+++ b/.github/workflows/pyaleph-ci.yml
@@ -21,6 +21,10 @@ jobs:
       with:
         # Fetch the whole history for all tags and branches (required for aleph.__version__)
         fetch-depth: 0
+    # Install nodejs for jsp2pd
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16'
     - name: Set up Python 3.8
       id: setup-python
       uses: actions/setup-python@v2
@@ -34,7 +38,9 @@ jobs:
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pip-${{ hashFiles('setup.cfg') }}
-    - name: Install dependencies
+    - name: Install jsp2pd
+      run: npm install --global libp2p-daemon@0.10.2
+    - name: Install Python dependencies
       run: |
         pip install .[testing]
     - name: Check types

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     hexbytes==0.2.2
     motor==2.5.1
     nuls2-python@git+https://github.com/aleph-im/nuls2-python.git
-    p2pclient@git+https://github.com/odesenfans/py-libp2p-daemon-bindings.git@c36b0262bf0b7581c0f9662c3f2fb4368e6b3c28
+    p2pclient@git+https://github.com/odesenfans/py-libp2p-daemon-bindings.git@f1a3aec9566a1067bd7f7f945e3205cb1073a505
     pymongo==3.12.3
     pynacl==1.5.0
     python-dateutil==2.8.2

--- a/src/aleph/services/p2p/jobs.py
+++ b/src/aleph/services/p2p/jobs.py
@@ -22,7 +22,7 @@ async def reconnect_p2p_job(config: Config, p2p_client: P2PClient, streamer: Opt
             )
             for peer in peers:
                 try:
-                    await connect_peer(config=config, p2p_client=p2p_client, streamer=streamer, peer=peer)
+                    await connect_peer(p2p_client=p2p_client, streamer=streamer, peer_maddr=peer)
                 except Exception:
                     LOGGER.debug("Can't reconnect to %s" % peer)
 

--- a/src/aleph/services/p2p/peers.py
+++ b/src/aleph/services/p2p/peers.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-from configmanager import Config
 from multiaddr import Multiaddr
 from p2pclient import Client as P2PClient
 from p2pclient.libp2p_stubs.peer.peerinfo import info_from_p2p_addr
@@ -8,8 +7,16 @@ from p2pclient.libp2p_stubs.peer.peerinfo import info_from_p2p_addr
 from .protocol import AlephProtocol
 
 
-async def connect_peer(config: Config, p2p_client: P2PClient, streamer: Optional[AlephProtocol], peer: str) -> None:
-    peer_info = info_from_p2p_addr(Multiaddr(peer))
+async def connect_peer(p2p_client: P2PClient, streamer: Optional[AlephProtocol], peer_maddr: str) -> None:
+    """
+    Connects to the specified peer.
+
+    :param p2p_client: P2P daemon client.
+    :param streamer: Protocol streamer, if configured.
+    :param peer_maddr: Fully qualified multi-address of the peer to connect to:
+                       /ip4/<ip-address>/tcp/<port>/p2p/<peer-id>
+    """
+    peer_info = info_from_p2p_addr(Multiaddr(peer_maddr))
     peer_id, _ = await p2p_client.identify()
 
     if str(peer_info.peer_id) == str(peer_id):
@@ -18,8 +25,5 @@ async def connect_peer(config: Config, p2p_client: P2PClient, streamer: Optional
 
     await p2p_client.connect(peer_info.peer_id, peer_info.addrs)
 
-    if "streamer" in config.p2p.clients.value:
-        if streamer is None:
-            raise ValueError("Protocol streamer not initialized")
-        if not await streamer.has_active_streams(peer_info.peer_id):
-            await streamer.create_connections(peer_info.peer_id)
+    if streamer is not None:
+        await streamer.add_peer(peer_info.peer_id)

--- a/src/aleph/services/p2p/pubsub.py
+++ b/src/aleph/services/p2p/pubsub.py
@@ -1,16 +1,29 @@
 import logging
-from typing import AsyncIterator
+from typing import AsyncIterator, Union
 
 from p2pclient import Client as P2PClient
 from p2pclient.pb.p2pd_pb2 import PSMessage
 from p2pclient.utils import read_pbmsg_safe
-
+import anyio
 
 LOGGER = logging.getLogger("P2P.pubsub")
 
 
-async def sub(p2p_client: P2PClient, topic: str) -> AsyncIterator[PSMessage]:
-    stream = await p2p_client.pubsub_subscribe(topic)
+async def subscribe(p2p_client: P2PClient, topic: str) -> anyio.abc.SocketStream:
+    """
+    Subscribes to the specified topic.
+    :param p2p_client: P2P daemon client.
+    :param topic: Topic on which to subscribe.
+    :return: A socket stream object. This stream can be used to read data posted by other peers on the topic.
+    """
+    return await p2p_client.pubsub_subscribe(topic)
+
+
+async def receive_pubsub_messages(stream: anyio.abc.SocketStream) -> AsyncIterator[PSMessage]:
+    """
+    Receives messages from a P2P pubsub topic in a loop and yields them one by one.
+    :param stream: The stream (= return value of the `subscribe` function) to read data from.
+    """
     while True:
         pubsub_msg = PSMessage()
         await read_pbmsg_safe(stream, pubsub_msg)
@@ -19,5 +32,13 @@ async def sub(p2p_client: P2PClient, topic: str) -> AsyncIterator[PSMessage]:
         yield pubsub_msg
 
 
-async def pub(p2p_client: P2PClient, topic: str, message: str) -> None:
-    await p2p_client.pubsub_publish(topic, message.encode("utf-8"))
+async def publish(p2p_client: P2PClient, topic: str, message: Union[bytes, str]) -> None:
+    """
+    Publishes a message on the specified topic.
+    :param p2p_client: P2P daemon client.
+    :param topic: Topic on which to send the message.
+    :param message: The message itself. Can be provided as bytes or as a string.
+    """
+
+    data = message if isinstance(message, bytes) else message.encode("UTF-8")
+    await p2p_client.pubsub_publish(topic, data)

--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -53,12 +53,12 @@ async def get_message_content(message: Dict):
 
 async def get_hash_content(
     hash,
-    engine: ItemType=ItemType.IPFS,
-    timeout=2,
-    tries=1,
-    use_network=True,
-    use_ipfs=True,
-    store_value=True,
+    engine: ItemType = ItemType.IPFS,
+    timeout: int = 2,
+    tries: int = 1,
+    use_network: bool = True,
+    use_ipfs: bool = True,
+    store_value: bool = True,
 ):
     # TODO: determine which storage engine to use
     ipfs_enabled = app["config"].ipfs.enabled.value

--- a/src/aleph/web/controllers/p2p.py
+++ b/src/aleph/web/controllers/p2p.py
@@ -5,7 +5,7 @@ from aiohttp import web
 from aleph.services.p2p.singleton import get_p2p_client
 
 from aleph.services.ipfs.pubsub import pub as pub_ipfs
-from aleph.services.p2p.pubsub import pub as pub_p2p
+from aleph.services.p2p.pubsub import publish as pub_p2p
 from aleph.types import Protocol
 from aleph.web import app
 

--- a/tests/p2p/conftest.py
+++ b/tests/p2p/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+from async_exit_stack import AsyncExitStack
+from p2pclient.daemon import make_p2pd_pair_ip4
+
+
+@pytest.fixture
+async def p2p_clients(request):
+    nb_p2p_daemons = request.param
+    assert isinstance(nb_p2p_daemons, int)
+
+    async with AsyncExitStack() as stack:
+        p2pd_tuples = [
+            await stack.enter_async_context(
+                make_p2pd_pair_ip4(
+                    daemon_executable="jsp2pd",
+                    enable_control=True,
+                    enable_connmgr=False,
+                    enable_dht=False,
+                    enable_pubsub=True,
+                )
+            )
+            for _ in range(nb_p2p_daemons)
+        ]
+        yield tuple(p2pd_tuple.client for p2pd_tuple in p2pd_tuples)

--- a/tests/p2p/test_connect.py
+++ b/tests/p2p/test_connect.py
@@ -1,0 +1,81 @@
+"""Tests to validate the connection / reconnection features of the P2P service."""
+
+from typing import Tuple
+
+import pytest
+from p2pclient import Client as P2PClient
+from aleph.services.p2p.peers import connect_peer
+from aleph.services.p2p.protocol import AlephProtocol
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("p2p_clients", [2], indirect=True)
+async def test_p2p_client_connect(p2p_clients: Tuple[P2PClient, P2PClient]):
+    """
+    Sanity check: verify that connecting two peers makes each peer appear in the peer list of the other peer.
+    This test is redundant with some tests in p2pclient itself.
+    """
+    client1, client2 = p2p_clients
+    client1_peer_id, client1_maddrs = await client1.identify()
+    client2_peer_id, client2_maddrs = await client2.identify()
+    await client2.connect(client1_peer_id, client1_maddrs)
+
+    client1_peers = await client1.list_peers()
+    client2_peers = await client2.list_peers()
+    assert client1_peer_id in [peer.peer_id for peer in client2_peers]
+    assert client2_peer_id in [peer.peer_id for peer in client1_peers]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("p2p_clients", [2], indirect=True)
+async def test_connect_peer_no_streamer(p2p_clients: Tuple[P2PClient, P2PClient]):
+    """
+    Checks that we can connect to a peer using the custom connect_peer function, without managing protocol connections.
+    """
+    client1, client2 = p2p_clients
+    client1_peer_id, client1_maddrs = await client1.identify()
+    client2_peer_id, client2_maddrs = await client2.identify()
+
+    peer_maddr = f"{client2_maddrs[0]}/p2p/{client2_peer_id}"
+
+    await connect_peer(p2p_client=client1, streamer=None, peer_maddr=peer_maddr)
+
+    assert client1_peer_id in [peer.peer_id for peer in await client2.list_peers()]
+    assert client2_peer_id in [peer.peer_id for peer in await client1.list_peers()]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("p2p_clients", [2], indirect=True)
+async def test_connect_peer_streamer(p2p_clients: Tuple[P2PClient, P2PClient]):
+    """
+    Checks that we can connect to a peer using the custom connect_peer function while managing protocol connections.
+    """
+
+    client1, client2 = p2p_clients
+    streamer_client1 = await AlephProtocol.create(client1)
+    # The receiver must have a handler registered for the protocol to be able to open a stream.
+    # The handler is registered when creating the protocol streamer instance.
+    streamer_client2 = await AlephProtocol.create(client2)
+
+    client1_peer_id, client1_maddrs = await client1.identify()
+    client2_peer_id, client2_maddrs = await client2.identify()
+
+    peer_maddr = f"{client2_maddrs[0]}/p2p/{client2_peer_id}"
+
+    await connect_peer(p2p_client=client1, streamer=streamer_client1, peer_maddr=peer_maddr)
+
+    assert client1_peer_id in [peer.peer_id for peer in await client2.list_peers()]
+    assert client2_peer_id in [peer.peer_id for peer in await client1.list_peers()]
+
+    # Check that the peer was added successfully
+    assert client2_peer_id in streamer_client1.peers
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("p2p_clients", [1], indirect=True)
+async def test_connect_to_self(p2p_clients: Tuple[P2PClient]):
+    """Checks that nothing bad happens if we try to connect to ourselves."""
+    client = p2p_clients[0]
+    peer_id, maddrs = await client.identify()
+
+    await connect_peer(p2p_client=client, streamer=None, peer_maddr=f"/p2p/{peer_id}")

--- a/tests/p2p/test_identify.py
+++ b/tests/p2p/test_identify.py
@@ -1,0 +1,14 @@
+from typing import Tuple
+
+import pytest
+from p2pclient import Client as P2PClient
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("p2p_clients", [1], indirect=True)
+async def test_p2p_client_identify(p2p_clients: Tuple[P2PClient]):
+    """Sanity check to make sure that the fixture deploys the P2P daemon and that the client can reach it."""
+
+    assert len(p2p_clients) == 1
+    client = p2p_clients[0]
+    _peer_id, _maddrs = await client.identify()

--- a/tests/p2p/test_pubsub.py
+++ b/tests/p2p/test_pubsub.py
@@ -1,0 +1,77 @@
+"""Tests to validate the sending and receiving of messages on pubsub P2P topics."""
+
+import asyncio
+from typing import Tuple
+
+import pytest
+from p2pclient import Client as P2PClient
+
+from aleph.services.p2p.pubsub import publish, receive_pubsub_messages, subscribe
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("p2p_clients", [2], indirect=True)
+async def test_pubsub(p2p_clients: Tuple[P2PClient, P2PClient]):
+    topic = "test-topic"
+
+    client1, client2 = p2p_clients
+    client1_peer_id, client1_maddrs = await client1.identify()
+    client2_peer_id, client2_maddrs = await client2.identify()
+    await client2.connect(client1_peer_id, client1_maddrs)
+
+    # Check that the peers are connected
+    assert client1_peer_id in [peer.peer_id for peer in await client2.list_peers()]
+    assert client2_peer_id in [peer.peer_id for peer in await client1.list_peers()]
+
+    # TODO: without this sleep, the test hangs randomly. Figure out why.
+    await asyncio.sleep(1)
+
+    stream = await subscribe(client2, topic)
+
+    msg = "Hello, peer"
+    await publish(client1, topic, msg)
+
+    received_msg = await asyncio.wait_for(receive_pubsub_messages(stream).__anext__(), timeout=10)
+    print(received_msg)
+    assert received_msg.data.decode("UTF-8") == msg
+    assert topic in received_msg.topicIDs
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("p2p_clients", [3], indirect=True)
+async def test_pubsub_multiple_subscribers(p2p_clients):
+    """
+    Tests that a pubsub message can go through several peers to reach its destination.
+    Note that the peers must all subscribe to the topic in order to publish the message to the other peers.
+    The connection in this test is: Peer #3 -> Peer #1 -> Peer #2.
+    """
+    topic = "test-topic-multi"
+    client1, client2, client3 = p2p_clients
+    client1_peer_id, client1_maddrs = await client1.identify()
+    client2_peer_id, client2_maddrs = await client2.identify()
+    client3_peer_id, client3_maddrs = await client3.identify()
+    await client2.connect(client1_peer_id, client1_maddrs)
+    await client3.connect(client1_peer_id, client1_maddrs)
+
+    # TODO: without this sleep, the test hangs randomly. Figure out why.
+    await asyncio.sleep(1)
+
+    # Check that the peers are connected
+    assert {client2_peer_id, client3_peer_id}.issubset(peer.peer_id for peer in await client1.list_peers())
+    assert client1_peer_id in [peer.peer_id for peer in await client2.list_peers()]
+    assert client1_peer_id in [peer.peer_id for peer in await client3.list_peers()]
+
+    stream_client1 = await subscribe(client1, topic)
+    stream_client2 = await subscribe(client2, topic)
+    msg = "Hello, distant peer"
+    await publish(client3, topic, msg)
+
+    # Check that the neighboring peer received the message
+    received_msg_client1 = await asyncio.wait_for(receive_pubsub_messages(stream_client1).__anext__(), timeout=10)
+    assert received_msg_client1.data.decode("UTF-8") == msg
+    assert topic in received_msg_client1.topicIDs
+
+    # Check that the distant peer also received the message
+    received_msg_client2 = await asyncio.wait_for(receive_pubsub_messages(stream_client2).__anext__(), timeout=10)
+    assert received_msg_client2.data.decode("UTF-8") == msg
+    assert topic in received_msg_client2.topicIDs


### PR DESCRIPTION
Added tests for the P2P service. We now test the connection and
pubsub functionalities.

The new tests spawn JS P2P daemons and act as simplified nodes
exchanging messages. We test the following features:

* connection to a remote node
* exchange of "hello" messages
* subscription and publication of messages on P2P topics.

The tests for the P2P streaming protocol will follow after a bug
within p2pclient and/or the P2P daemon is fixed.