### PR TITLE
[Config] Disable "protocol" P2P config

### DIFF
--- a/src/aleph/exceptions.py
+++ b/src/aleph/exceptions.py
@@ -2,5 +2,9 @@ class AlephException(Exception):
     ...
 
 
+class InvalidConfigException(AlephException):
+    ...
+
+
 class PrivateKeyNotFoundException(AlephException):
-    pass
+    ...


### PR DESCRIPTION
The "protocol" client type is not supported at the moment due
to a bug within the JS P2P daemon. Added an error message and
stopped the node early if someone attempts to use it.