### PR TITLE
[Fix] Translate pubsub message to dict early

### DIFF
--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -13,6 +13,7 @@ from p2pclient.libp2p_stubs.peer.id import ID
 
 from aleph import __version__
 from aleph.network import incoming_check
+from aleph.services.utils import pubsub_msg_to_dict
 from aleph.types import InvalidMessageError
 from .pubsub import receive_pubsub_messages, subscribe
 
@@ -171,15 +172,14 @@ async def incoming_channel(p2p_client: P2PClient, topic: str) -> None:
 
     while True:
         try:
-            async for mvalue in receive_pubsub_messages(stream):
-                LOGGER.debug("Received from P2P:", mvalue)
+            async for pubsub_message in receive_pubsub_messages(stream):
                 try:
-                    message = json.loads(mvalue["data"])
-
+                    msg_dict = pubsub_msg_to_dict(pubsub_message)
+                    LOGGER.debug("Received from P2P:", msg_dict)
                     # we should check the sender here to avoid spam
                     # and such things...
                     try:
-                        message = await incoming_check(mvalue)
+                        message = await incoming_check(msg_dict)
                     except InvalidMessageError:
                         continue
 

--- a/src/aleph/services/peers/monitor.py
+++ b/src/aleph/services/peers/monitor.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Dict, Union
+from typing import Any, Dict
 from urllib.parse import unquote
 
 from p2pclient import Client as P2PClient
@@ -9,6 +9,7 @@ from p2pclient.utils import read_pbmsg_safe
 
 from aleph.services.ipfs.pubsub import sub as sub_ipfs
 from aleph.services.peers.common import ALIVE_TOPIC, IPFS_ALIVE_TOPIC
+from aleph.services.utils import pubsub_msg_to_dict
 from aleph.types import Protocol
 
 LOGGER = logging.getLogger("P2P.peers")
@@ -47,21 +48,6 @@ async def handle_incoming_host(pubsub_msg: Dict[str, Any], source: Protocol = Pr
             LOGGER.info("Received a bad peer info %s from %s" % (e.args[0], sender))
         else:
             LOGGER.exception("Exception in pubsub peers monitoring")
-
-
-def pubsub_msg_to_dict(pubsub_msg: PSMessage) -> Dict[str, Any]:
-    """
-    A compatibility method that translates a p2pd pubsub message to the equivalent dictionary.
-    The returned value is then passed to `handle_incoming_host`.
-
-    TODO: use a better system than a dict to pass these parameters around.
-    """
-    return {
-        "from": getattr(pubsub_msg, "from"),
-        "data": pubsub_msg.data,
-        "seqno": pubsub_msg.seqno,
-        "topicIDs": pubsub_msg.topicIDs,
-    }
 
 
 async def monitor_hosts_p2p(p2p_client: P2PClient) -> None:

--- a/src/aleph/services/utils.py
+++ b/src/aleph/services/utils.py
@@ -1,8 +1,10 @@
 import logging
 import re
 import socket
+from typing import Any, Dict
 
 import aiohttp
+from p2pclient.pb.p2pd_pb2 import PSMessage
 
 logger = logging.getLogger(__name__)
 
@@ -46,3 +48,18 @@ async def get_IP() -> str:
     except Exception as error:
         logging.exception("Error when fetching IPv4 from service")
         return get_ip4_from_socket()
+
+
+def pubsub_msg_to_dict(pubsub_msg: PSMessage) -> Dict[str, Any]:
+    """
+    A compatibility method that translates a p2pd pubsub message to the equivalent dictionary.
+    The returned value is then passed to `handle_incoming_host`.
+
+    TODO: use a better system than a dict to pass these parameters around.
+    """
+    return {
+        "from": getattr(pubsub_msg, "from"),
+        "data": pubsub_msg.data,
+        "seqno": pubsub_msg.seqno,
+        "topicIDs": pubsub_msg.topicIDs,
+    }


### PR DESCRIPTION
Fixed an issue where a PSMessage instance was treated as a dict.
The easiest fix is to translate this object to a dictionary to
maintain compatibility.