### PR TITLE
[API] Add start/end dates to message schema

### DIFF
--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -25,6 +25,8 @@ KNOWN_QUERY_FIELDS = {
     "history",
     "pagination",
     "page",  # page is handled in Pagination.get_pagination_params
+    "startDate",
+    "endDate",
 }
 
 


### PR DESCRIPTION
Added the `startDate` and `endDate` parameters to
`KNOWN_QUERY_FIELDS`.

Fork of #160 with rebase to `origin/dev`