### PR TITLE
Fix: The `beta` docker image was used only for `chown`

### DIFF
--- a/docs/guides/install.rst
+++ b/docs/guides/install.rst
@@ -113,11 +113,11 @@ An Aleph.im node must have a persistent public-private keypair to authenticate t
 These keys can be created using the Docker image.
 We strongly advise to back up your keys once generated.
 
-.. code-block:: bash
+.. parsed-literal::
 
     mkdir keys
-    docker run --rm -ti --user root -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:beta chown aleph:aleph /opt/pyaleph/keys
-    docker run --rm -ti -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:beta pyaleph --gen-keys --key-dir /opt/pyaleph/keys
+    docker run --rm -ti --user root -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:|pyaleph_version| chown aleph:aleph /opt/pyaleph/keys
+    docker run --rm -ti -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:|pyaleph_version| pyaleph --gen-keys --key-dir /opt/pyaleph/keys
 
 To check that the generation of the keys succeeded, print your private key:
 

--- a/docs/guides/upgrade.rst
+++ b/docs/guides/upgrade.rst
@@ -18,11 +18,11 @@ The updater expects that you already created a keys/ directory to hold your priv
 If you do not already have one, you need to create the directory, copy the key of your node in it
 and adjust the ownership of the folder:
 
-.. code-block:: bash
+.. parsed-literal::
 
     mkdir keys
     cp node-secret.key keys/
-    docker run --rm -ti --user root -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:beta chown -R aleph:aleph /opt/pyaleph/keys
+    docker run --rm -ti --user root -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:|pyaleph_version| chown -R aleph:aleph /opt/pyaleph/keys
 
 Download the latest image
 -------------------------


### PR DESCRIPTION
Solution: Use the current release tag instead.