### PR TITLE
[IPFS] Put IPFS messages in the pending queue

### DIFF
--- a/src/aleph/chains/common.py
+++ b/src/aleph/chains/common.py
@@ -47,7 +47,12 @@ async def mark_confirmed_data(chain_name, tx_hash, height):
     }
 
 
-async def delayed_incoming(message, chain_name=None, tx_hash=None, height=None):
+async def delayed_incoming(
+    message: Optional[Dict],
+    chain_name: Optional[str] = None,
+    tx_hash: Optional[str] = None,
+    height: Optional[int] = None,
+):
     if message is None:
         return
     await PendingMessage.collection.insert_one(

--- a/src/aleph/jobs.py
+++ b/src/aleph/jobs.py
@@ -67,12 +67,12 @@ async def join_pending_message_tasks(
         LOGGER.exception("error in incoming task")
     tasks.clear()
 
-    if messages_actions_list is not None and len(messages_actions_list):
+    if messages_actions_list:
         await Message.collection.bulk_write(messages_actions_list)
         await CappedMessage.collection.bulk_write(messages_actions_list)
         messages_actions_list.clear()
 
-    if actions_list is not None and len(actions_list):
+    if actions_list:
         await PendingMessage.collection.bulk_write(actions_list)
         actions_list.clear()
 


### PR DESCRIPTION
Modified the processing of IPFS messages to mirror what is done
for messages coming from the P2P pubsub topic and from the chains.

Messages must be put in the pending queue and then processed later,
not processed on the spot.