### PR TITLE
[DB] Remove partial attribute on retries + time index

### DIFF
--- a/src/aleph/model/pending.py
+++ b/src/aleph/model/pending.py
@@ -16,8 +16,7 @@ class PendingMessage(BaseClass):
         IndexModel([("source.chain_name", ASCENDING)]),
         #    IndexModel([("source.height", ASCENDING)]),
         IndexModel([("message.time", ASCENDING)]),
-        IndexModel([("retries", ASCENDING), ("message.time", ASCENDING)],
-                   partialFilterExpression={"retries": {"$gt": 0}}),
+        IndexModel([("retries", ASCENDING), ("message.time", ASCENDING)]),
     ]
 
 


### PR DESCRIPTION
Fixed an issue where this index would not be used by the query
listing pending messages because the query looks for all messages
and not only those who have already been retried. This would result
in a memory error with MongoDB given the number of pending messages.