### PR TITLE
[Fix] Pins KeyError

### DIFF
--- a/src/aleph/handlers/storage.py
+++ b/src/aleph/handlers/storage.py
@@ -81,7 +81,7 @@ async def handle_new_storage(message: Dict, content: Dict):
                 is_folder = stats["Type"] == "directory"
                 async for status in pin_api.pin.add(item_hash):
                     timer += 1
-                    if timer > 30 and status["Pins"] is None:
+                    if timer > 30 and "Pins" not in status:
                         return None  # Can't retrieve data now.
                 do_standard_lookup = False
 


### PR DESCRIPTION
Fixed a KeyError that popped up regularly when trying to add a pin
for an IPFS file. The "Pins" key is not present in the dictionary
returned by the IPFS client instead of being present with a null
value.