### PR TITLE
[Index] Fix minor issues

### DIFF
--- a/src/aleph/web/controllers/metrics.py
+++ b/src/aleph/web/controllers/metrics.py
@@ -168,8 +168,10 @@ async def get_metrics(shared_stats: dict) -> Metrics:
     else:
         sync_messages_remaining_total = None
 
-    if not (eth_reference_height is None or eth_last_committed_height is None):
-        eth_remaining_height = eth_reference_height - eth_last_committed_height
+    if eth_reference_height and eth_last_committed_height:
+        # Some blocks may not contain Aleph messages, and therefore the last committed height
+        # may be higher than the height of the last block containing Aleph messages.
+        eth_remaining_height = max(eth_reference_height - eth_last_committed_height, 0)
     else:
         eth_remaining_height = None
 

--- a/src/aleph/web/templates/index.html
+++ b/src/aleph/web/templates/index.html
@@ -85,7 +85,7 @@
                 {{pyaleph_status_chain_eth_height_remaining_total}}
             </span> left )
             <br/>
-            <progress data-ratio="chain_eth" value="{{pyaleph_status_chain_eth_last_committed_height}}" max="100"></progress>
+            <progress data-ratio="chain_eth" value="{{ pyaleph_status_chain_eth_last_committed_height }} / {{ pyaleph_status_chain_eth_last_committed_height }}" max="100"></progress>
         {% endif %}
     </p>
 </section>


### PR DESCRIPTION
Fixed two issues in the index page of the node.

* Fixed an issue where the number of remaining blocks to integrate
  could be negative. This happened because we compare the last
  block holding Aleph data with the total height of the blockchain.
  As some blocks do not contain Aleph data, the balance could
  become negative. Floored the balance to 0 to avoid the issue.

* Fixed an issue in the progress bar where the current height was
  not divided by the total height, resulting in an incorrect
  progress status.