### PR TITLE
[Docs] Use version in download links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -290,3 +290,8 @@ intersphinx_mapping = {
     'pandas': ('http://pandas.pydata.org/pandas-docs/stable', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
 }
+
+
+rst_epilog = """
+.. |pyaleph_version| replace:: v0.2.0-rc1
+"""

--- a/docs/guides/install.rst
+++ b/docs/guides/install.rst
@@ -67,9 +67,9 @@ Configuration file
 This section describes how to create and customize the PyAleph configuration file.
 First, download the PyAleph configuration template:
 
-.. code-block:: bash
+.. parsed-literal::
 
-    wget "https://raw.githubusercontent.com/aleph-im/pyaleph/master/deployment/samples/docker-compose/sample-config.yml"
+    wget "https://raw.githubusercontent.com/aleph-im/pyaleph/|pyaleph_version|/deployment/samples/docker-compose/sample-config.yml"
 
 Then rename the file to config.yml:
 
@@ -130,9 +130,9 @@ To check that the generation of the keys succeeded, print your private key:
 
 Download the Docker Compose file that defines how to run PyAleph, MongoDB and IPFS together.
 
-.. code-block:: bash
+.. parsed-literal::
 
-    wget "https://raw.githubusercontent.com/aleph-im/pyaleph/master/deployment/samples/docker-compose/docker-compose.yml"
+    wget "https://raw.githubusercontent.com/aleph-im/pyaleph/|pyaleph_version|/deployment/samples/docker-compose/docker-compose.yml"
 
 At this stage, you will need your configuration file and your keys.
 Check the configuration section to see how you can generate them.

--- a/docs/guides/upgrade.rst
+++ b/docs/guides/upgrade.rst
@@ -27,10 +27,10 @@ Download the latest image
 
 Upgrade the docker-compose file:
 
-.. code-block:: bash
+.. parsed-literal::
 
     mv docker-compose.yml docker-compose-old.yml
-    wget "https://raw.githubusercontent.com/aleph-im/pyaleph/master/deployment/samples/docker-compose/docker-compose.yml"
+    wget "https://raw.githubusercontent.com/aleph-im/pyaleph/|pyaleph_version|/deployment/samples/docker-compose/docker-compose.yml"
 
 .. code-block:: bash
 


### PR DESCRIPTION
Modified all links pointing to the git repository to make them
point to the latest released version instead of master.