### PR TITLE
[Storage] Rewrite status codes as exceptions

### DIFF
--- a/src/aleph/chains/common.py
+++ b/src/aleph/chains/common.py
@@ -214,7 +214,7 @@ async def incoming(
             return IncomingStatus.FAILED_PERMANENTLY
 
         except (ContentCurrentlyUnavailable, Exception) as e:
-            if not isinstance(ContentCurrentlyUnavailable, e):
+            if not isinstance(e, ContentCurrentlyUnavailable):
                 LOGGER.exception("Can't get content of object %r" % hash)
             await mark_message_for_retry(
                 message=message,

--- a/src/aleph/chains/common.py
+++ b/src/aleph/chains/common.py
@@ -293,7 +293,7 @@ async def incoming(
         # message.update(new_values)
         updates["$set"] = {
             "content": json_content,
-            "size": len(content.raw_content),
+            "size": len(content.raw_value),
             "item_content": message.get("item_content"),
             "item_type": message.get("item_type"),
             "channel": message.get("channel"),
@@ -368,10 +368,11 @@ async def get_chaindata_messages(
         try:
             content = await get_json(chaindata["content"], timeout=10)
         except AlephStorageException:
+            # Pass the exception to the caller
             raise
         except Exception:
             error_msg = f"Can't get content of offchain object {chaindata['context']!r}"
-            LOGGER.exception(error_msg)
+            LOGGER.exception("%s", error_msg)
             raise ContentCurrentlyUnavailable(error_msg)
 
         try:
@@ -399,7 +400,7 @@ async def get_chaindata_messages(
         return messages
     else:
         error_msg = f"Got unknown protocol/version object in tx {context!r}"
-        LOGGER.info(error_msg)
+        LOGGER.info("%s", error_msg)
         raise InvalidContent(error_msg)
 
 

--- a/src/aleph/chains/common.py
+++ b/src/aleph/chains/common.py
@@ -368,7 +368,7 @@ async def get_chaindata_messages(
         try:
             content = await get_json(chaindata["content"], timeout=10)
         except AlephStorageException:
-            # Pass the exception to the caller
+            # Let the caller handle unavailable/invalid content
             raise
         except Exception:
             error_msg = f"Can't get content of offchain object {chaindata['context']!r}"

--- a/src/aleph/chains/common.py
+++ b/src/aleph/chains/common.py
@@ -213,8 +213,9 @@ async def incoming(
             LOGGER.warning("Can't get content of object %r, won't retry." % hash)
             return IncomingStatus.FAILED_PERMANENTLY
 
-        except (ContentCurrentlyUnavailable, Exception):
-            LOGGER.exception("Can't get content of object %r" % hash)
+        except (ContentCurrentlyUnavailable, Exception) as e:
+            if not isinstance(ContentCurrentlyUnavailable, e):
+                LOGGER.exception("Can't get content of object %r" % hash)
             await mark_message_for_retry(
                 message=message,
                 chain_name=chain_name,

--- a/src/aleph/exceptions.py
+++ b/src/aleph/exceptions.py
@@ -2,6 +2,14 @@ class AlephException(Exception):
     ...
 
 
+class AlephStorageException(AlephException):
+    """
+    Base exception class for all errors related to the storage
+    and retrieval of Aleph messages.
+    """
+    ...
+
+
 class InvalidConfigException(AlephException):
     ...
 
@@ -11,4 +19,21 @@ class InvalidKeyDirException(AlephException):
 
 
 class KeyNotFoundException(AlephException):
+    ...
+
+
+class InvalidContent(AlephStorageException):
+    """
+    The content requested by the user is invalid. Examples:
+    * its integrity is compromised
+    * it does not match the Aleph message specification.
+    """
+    ...
+
+
+class ContentCurrentlyUnavailable(AlephStorageException):
+    """
+    The content is currently unavailable, for example because of a
+    synchronisation issue.
+    """
     ...

--- a/src/aleph/handlers/forget.py
+++ b/src/aleph/handlers/forget.py
@@ -81,8 +81,8 @@ async def is_allowed_to_forget(target: Dict, by: ForgetMessage) -> bool:
         return True
     else:
         # The forget sender matches the content address:
-        target_content, _ = await get_message_content(target)
-        if by.sender == target_content["address"]:
+        target_content = await get_message_content(target)
+        if by.sender == target_content.value["address"]:
             return True
     return False
 

--- a/src/aleph/handlers/storage.py
+++ b/src/aleph/handlers/storage.py
@@ -36,20 +36,14 @@ async def handle_new_storage(message, content):
         return -1  # not allowed, ignore.
 
     is_folder = False
-    try:
-        item_hash = content["item_hash"]
-    except KeyError as e:
-        error_msg = f"Could not load item_hash / message: {message} - content {content}"
-        LOGGER.error(error_msg)
-        raise Exception(error_msg) from e
-
+    item_hash = content["item_hash"]
     ipfs_enabled = app["config"].ipfs.enabled.value
     do_standard_lookup = True
     size = 0
 
     if engine == ItemType.IPFS and ipfs_enabled:
         if ItemType.from_hash(item_hash) != ItemType.IPFS:
-            LOGGER.warning(f"Invalid IPFS hash: '{item_hash}'")
+            LOGGER.warning("Invalid IPFS hash: '%s'", item_hash)
             raise UnknownHashError(f"Invalid IPFS hash: '{item_hash}'")
 
         api = await get_ipfs_api(timeout=5)

--- a/src/aleph/services/ipfs/common.py
+++ b/src/aleph/services/ipfs/common.py
@@ -62,3 +62,13 @@ async def get_public_address():
     for address in addresses:
         if "127.0.0.1" in address and "/tcp" in address and "/p2p" in address:
             return address.replace("127.0.0.1", public_ip)
+
+
+def get_cid_version(ipfs_hash: str) -> int:
+    if ipfs_hash.startswith("Qm") and 44 <= len(ipfs_hash) <= 46:  # CIDv0
+        return 0
+
+    if ipfs_hash.startswith("bafy") and len(ipfs_hash) == 59:  # CIDv1
+        return 1
+
+    raise ValueError(f"Not a IPFS hash: '{ipfs_hash}'.")

--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -55,7 +55,7 @@ class RawContent(StoredContent):
 
 
 @dataclass
-class JsonContent(StoredContent):
+class MessageContent(StoredContent):
     value: Any
     raw_value: bytes
 
@@ -66,7 +66,7 @@ async def json_async_loads(s: AnyStr):
     return await run_in_executor(None, json.loads, s)
 
 
-async def get_message_content(message: Dict) -> JsonContent:
+async def get_message_content(message: Dict) -> MessageContent:
     item_type: str = message.get("item_type", ItemType.IPFS)
     item_hash = message["item_hash"]
 
@@ -84,7 +84,7 @@ async def get_message_content(message: Dict) -> JsonContent:
             LOGGER.warning(error_msg)
             raise InvalidContent(error_msg)
 
-        return JsonContent(
+        return MessageContent(
             hash=item_hash,
             source=ContentSource.INLINE,
             value=item_content,
@@ -217,7 +217,7 @@ async def get_hash_content(
 
 async def get_json(
     content_hash: str, engine=ItemType.IPFS, timeout: int = 2, tries: int = 1
-) -> JsonContent:
+) -> MessageContent:
     content = await get_hash_content(
         content_hash, engine=engine, timeout=timeout, tries=tries
     )
@@ -228,7 +228,7 @@ async def get_json(
         LOGGER.exception("Can't decode JSON")
         raise InvalidContent("Cannot decode JSON") from e
 
-    return JsonContent(
+    return MessageContent(
         hash=content.hash,
         value=json_content,
         source=content.source,

--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -20,11 +20,20 @@ from aleph.services.p2p.singleton import get_streamer
 from aleph.types import ItemType
 from aleph.utils import run_in_executor, get_sha256
 from aleph.web import app
+from aleph.services.ipfs.common import get_cid_version
+from functools import partial
 
 LOGGER = logging.getLogger("STORAGE")
 
 
 class ContentSource(str, Enum):
+    """
+    Defines the source of the content of a message.
+
+    Message content can be fetched from different sources depending on the procedure followed by the user sending
+    a particular message. This enum determines where the node found the content.
+    """
+
     DB = "DB"
     P2P = "P2P"
     IPFS = "IPFS"
@@ -48,7 +57,7 @@ class RawContent(StoredContent):
 @dataclass
 class JsonContent(StoredContent):
     value: Any
-    raw_content: bytes
+    raw_value: bytes
 
 
 async def json_async_loads(s: AnyStr):
@@ -72,14 +81,14 @@ async def get_message_content(message: Dict) -> JsonContent:
             item_content = await json_async_loads(message["item_content"])
         except (json.JSONDecodeError, KeyError) as e:
             error_msg = f"Can't decode JSON: {e}"
-            LOGGER.exception(error_msg)
+            LOGGER.warning(error_msg)
             raise InvalidContent(error_msg)
 
         return JsonContent(
             hash=item_hash,
             source=ContentSource.INLINE,
             value=item_content,
-            raw_content=message["item_content"],
+            raw_value=message["item_content"],
         )
     else:
         # unknown, could retry later? shouldn't have arrived this far though.
@@ -107,30 +116,26 @@ async def fetch_content_from_network(
 
 
 async def compute_content_hash_ipfs(
-    content: bytes, expected_hash: str
+    content: bytes, cid_version: int = 1
 ) -> Optional[str]:
     """
     Computes the IPFS hash of the content.
     :param content: Content to hash.
-    :param expected_hash: Expected hash of the content.
+    :param cid_version: CID version of the hash.
     :return: The computed hash of the content. Can return None if the operation fails for some reason.
     """
 
     # TODO: get a better way to compare hashes (without depending on the IPFS daemon)
     try:
-        cid_version = 0
-        if len(expected_hash) >= 58:
-            cid_version = 1
-
         computed_hash = await add_ipfs_bytes(content, cid_version=cid_version)
         return computed_hash
 
     except asyncio.TimeoutError:
-        LOGGER.warning(f"Timeout while computing IPFS hash for '{expected_hash}'.")
+        LOGGER.warning(f"Timeout while computing IPFS hash.")
         return None
 
 
-async def compute_content_hash_sha256(content: bytes, expected_hash: str) -> str:
+async def compute_content_hash_sha256(content: bytes) -> str:
     return get_sha256(content)
 
 
@@ -144,13 +149,17 @@ async def verify_content_hash(
     ipfs_enabled = app["config"].ipfs.enabled.value
 
     if engine == ItemType.IPFS and ipfs_enabled:
-        compute_hash = compute_content_hash_ipfs
+        try:
+            cid_version = get_cid_version(expected_hash)
+        except ValueError as e:
+            raise InvalidContent(e) from e
+        compute_hash_task = compute_content_hash_ipfs(content, cid_version)
     elif engine == ItemType.Storage:
-        compute_hash = compute_content_hash_sha256
+        compute_hash_task = compute_content_hash_sha256(content)
     else:
         raise ValueError(f"Invalid storage engine: '{engine}'.")
 
-    computed_hash = await compute_hash(content, expected_hash)
+    computed_hash = await compute_hash_task
 
     if computed_hash is None:
         error_msg = f"Could not compute hash for '{expected_hash}'."
@@ -223,7 +232,7 @@ async def get_json(
         hash=content.hash,
         value=json_content,
         source=content.source,
-        raw_content=content.value,
+        raw_value=content.value,
     )
 
 

--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -1,13 +1,15 @@
 """ Storage module for Aleph.
 Basically manages the IPFS storage.
 """
-
 import asyncio
 import json
 import logging
+from dataclasses import dataclass
+from enum import Enum
 from hashlib import sha256
-from typing import Any, Dict, IO, Literal, Optional, Union, cast
+from typing import Any, AnyStr, Dict, IO, Optional
 
+from aleph.exceptions import InvalidContent, ContentCurrentlyUnavailable
 from aleph.services.filestore import get_value, set_value
 from aleph.services.ipfs.storage import add_bytes as add_ipfs_bytes
 from aleph.services.ipfs.storage import add_file as ipfs_add_file
@@ -22,113 +24,207 @@ from aleph.web import app
 LOGGER = logging.getLogger("STORAGE")
 
 
-async def json_async_loads(s: str):
+class ContentSource(str, Enum):
+    DB = "DB"
+    P2P = "P2P"
+    IPFS = "IPFS"
+    INLINE = "inline"
+
+
+@dataclass
+class StoredContent:
+    hash: str
+    source: Optional[ContentSource]
+
+
+@dataclass
+class RawContent(StoredContent):
+    value: bytes
+
+    def __len__(self):
+        return len(self.value)
+
+
+@dataclass
+class JsonContent(StoredContent):
+    value: Any
+    raw_content: bytes
+
+
+async def json_async_loads(s: AnyStr):
     """Deserialize ``s`` (a ``str``, ``bytes`` or ``bytearray`` instance
     containing a JSON document) to a Python object in an asynchronous executor."""
     return await run_in_executor(None, json.loads, s)
 
 
-async def get_message_content(message: Dict):
+async def get_message_content(message: Dict) -> JsonContent:
     item_type: str = message.get("item_type", ItemType.IPFS)
+    item_hash = message["item_hash"]
 
     if item_type in (ItemType.IPFS, ItemType.Storage):
-        return await get_json(message["item_hash"], engine=ItemType(item_type))
+        return await get_json(item_hash, engine=ItemType(item_type))
     elif item_type == ItemType.Inline:
         if "item_content" not in message:
-            LOGGER.warning(f"No item_content in message {message.get('item_hash')}")
-            return -1, 0  # never retry, bogus data
+            error_msg = f"No item_content in message {message.get('item_hash')}"
+            LOGGER.warning(error_msg)
+            raise InvalidContent(error_msg)  # never retry, bogus data
         try:
             item_content = await json_async_loads(message["item_content"])
-        except (json.JSONDecodeError, KeyError):
-            LOGGER.exception("Can't decode JSON")
-            return -1, 0  # never retry, bogus data
-        return item_content, len(message["item_content"])
+        except (json.JSONDecodeError, KeyError) as e:
+            error_msg = f"Can't decode JSON: {e}"
+            LOGGER.exception(error_msg)
+            raise InvalidContent(error_msg)
+
+        return JsonContent(
+            hash=item_hash,
+            source=ContentSource.INLINE,
+            value=item_content,
+            raw_content=message["item_content"],
+        )
     else:
-        LOGGER.exception("Unknown item type: %s", item_type)
-        return (
-            None,
-            0,
-        )  # unknown, could retry later? shouldn't have arrived this far though.
+        # unknown, could retry later? shouldn't have arrived this far though.
+        error_msg = f"Unknown item type: '{item_type}'."
+        raise ContentCurrentlyUnavailable(error_msg)
+
+
+async def fetch_content_from_network(
+    content_hash: str, engine: ItemType, timeout: int
+) -> Optional[bytes]:
+    content = None
+    enabled_clients = app["config"].p2p.clients.value
+
+    if "protocol" in enabled_clients:
+        streamer = get_streamer()
+        content = await streamer.request_hash(content_hash)
+
+    if content is None and "http" in enabled_clients:
+        content = await p2p_http_request_hash(content_hash, timeout=timeout)
+
+    if content is not None:
+        await verify_content_hash(content, engine, content_hash)
+
+    return content
+
+
+async def compute_content_hash_ipfs(
+    content: bytes, expected_hash: str
+) -> Optional[str]:
+    """
+    Computes the IPFS hash of the content.
+    :param content: Content to hash.
+    :param expected_hash: Expected hash of the content.
+    :return: The computed hash of the content. Can return None if the operation fails for some reason.
+    """
+
+    # TODO: get a better way to compare hashes (without depending on the IPFS daemon)
+    try:
+        cid_version = 0
+        if len(expected_hash) >= 58:
+            cid_version = 1
+
+        computed_hash = await add_ipfs_bytes(content, cid_version=cid_version)
+        return computed_hash
+
+    except asyncio.TimeoutError:
+        LOGGER.warning(f"Timeout while computing IPFS hash for '{expected_hash}'.")
+        return None
+
+
+async def compute_content_hash_sha256(content: bytes, expected_hash: str) -> str:
+    return get_sha256(content)
+
+
+async def verify_content_hash(
+    content: bytes, engine: ItemType, expected_hash: str
+) -> None:
+    """
+    Checks that the hash of a content we fetched from the network matches the expected hash.
+    :return: True if the hashes match, False otherwise.
+    """
+    ipfs_enabled = app["config"].ipfs.enabled.value
+
+    if engine == ItemType.IPFS and ipfs_enabled:
+        compute_hash = compute_content_hash_ipfs
+    elif engine == ItemType.Storage:
+        compute_hash = compute_content_hash_sha256
+    else:
+        raise ValueError(f"Invalid storage engine: '{engine}'.")
+
+    computed_hash = await compute_hash(content, expected_hash)
+
+    if computed_hash is None:
+        error_msg = f"Could not compute hash for '{expected_hash}'."
+        LOGGER.warning(error_msg)
+        raise ContentCurrentlyUnavailable(error_msg)
+
+    if computed_hash != expected_hash:
+        error_msg = f"Got a bad hash! Expected '{expected_hash}' but computed '{computed_hash}'."
+        LOGGER.warning(error_msg)
+        raise InvalidContent(error_msg)
 
 
 async def get_hash_content(
-    hash: str,
+    content_hash: str,
     engine: ItemType = ItemType.IPFS,
     timeout: int = 2,
     tries: int = 1,
     use_network: bool = True,
     use_ipfs: bool = True,
     store_value: bool = True,
-):
+) -> RawContent:
     # TODO: determine which storage engine to use
     ipfs_enabled = app["config"].ipfs.enabled.value
-    enabled_clients = app["config"].p2p.clients.value
-    # content = await loop.run_in_executor(None, get_value, hash)
-    content: Optional[Union[Literal[-1], bytes]] = await get_value(hash)
+
+    source = None
+
+    # Try to retrieve the data from the DB, then from the network or IPFS.
+    content = await get_value(content_hash)
+    if content is not None:
+        source = ContentSource.DB
+
+    if content is None and use_network:
+        content = await fetch_content_from_network(content_hash, engine, timeout)
+        source = ContentSource.P2P
+
     if content is None:
-        if use_network:
-            if "protocol" in enabled_clients:
-                streamer = get_streamer()
-                content = await streamer.request_hash(hash)
+        if ipfs_enabled and engine == ItemType.IPFS and use_ipfs:
+            content = await get_ipfs_content(content_hash, timeout=timeout, tries=tries)
+            source = ContentSource.IPFS
 
-            if "http" in enabled_clients and content is None:
-                content = await p2p_http_request_hash(hash, timeout=timeout)
+    if content is None:
+        raise ContentCurrentlyUnavailable(
+            f"Could not fetch content for '{content_hash}'."
+        )
 
-        if content is not None:
-            if engine == ItemType.IPFS and ipfs_enabled:
-                # TODO: get a better way to compare hashes (without depending on IPFS daemon)
-                try:
-                    cid_version = 0
-                    if len(hash) >= 58:
-                        cid_version = 1
+    LOGGER.info("Got content from %s for '%s'.", source.value, content_hash)  # type: ignore
 
-                    compared_hash = await add_ipfs_bytes(
-                        content, cid_version=cid_version
-                    )
+    # Store content locally if we fetched it from the network
+    if store_value and source != ContentSource.DB:
+        LOGGER.debug(f"Storing content for '{content_hash}'.")
+        await set_value(content_hash, content)
 
-                    if compared_hash != hash:
-                        LOGGER.warning(f"Got a bad hash! {hash}/{compared_hash}")
-                        content = -1
-                except asyncio.TimeoutError:
-                    LOGGER.warning(f"Can't verify hash {hash}")
-                    content = None
-
-            elif engine == ItemType.Storage:
-                compared_hash = await run_in_executor(None, get_sha256, content)
-                # compared_hash = sha256(content.encode('utf-8')).hexdigest()
-                if compared_hash != hash:
-                    LOGGER.warning(f"Got a bad hash! {hash}/{compared_hash}")
-                    content = -1
-
-        if content is None:
-            if ipfs_enabled and engine == ItemType.IPFS and use_ipfs:
-                content = await get_ipfs_content(hash, timeout=timeout, tries=tries)
-        else:
-            LOGGER.info(f"Got content from p2p {hash}")
-
-        if content is not None and content != -1 and store_value:
-            LOGGER.debug(f"Storing content for{hash}")
-            # This cast is required because mypy does not understand that content
-            # cannot be int anymore
-            content = cast(bytes, content)
-            await set_value(hash, content)
-    else:
-        LOGGER.debug(f"Using stored content for {hash}")
-
-    return content
+    return RawContent(hash=content_hash, value=content, source=source)
 
 
-async def get_json(hash: str, engine: ItemType = ItemType.IPFS, timeout: int = 2, tries: int = 1):
-    content = await get_hash_content(hash, engine=engine, timeout=timeout, tries=tries)
-    size = 0
-    if content is not None and content != -1:
-        size = len(content)
-        try:
-            content = await json_async_loads(content)
-        except json.JSONDecodeError:
-            LOGGER.exception("Can't decode JSON")
-            content = -1  # never retry, bogus data
-    return content, size
+async def get_json(
+    content_hash: str, engine=ItemType.IPFS, timeout: int = 2, tries: int = 1
+) -> JsonContent:
+    content = await get_hash_content(
+        content_hash, engine=engine, timeout=timeout, tries=tries
+    )
+
+    try:
+        json_content = await json_async_loads(content.value)
+    except json.JSONDecodeError as e:
+        LOGGER.exception("Can't decode JSON")
+        raise InvalidContent("Cannot decode JSON") from e
+
+    return JsonContent(
+        hash=content.hash,
+        value=json_content,
+        source=content.source,
+        raw_content=content.value,
+    )
 
 
 async def pin_hash(chash: str, timeout: int = 2, tries: int = 1):
@@ -152,7 +248,9 @@ async def add_json(value: Any, engine: ItemType = ItemType.IPFS) -> str:
     return chash
 
 
-async def add_file(fileobject: IO, filename: Optional[str] = None, engine: ItemType = ItemType.IPFS) -> str:
+async def add_file(
+    fileobject: IO, filename: Optional[str] = None, engine: ItemType = ItemType.IPFS
+) -> str:
 
     if engine == ItemType.IPFS:
         output = await ipfs_add_file(fileobject, filename)


### PR DESCRIPTION
Simplified the storage code and made it more pythonic by replacing
status codes like None and -1 by exceptions. Two new exceptions
describe if the content the user is looking for is invalid (-1)
or just currently unavailable because of a synchronisation issue
or a technical issue (None).

This simplifies the whole logic and avoids the propagation of weird
codes all over the place.

Added new dataclasses to keep track of the retrieved content,
its hash and the source from which the data was fetched.
The `RawContent` class keeps track of binary content while
the `JsonContent` class represents raw content that was interpreted
as JSON.
