### PR TITLE
 [Config] Remove dependency to API in non-API code

### DIFF
--- a/src/aleph/chains/ethereum.py
+++ b/src/aleph/chains/ethereum.py
@@ -34,9 +34,7 @@ CHAIN_NAME = "ETH"
 
 async def verify_signature(message):
     """Verifies a signature of a message, return True if verified, false if not"""
-    from aleph.web import app
 
-    config = app["config"]
     # w3 = await loop.run_in_executor(None, get_web3, config)
 
     verification = await get_verification_buffer(message)

--- a/src/aleph/chains/nuls2.py
+++ b/src/aleph/chains/nuls2.py
@@ -348,9 +348,9 @@ register_outgoing_worker(CHAIN_NAME, nuls2_outgoing_worker)
 async def nuls2_balance_getter(address, config=None):
     global DECIMALS
     if config is None:
-        from aleph.web import app
+        from aleph.config import get_config
+        config = get_config()
 
-        config = app["config"]
     server = get_server(config.nuls2.api_url.value)
     contract_address = get_server(config.nuls2.contract_address.value)
     chain_id = config.nuls2.chain_id.value

--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -1,5 +1,7 @@
 import logging
 
+from configmanager import Config
+
 
 def get_defaults():
     return {
@@ -85,3 +87,10 @@ def get_defaults():
             "traces_sample_rate": None,
         },
     }
+
+
+app_config = Config(schema=get_defaults())
+
+
+def get_config() -> Config:
+    return app_config

--- a/src/aleph/jobs/job_utils.py
+++ b/src/aleph/jobs/job_utils.py
@@ -1,24 +1,30 @@
 import asyncio
 from typing import Dict
+from typing import Tuple
+
+import aleph.config
+from aleph.model import init_db_globals
+from aleph.services.ipfs.common import init_ipfs_globals
+from aleph.services.p2p import init_p2p_client
+from configmanager import Config
 
 
-def prepare_loop(config_values: Dict) -> asyncio.AbstractEventLoop:
-    from aleph.model import init_db
-    from aleph.web import app
-    from configmanager import Config
-    from aleph.config import get_defaults
-    from aleph.services.ipfs.common import get_ipfs_api
-    from aleph.services.p2p import http, init_p2p_client
+def prepare_loop(config_values: Dict) -> Tuple[asyncio.AbstractEventLoop, Config]:
+    """
+    Prepares all the global variables (sigh) needed to run an Aleph subprocess.
 
-    http.SESSION = None  # type:ignore
+    :param config_values: Dictionary of config values, as provided by the main process.
+    :returns: A preconfigured event loop, and the application config for convenience.
+              Use the event loop as event loop of the process as it is used by Motor. Using another
+              event loop will cause DB calls to fail.
+    """
 
     loop = asyncio.get_event_loop()
 
-    config = Config(schema=get_defaults())
-    app["config"] = config
+    config = aleph.config.app_config
     config.load_values(config_values)
 
-    init_db(config, ensure_indexes=False)
-    loop.run_until_complete(get_ipfs_api(timeout=2, reset=True))
+    init_db_globals(config)
+    init_ipfs_globals(config)
     _ = init_p2p_client(config)
-    return loop
+    return loop, config

