### PR TITLE
[Forget] Fix ordering issues

### DIFF
--- a/src/aleph/chains/common.py
+++ b/src/aleph/chains/common.py
@@ -51,7 +51,12 @@ async def mark_confirmed_data(chain_name, tx_hash, height):
     }
 
 
-async def delayed_incoming(message, chain_name=None, tx_hash=None, height=None):
+async def delayed_incoming(
+    message: Dict,
+    chain_name: Optional[str] = None,
+    tx_hash: Optional[str] = None,
+    height: Optional[int] = None,
+):
     if message is None:
         return
     await PendingMessage.collection.insert_one(
@@ -325,11 +330,11 @@ async def incoming(
     return IncomingStatus.MESSAGE_HANDLED, []
 
 
-async def process_one_message(message: Dict):
+async def process_one_message(message: Dict, *args, **kwargs):
     """
     Helper function to process a message on the spot.
     """
-    status, ops = await incoming(message)
+    status, ops = await incoming(message, *args, **kwargs)
     for op in ops:
         await op.collection.collection.bulk_write([op.operation])
 
@@ -419,4 +424,6 @@ async def incoming_chaindata(content: Dict, context: TxContext):
     Content can be inline of "offchain" through an ipfs hash.
     For now we only add it to the database, it will be processed later.
     """
-    await PendingTX.collection.insert_one({"content": content, "context": asdict(context)})
+    await PendingTX.collection.insert_one(
+        {"content": content, "context": asdict(context)}
+    )

--- a/tests/storage/forget/test_forget_missing_messages.py
+++ b/tests/storage/forget/test_forget_missing_messages.py
@@ -1,0 +1,81 @@
+import pytest
+
+from aleph.chains.common import process_one_message, delayed_incoming
+from aleph.handlers.forget import handle_forget_message
+from aleph.model.messages import Message
+from aleph.model.pending import PendingMessage
+
+FORGET_MESSAGE = {
+    "chain": "ETH",
+    "item_hash": "884dd713e94fa0350239b67e65eecaa54361df8af0e3f6d0e42e0f8de059e15a",
+    "sender": "0xB68B9D4f3771c246233823ed1D3Add451055F9Ef",
+    "type": "FORGET",
+    "channel": "TEST",
+    "item_content": '{"address":"0xB68B9D4f3771c246233823ed1D3Add451055F9Ef","time":1639058312.376,"hashes":["e3b24727335e34016247c0d37e2b0203bb8c2d76deddafc1700b4cf0e13845c5"],"reason":"None"}',
+    "item_type": "inline",
+    "signature": "0x7dc7a45aab12d78367c085799d06ef2e98fce31f76ca06975ce570fe4d92008f66f307bf68ed3ca450d04d4e779776ca13a1e7851cb48915bd390389ae4afd1b1c",
+    "size": 172,
+    "time": 1639058312.376,
+}
+FORGET_MESSAGE_CONTENT = {
+    "address": "0xB68B9D4f3771c246233823ed1D3Add451055F9Ef",
+    "time": 1639058312.376,
+    "hashes": ["e3b24727335e34016247c0d37e2b0203bb8c2d76deddafc1700b4cf0e13845c5"],
+    "reason": "None",
+}
+
+
+@pytest.mark.asyncio
+async def test_handle_forget_missing_message(mocker):
+    """
+    Tests that the FORGET message handler marks the message for retry if
+    the targeted message is not in the database.
+    """
+
+    class NoMessageFoundIterator:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            return StopAsyncIteration
+
+    message_mock = mocker.patch("aleph.handlers.forget.Message")
+    message_mock.return_value.collection.return_value.find.return_value = (
+        NoMessageFoundIterator()
+    )
+    result = await handle_forget_message(FORGET_MESSAGE, FORGET_MESSAGE_CONTENT)
+    assert result is None
+
+    assert message_mock.collection.find.called_once()
+
+
+@pytest.mark.asyncio
+async def test_forget_missing_message_db(mocker, test_db):
+    """
+    Tests that processing a FORGET message that targets missing messages
+    results in the FORGET message remaining in the pending message queue,
+    marked for retry.
+    """
+
+    result = await handle_forget_message(FORGET_MESSAGE, FORGET_MESSAGE_CONTENT)
+    assert result is None
+
+    await delayed_incoming(FORGET_MESSAGE)
+
+    db_id = (
+        await PendingMessage.collection.find_one(
+            {"message.item_hash": FORGET_MESSAGE["item_hash"]}, {"_id": 1}
+        )
+    )["_id"]
+
+    await process_one_message(FORGET_MESSAGE, retrying=True, existing_id=db_id)
+
+    pending_message = await PendingMessage.collection.find_one({"_id": db_id})
+    assert pending_message is not None
+    assert pending_message["retries"] == 1
+
+    # Check that no message was inserted
+    message = await Message.collection.find_one(
+        {"item_hash": FORGET_MESSAGE["item_hash"]}
+    )
+    assert message is None


### PR DESCRIPTION
The FORGET message handler will now mark a FORGET message for retry
if any of the message it targets is missing from the database.
This resolves potential ordering issues where the FORGET message
arrives earlier than the message it is supposed to FORGET.

Resolves #209.