### PR TITLE
[Logging] Use property value for max_log_file_size

### DIFF
--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -91,7 +91,7 @@ def run_server_coroutine(
     setup_logging(
         loglevel=config.logging.level.value,
         filename=f"/tmp/run_server_coroutine-{port}.log",
-        max_log_file_size=config.logging.max_log_file_size,
+        max_log_file_size=config.logging.max_log_file_size.value,
     )
     if enable_sentry:
         sentry_sdk.init(

--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -187,7 +187,7 @@ def pending_messages_subprocess(
     setup_logging(
         loglevel=config.logging.level.value,
         filename="/tmp/messages_task_loop.log",
-        max_log_file_size=config.logging.max_log_file_size,
+        max_log_file_size=config.logging.max_log_file_size.value,
     )
     singleton.api_servers = api_servers
 

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -142,7 +142,7 @@ def pending_txs_subprocess(config_values: Dict, api_servers: List):
     setup_logging(
         loglevel=config.logging.level.value,
         filename="/tmp/txs_task_loop.log",
-        max_log_file_size=config.logging.max_log_file_size,
+        max_log_file_size=config.logging.max_log_file_size.value,
     )
     singleton.api_servers = api_servers
 


### PR DESCRIPTION
Fixed an omission, pass the actual value of the config option
when starting subprocesses. This issue caused the subprocesses
to crash at boot.