### PR TITLE
[P2P] Do not run P2P tasks in web servers

### DIFF
--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -88,7 +88,6 @@ def run_server_coroutine(
     config_values,
     host,
     port,
-    idx,
     shared_stats,
     enable_sentry: bool = True,
     extra_web_config: Optional[Dict] = None,
@@ -109,11 +108,9 @@ def run_server_coroutine(
     # Use a try-catch-capture_exception to work with multiprocessing, see
     # https://github.com/getsentry/raven-python/issues/1110
     try:
-        loop, tasks = prepare_loop(config_values, idx=idx)
+        loop = prepare_loop(config_values)
         loop.run_until_complete(
-            asyncio.gather(
-                *tasks, run_server(host, port, shared_stats, extra_web_config)
-            )
+            asyncio.gather(run_server(host, port, shared_stats, extra_web_config))
         )
     except Exception as e:
         if enable_sentry:
@@ -156,7 +153,6 @@ def main(args):
         msg = "The 'protocol' P2P config is not supported by the current version."
         LOGGER.error(msg)
         raise InvalidConfigException(msg)
-
 
     # We only check that the serialized key exists.
     serialized_key_file_path = os.path.join(args.key_dir, "serialized-node-secret.key")
@@ -227,7 +223,6 @@ def main(args):
                 config_values,
                 config.aleph.host.value,
                 config.p2p.http_port.value,
-                3,
                 shared_stats,
                 args.sentry_disabled is False and app["config"].sentry.dsn.value,
                 extra_web_config,
@@ -239,7 +234,6 @@ def main(args):
                 config_values,
                 config.aleph.host.value,
                 config.aleph.port.value,
-                4,
                 shared_stats,
                 args.sentry_disabled is False and app["config"].sentry.dsn.value,
                 extra_web_config,

--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -109,9 +109,7 @@ def run_server_coroutine(
     # https://github.com/getsentry/raven-python/issues/1110
     try:
         loop = prepare_loop(config_values)
-        loop.run_until_complete(
-            asyncio.gather(run_server(host, port, shared_stats, extra_web_config))
-        )
+        loop.run_until_complete(run_server(host, port, shared_stats, extra_web_config))
     except Exception as e:
         if enable_sentry:
             sentry_sdk.capture_exception(e)

--- a/src/aleph/services/p2p/__init__.py
+++ b/src/aleph/services/p2p/__init__.py
@@ -19,15 +19,16 @@ def init_p2p_client(config: Config) -> P2PClient:
     listen_maddr = Multiaddr(f"/ip4/0.0.0.0/tcp/{listen_port}")
     p2p_client = P2PClient(control_maddr=control_maddr, listen_maddr=listen_maddr)
 
-    return p2p_client
-
-
-async def init_p2p(config: Config, listen: bool = True, port_id: int = 0) -> Tuple[P2PClient, List[Coroutine]]:
-    p2p_client = init_p2p_client(config)
     # This singleton will not be required anymore once the API is in its own separate program.
     singleton.client = p2p_client
 
-    port = config.p2p.port.value + port_id
+    return p2p_client
+
+
+async def init_p2p(config: Config, listen: bool = True) -> Tuple[P2PClient, List[Coroutine]]:
+    p2p_client = init_p2p_client(config)
+
+    port = config.p2p.port.value
     singleton.streamer, tasks = await initialize_host(
         config=config,
         p2p_client=p2p_client,


### PR DESCRIPTION
The web server processes must initialize all the global variables
(DB, IPFS, P2P) on their own. The function used to initialize
the P2P system would also spawn the subscriber tasks. The API
only needs to be able to write to the P2P pubsub topics.

Moved the initialization of the singleton P2P client in
the `init_p2p_client` function and used that function instead
of `init_p2p` in API processes.