### PR TITLE
[Fix] Remove nonexisting dependencies in Docker Compose

### DIFF
--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       - mongodb
       - ipfs
       - p2pd
-      - pyaleph-migrations
     networks:
       - pyaleph
     logging:
@@ -29,8 +28,6 @@ services:
   p2pd:
     restart: always
     image: alephim/jsp2pd:0.10.2-1.0.0
-    depends_on:
-      - pyaleph-updater
     networks:
       - pyaleph
     environment:


### PR DESCRIPTION
Fixed an error that went through with the updater PR. Reverted
unwanted changes to the dependencies of the pyaleph and p2pd
services in the Docker Compose file.