### PR TITLE
[Doc] Use recursive chown in upgrade guide

### DIFF
--- a/docs/guides/upgrade.rst
+++ b/docs/guides/upgrade.rst
@@ -22,7 +22,7 @@ and adjust the ownership of the folder:
 
     mkdir keys
     cp node-secret.key keys/
-    docker run --rm -ti --user root -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:beta chown aleph:aleph /opt/pyaleph/keys
+    docker run --rm -ti --user root -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:beta chown -R aleph:aleph /opt/pyaleph/keys
 
 Download the latest image
 -------------------------


### PR DESCRIPTION
Fixed an issue in the upgrade guide where the recursive flag is
missing, causing a file to have incorrect access rights.