### PR TITLE
Fix: On some servers, ip returned as chinese chars instead if IPv4

### DIFF
--- a/src/aleph/services/utils.py
+++ b/src/aleph/services/utils.py
@@ -1,14 +1,16 @@
 import socket
 
-import aiohttp
+# import aiohttp
+import requests
 
 
 async def get_IP():
     ip = None
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get("https://v4.ident.me/") as resp:
-                ip = await resp.text()
+        # async with aiohttp.ClientSession() as session:
+        #     async with session.get("https://v4.ident.me/") as resp:
+        #         ip = await resp.text()
+        ip = requests.get("https://v4.ident.me/").text
     except:
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         s.connect(("8.8.8.8", 80))


### PR DESCRIPTION
The bug only happened when using aiohttp and was not reproduced using requests.

We should investigate the issue more since this does not identify the source of the problem and the solution is not elegant.