--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -194,16 +194,17 @@ def pending_messages_subprocess(
     """
 
     setproctitle("aleph.jobs.messages_task_loop")
+    loop, config = prepare_loop(config_values)
+
     sentry_sdk.init(
-        dsn=config_values["sentry"]["dsn"],
-        traces_sample_rate=config_values["sentry"]["traces_sample_rate"],
+        dsn=config.sentry.dsn.value,
+        traces_sample_rate=config.sentry.traces_sample_rate.value,
         ignore_errors=[KeyboardInterrupt],
     )
     setup_logging(
-        loglevel=config_values["logging"]["level"],
+        loglevel=config.logging.level.value,
         filename="/tmp/messages_task_loop.log",
     )
     singleton.api_servers = api_servers
 
-    loop = prepare_loop(config_values)
-    loop.run_until_complete(asyncio.gather(retry_messages_task(shared_stats)))
+    loop.run_until_complete(retry_messages_task(shared_stats))

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -134,16 +134,17 @@ async def handle_txs_task():
 
 def pending_txs_subprocess(config_values: Dict, api_servers: List):
     setproctitle("aleph.jobs.txs_task_loop")
+    loop, config = prepare_loop(config_values)
+
     sentry_sdk.init(
-        dsn=config_values["sentry"]["dsn"],
-        traces_sample_rate=config_values["sentry"]["traces_sample_rate"],
+        dsn=config.sentry.dsn.value,
+        traces_sample_rate=config.sentry.traces_sample_rate.value,
         ignore_errors=[KeyboardInterrupt],
     )
     setup_logging(
-        loglevel=config_values["logging"]["level"],
+        loglevel=config.logging.level.value,
         filename="/tmp/txs_task_loop.log",
     )
     singleton.api_servers = api_servers
 
-    loop = prepare_loop(config_values)
     loop.run_until_complete(handle_txs_task())

--- a/src/aleph/model/__init__.py
+++ b/src/aleph/model/__init__.py
@@ -1,3 +1,4 @@
+import asyncio
 from logging import getLogger
 
 from configmanager import Config
@@ -22,11 +23,15 @@ db = None
 fs = None
 
 
-def init_db(config: Config, ensure_indexes: bool = True):
+def init_db_globals(config: Config):
     global connection, db, fs
     connection = AsyncIOMotorClient(config.mongodb.uri.value, tz_aware=True)
     db = connection[config.mongodb.database.value]
     fs = AsyncIOMotorGridFSBucket(db)
+
+
+def init_db(config: Config, ensure_indexes: bool = True):
+    init_db_globals(config)
     sync_connection = MongoClient(config.mongodb.uri.value, tz_aware=True)
     sync_db = sync_connection[config.mongodb.database.value]
 

--- a/src/aleph/network.py
+++ b/src/aleph/network.py
@@ -107,7 +107,6 @@ async def check_message(
 
         if message.get("hash_type", "sha256") == "sha256":  # leave the door open.
             if not trusted:
-                loop = asyncio.get_event_loop()
                 item_hash = get_sha256(message["item_content"])
                 # item_hash = await loop.run_in_executor(None, get_sha256, message['item_content'])
                 # item_hash = sha256(message['item_content'].encode('utf-8')).hexdigest()

--- a/src/aleph/services/filestore.py
+++ b/src/aleph/services/filestore.py
@@ -1,16 +1,20 @@
 import logging
 from typing import Optional, Union
 
-from bson.objectid import ObjectId
-
+from aleph.config import get_config
 from aleph.model import hashes
-from aleph.web import app
+from bson.objectid import ObjectId
 
 LOGGER = logging.getLogger("filestore")
 
 
+def _get_storage_engine() -> str:
+    config = get_config()
+    return config.storage.engine.value
+
+
 async def get_value(key: str) -> Optional[bytes]:
-    engine = app["config"].storage.engine.value
+    engine = _get_storage_engine()
 
     if engine != "mongodb":
         raise ValueError(f"Unsupported storage engine: '{engine}'.")
@@ -24,7 +28,7 @@ async def get_value(key: str) -> Optional[bytes]:
 
 
 async def set_value(key: Union[bytes, str], value: Union[bytes, str]) -> ObjectId:
-    engine = app["config"].storage.engine.value
+    engine = _get_storage_engine()
 
     if engine != "mongodb":
         raise ValueError(f"Unsupported storage engine: '{engine}'.")

--- a/src/aleph/services/ipfs/common.py
+++ b/src/aleph/services/ipfs/common.py
@@ -38,7 +38,7 @@ def init_ipfs_globals(config: Config, timeout: int = 5) -> None:
 async def get_ipfs_api(timeout: int = 5, reset: bool = False):
     global API
     if API is None or reset:
-        init_ipfs_globals(aleph.config.app_config, timeout)
+        init_ipfs_globals(aleph.config.get_config(), timeout)
 
     return API
 

--- a/src/aleph/services/ipfs/storage.py
+++ b/src/aleph/services/ipfs/storage.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import aiohttp
 import aioipfs
+from aleph.config import get_config
 
 from .common import get_ipfs_api, get_base_url
 from ...utils import run_in_executor
@@ -106,10 +107,10 @@ async def pin_add(hash: str, timeout: int = 2, tries: int = 1):
 
 
 async def add_file(fileobject, filename):
-    async with aiohttp.ClientSession() as session:
-        from aleph.web import app
+    config = get_config()
 
-        url = "%s/api/v0/add" % (await get_base_url(app["config"]))
+    async with aiohttp.ClientSession() as session:
+        url = "%s/api/v0/add" % (await get_base_url(config))
         data = aiohttp.FormData()
         data.add_field("path", fileobject, filename=filename)
 

--- a/src/aleph/services/p2p/manager.py
+++ b/src/aleph/services/p2p/manager.py
@@ -40,13 +40,11 @@ async def initialize_host(
         tidy_http_peers_job(config=config, api_servers=api_servers),
     ]
     if listen:
-        from aleph.web import app
-
         peer_id, _ = await p2p_client.identify()
         LOGGER.info("Listening on " + f"{transport_opt}/p2p/{peer_id}")
         ip = await get_IP()
         public_address = f"/ip4/{ip}/tcp/{port}/p2p/{peer_id}"
-        http_port = app["config"].p2p.http_port.value
+        http_port = config.p2p.http_port.value
         public_adresses.append(public_address)
 
         public_http_address = f"http://{ip}:{http_port}"
@@ -60,7 +58,7 @@ async def initialize_host(
                 p2p_alive_topic=config.p2p.alive_topic.value,
                 ipfs_alive_topic=config.ipfs.alive_topic.value,
                 peer_type="P2P",
-                use_ipfs=app["config"].ipfs.enabled.value,
+                use_ipfs=config.ipfs.enabled.value,
             ),
             publish_host(
                 public_http_address,
@@ -68,14 +66,14 @@ async def initialize_host(
                 p2p_alive_topic=config.p2p.alive_topic.value,
                 ipfs_alive_topic=config.ipfs.alive_topic.value,
                 peer_type="HTTP",
-                use_ipfs=app["config"].ipfs.enabled.value,
+                use_ipfs=config.ipfs.enabled.value,
             ),
             monitor_hosts_p2p(p2p_client, alive_topic=config.p2p.alive_topic.value),
         ]
 
-        if app["config"].ipfs.enabled.value:
+        if config.ipfs.enabled.value:
             tasks.append(
-                monitor_hosts_ipfs(alive_topic=app["config"].ipfs.alive_topic.value)
+                monitor_hosts_ipfs(alive_topic=config.ipfs.alive_topic.value)
             )
             try:
                 public_ipfs_address = await get_public_address()

--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -19,8 +19,8 @@ from aleph.services.p2p.http import request_hash as p2p_http_request_hash
 from aleph.services.p2p.singleton import get_streamer
 from aleph.types import ItemType
 from aleph.utils import run_in_executor, get_sha256
-from aleph.web import app
 from aleph.services.ipfs.common import get_cid_version
+from aleph.config import get_config
 
 LOGGER = logging.getLogger("STORAGE")
 
@@ -99,7 +99,8 @@ async def fetch_content_from_network(
     content_hash: str, engine: ItemType, timeout: int
 ) -> Optional[bytes]:
     content = None
-    enabled_clients = app["config"].p2p.clients.value
+    config = get_config()
+    enabled_clients = config.p2p.clients.value
 
     if "protocol" in enabled_clients:
         streamer = get_streamer()
@@ -145,7 +146,8 @@ async def verify_content_hash(
     Checks that the hash of a content we fetched from the network matches the expected hash.
     :return: True if the hashes match, False otherwise.
     """
-    ipfs_enabled = app["config"].ipfs.enabled.value
+    config = get_config()
+    ipfs_enabled = config.ipfs.enabled.value
 
     if engine == ItemType.IPFS and ipfs_enabled:
         try:
@@ -181,7 +183,8 @@ async def get_hash_content(
     store_value: bool = True,
 ) -> RawContent:
     # TODO: determine which storage engine to use
-    ipfs_enabled = app["config"].ipfs.enabled.value
+    config = get_config()
+    ipfs_enabled = config.ipfs.enabled.value
 
     source = None
 

--- a/src/aleph/utils.py
+++ b/src/aleph/utils.py
@@ -7,7 +7,7 @@ from aleph.settings import settings
 
 async def run_in_executor(executor, func, *args):
     if settings.use_executors:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(executor, func, *args)
     else:
         return func(*args)

--- a/src/aleph/web/controllers/metrics.py
+++ b/src/aleph/web/controllers/metrics.py
@@ -1,24 +1,19 @@
-from logging import getLogger
-
 import asyncio
 import json
-import logging
 import platform
 from dataclasses import dataclass, asdict
+from logging import getLogger
 from typing import Dict, Optional
 from urllib.parse import urljoin
-from requests import HTTPError
 
 import aiohttp
-from aiocache import cached
-from dataclasses_json import DataClassJsonMixin
-from web3 import Web3
-
 import aleph.model
+from aiocache import cached
 from aleph import __version__
-from aleph.web import app
-
-LOGGER = logging.getLogger(__name__)
+from aleph.config import get_config
+from dataclasses_json import DataClassJsonMixin
+from requests import HTTPError
+from web3 import Web3
 
 LOGGER = getLogger("WEB.metrics")
 
@@ -104,7 +99,8 @@ async def fetch_reference_total_messages() -> Optional[int]:
     """Obtain the total number of Aleph messages from another node."""
     LOGGER.debug("Fetching Aleph messages count")
 
-    url = app["config"].aleph.reference_node_url.value
+    config = get_config()
+    url = config.aleph.reference_node_url.value
     if url is None:
         return None
 
@@ -125,7 +121,7 @@ async def fetch_reference_total_messages() -> Optional[int]:
 async def fetch_eth_height() -> Optional[int]:
     """Obtain the height of the Ethereum blockchain."""
     LOGGER.debug("Fetching ETH height")
-    config = app["config"]
+    config = get_config()
 
     try:
         if config.ethereum.enabled.value:

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -1,13 +1,16 @@
+import aleph.config
 import pytest
 from configmanager import Config
-from aleph.config import get_defaults
 
 
 @pytest.fixture
 def mock_config(mocker):
-    config = Config(get_defaults())
+    config = Config(aleph.config.get_defaults())
     # To test handle_new_storage
     config.storage.store_files.value = True
 
-    mock_config = mocker.patch("aleph.config.app_config", config)
+    # We set the global variable directly instead of patching it because of an issue
+    # with mocker.patch. mocker.patch uses hasattr to determine the properties of
+    # the mock, which does not work well with configmanager Config objects.
+    aleph.config.app_config = config
     return mock_config

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 from configmanager import Config
 from aleph.config import get_defaults
-from aleph.web import app
 
 
 @pytest.fixture
@@ -10,5 +9,5 @@ def mock_config(mocker):
     # To test handle_new_storage
     config.storage.store_files.value = True
 
-    mock_config = mocker.patch.dict(app, {"config": config})
+    mock_config = mocker.patch("aleph.config.app_config", config)
     return mock_config


### PR DESCRIPTION
Removed all dependencies to the aiohttp app object in non-API code.
This object was used all over the place to retrieve the config
object. Instead, we now use a global variable to store the config
object itself.