### PR TITLE
[P2P] Reduce amount of logs in case of errors

### DIFF
--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -180,7 +180,7 @@ async def incoming_channel(p2p_client: P2PClient, topic: str) -> None:
     # The communication with the P2P daemon sometimes fails repeatedly, spamming
     # IncompleteRead exceptions. We still want to log these to Sentry without sending
     # thousands of logs.
-    incomplete_read_threshold = 30000
+    incomplete_read_threshold = 150
     incomplete_read_counter = 0
 
     while True:
@@ -211,3 +211,5 @@ async def incoming_channel(p2p_client: P2PClient, topic: str) -> None:
 
         except Exception:
             LOGGER.exception("Exception in pubsub, reconnecting.")
+
+        await asyncio.sleep(2)


### PR DESCRIPTION
Improved the threshold mechanism for incomplete read errors linked
to the P2P daemon that sometimes occur over long periods of time.

* Added a sleep of 2 seconds before the next reconnection attempt
* Adapted the threshold so that a log is sent approximately every
  10 minutes
* Added a retry to some monitoring jobs that were not restarted
  after the first failure.