### PR TITLE
[Doc] Fix warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,25 +72,11 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.todo',
 templates_path = ['_templates']
 
 
-# To configure AutoStructify
-def setup(app):
-    from recommonmark.transform import AutoStructify
-    app.add_config_value('recommonmark_config', {
-        'auto_toc_tree_section': 'Contents',
-        'enable_eval_rst': True,
-        'enable_auto_doc_ref': True,
-        'enable_math': True,
-        'enable_inline_math': True
-    }, True)
-    app.add_transform(AutoStructify)
-
 # Additional parsers besides rst
-source_parsers = {
-   '.md': 'recommonmark.parser.CommonMarkParser',
-}
+source_parsers = {}
 
 # The suffix of source filenames.
-source_suffix = ['.rst', '.md']
+source_suffix = ['.rst']
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'

--- a/docs/protocol/messages/index.rst
+++ b/docs/protocol/messages/index.rst
@@ -89,6 +89,5 @@ Message types
 .. toctree::
    :maxdepth: 2
 
-   aggregates
+   aggregate
    post
-   store

--- a/setup.cfg
+++ b/setup.cfg
@@ -101,7 +101,6 @@ cosmos =
     cosmospy
 docs =
     sphinxcontrib-plantuml
-    recommonmark
 
 [options.entry_points]
 # Add here console scripts like:

--- a/src/aleph/services/keys.py
+++ b/src/aleph/services/keys.py
@@ -21,9 +21,9 @@ def generate_keypair(print_key: bool) -> KeyPair:
 def save_keys(key_pair: KeyPair, key_dir: str) -> None:
     """
     Saves the private and public keys to the specified directory. The keys are stored in 3 formats:
-    * The private key is stored in PEM format for ease of use, and in a serialized format compatible with the P2P
-      daemon (DER + protobuf encoding).
-    * The public key is stored in PEM format.
+    - The private key is stored in PEM format for ease of use, and in a serialized format compatible with the P2P
+    daemon (DER + protobuf encoding).
+    - The public key is stored in PEM format.
     """
     # Create the key directory if it does not exist
     if os.path.exists(key_dir):


### PR DESCRIPTION
Fixed all the warnings that popped up when building the docs:
* Removed all references to recommonmark as it is now deprecated
  and unused in the project anyway
* Removed the empty take.rst file
* Fixed index issues in docs/protocol/messages
* Fixed indentation issues in a docstring.