### PR TITLE
[CI] Cache Docker images

### DIFF
--- a/.github/workflows/pyaleph-ci.yml
+++ b/.github/workflows/pyaleph-ci.yml
@@ -46,7 +46,20 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Download Docker cache image (if available)
+        run: docker pull ghcr.io/$GITHUB_REPOSITORY/build-cache || true
+
       - name: Build the Docker image
         run: |
           git fetch --prune --unshallow --tags
-          docker build . -t pyaleph-node:${GITHUB_REF##*/} -f deployment/docker-build/pyaleph.dockerfile # --cache-from=docker.pkg.github.com/$GITHUB_REPOSITORY/build-cache
+          docker build . -t pyaleph-node:${GITHUB_REF##*/} -f deployment/docker-build/pyaleph.dockerfile --cache-from=ghcr.io/$GITHUB_REPOSITORY/build-cache
+
+      - name: Push the image to the cache
+        # It's not possible to push packages from fork PRs.
+        if: github.event.pull_request.head.repo.full_name == $GITHUB_REPOSITORY
+        run: |
+          docker tag pyaleph-node:${GITHUB_REF##*/} ghcr.io/$GITHUB_REPOSITORY/build-cache
+          docker push ghcr.io/$GITHUB_REPOSITORY/build-cache

--- a/.github/workflows/pyaleph-ci.yml
+++ b/.github/workflows/pyaleph-ci.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Push the image to the cache
         # It's not possible to push packages from fork PRs.
-        if: github.event.pull_request.head.repo.full_name == $GITHUB_REPOSITORY
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           docker tag pyaleph-node:${GITHUB_REF##*/} ghcr.io/$GITHUB_REPOSITORY/build-cache
           docker push ghcr.io/$GITHUB_REPOSITORY/build-cache


### PR DESCRIPTION
Added a mechanism to cache Docker images after build to speed up
the next CI run. The mechanism is similar to what was done in
the previous CI but uses the new Github Container Registry
instead of the deprecated Docker Registry.