### PR TITLE
Fix: get_ipfs_content ignored the `timeout` argument

### DIFF
--- a/src/aleph/services/ipfs/storage.py
+++ b/src/aleph/services/ipfs/storage.py
@@ -22,7 +22,7 @@ async def get_ipfs_content(hash: str, timeout: int = 1, tries: int = 1) -> Optio
         try_count += 1
         try:
             api = await get_ipfs_api(timeout=5)
-            result = await asyncio.wait_for(api.cat(hash, length=MAX_LEN), 5)
+            result = await asyncio.wait_for(api.cat(hash, length=MAX_LEN), timeout=timeout)
             if len(result) == MAX_LEN:
                 result = None
                 break


### PR DESCRIPTION
Solution: Use the timeout when getting the IPFS data using `ipfs_api.cat(...)`.