### PR TITLE
[Processing] Simplify incoming message functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Next release
+============
+
+- Breaking change: the "pyaleph_processing_pending_messages_action_total" and
+  "pyaleph_processing_pending_messages_action_total" values are no longer part of the metrics.
+
 Version 0.2.1
 =============
 

--- a/src/aleph/jobs.py
+++ b/src/aleph/jobs.py
@@ -53,6 +53,7 @@ async def join_pending_message_tasks(tasks):
     for error in errors:
         LOGGER.error("Error while processing message: %s", error)
 
+    # Sort the operations by collection name before grouping and executing them.
     db_operations = sorted(
         (
             op

--- a/src/aleph/model/db_bulk_operation.py
+++ b/src/aleph/model/db_bulk_operation.py
@@ -1,0 +1,13 @@
+from .base import BaseClass
+from typing import Type, Union
+from dataclasses import dataclass
+from pymongo import DeleteMany, DeleteOne, InsertOne, UpdateMany, UpdateOne
+
+
+BulkOperation = Union[DeleteMany, DeleteOne, InsertOne, UpdateMany, UpdateOne]
+
+
+@dataclass
+class DbBulkOperation:
+    collection: Type[BaseClass]
+    operation: BulkOperation

--- a/src/aleph/model/db_bulk_operation.py
+++ b/src/aleph/model/db_bulk_operation.py
@@ -4,10 +4,10 @@ from dataclasses import dataclass
 from pymongo import DeleteMany, DeleteOne, InsertOne, UpdateMany, UpdateOne
 
 
-BulkOperation = Union[DeleteMany, DeleteOne, InsertOne, UpdateMany, UpdateOne]
+MongoOperation = Union[DeleteMany, DeleteOne, InsertOne, UpdateMany, UpdateOne]
 
 
 @dataclass
 class DbBulkOperation:
     collection: Type[BaseClass]
-    operation: BulkOperation
+    operation: MongoOperation

--- a/src/aleph/services/ipfs/pubsub.py
+++ b/src/aleph/services/ipfs/pubsub.py
@@ -42,8 +42,9 @@ async def pub(topic: str, message: Union[str, bytes]):
 
 async def incoming_channel(topic) -> None:
     from aleph.network import incoming_check
-    from aleph.chains.common import incoming
+    from aleph.chains.common import process_one_message
 
+    # TODO: implement a check at startup
     # When using some deployment strategies such as docker-compose,
     # the IPFS service may not be ready by the time this function
     # is called. This variable define how many connection attempts
@@ -51,12 +52,11 @@ async def incoming_channel(topic) -> None:
     trials_before_exception: int = 5
     while True:
         try:
-            # seen_ids = []
             async for mvalue in sub(topic):
                 try:
                     message = await incoming_check(mvalue)
                     LOGGER.debug("New message %r" % message)
-                    asyncio.create_task(incoming(message, bulk_operation=False))
+                    asyncio.create_task(process_one_message(message))
                 except InvalidMessageError:
                     LOGGER.warning(f"Invalid message {mvalue}")
 

--- a/tests/chains/test_common.py
+++ b/tests/chains/test_common.py
@@ -49,5 +49,5 @@ async def test_incoming_inline(mocker):
            'signature': '21027c108022f992f090bbe5c78ca8822f5b7adceb705ae2cd5318543d7bcdd2a74700473045022100b59f7df5333d57080a93be53b9af74e66a284170ec493455e675eb2539ac21db022077ffc66fe8dde7707038344496a85266bf42af1240017d4e1fa0d7068c588ca7'
            }
     msg['item_type'] = 'inline'
-    v = await incoming(msg, check_message=True)
-    assert v == IncomingStatus.MESSAGE_HANDLED
+    status, ops = await incoming(msg, check_message=True)
+    assert status == IncomingStatus.MESSAGE_HANDLED

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -2,8 +2,9 @@ import pytest
 
 # Mandatory import, otherwise VERIFIER_REGISTER is not populated. TODO: improve the registration system.
 import aleph.chains
-from aleph.network import check_message
 from aleph.exceptions import InvalidMessageError
+from aleph.chains.common import IncomingStatus
+from aleph.network import check_message
 
 __author__ = "Moshe Malawach"
 __copyright__ = "Moshe Malawach"
@@ -140,5 +141,5 @@ async def test_incoming_inline_content(mocker):
            }
     # msg['item_type'] = 'inline'
     msg = await check_message(msg)
-    v = await incoming(msg)
-    assert v is True
+    status, ops = await incoming(msg)
+    assert status == IncomingStatus.MESSAGE_HANDLED


### PR DESCRIPTION
Improved the `incoming` function to simplify it and make it more
generic.

Removed the `bulk_operation` flag as we always wish for bulk DB
operations. The function now returns a status + a list of DB
operations. DB operations are a new class that contains a Mongo
operation and the name of the collection to target.
This avoids passing lists as arguments and modifying them in place.

The loop to await individual message tasks now waits for all tasks
to complete instead of failing on the first operation.
This fixes an issue where, if an exception occurs soon enough in
the batch, the output of still-running tasks could be lost.

Added type hints.