### PR TITLE
Change: Drop support for Python 3.6, require 3.8+

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,6 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You're ready to go!
 
 ## Software used
 
-The Aleph CCN is written in Python and requires Python v3.6+. It will not work with older versions of Python.
+The Aleph CCN is written in Python and requires Python v3.8+. It will not work with older versions of Python.
 
 It also relies on [MongoDB](https://www.mongodb.com/) and [IPFS](https://ipfs.io/).
 


### PR DESCRIPTION
With both Ubuntu 20.04 LTS and Debian 11 ship Python 3.8, and most deployments using containers, there is no valid reason to keep supporting older versions of Python.