### PR TITLE
[Storage] Remove filename parameter

### DIFF
--- a/src/aleph/services/ipfs/storage.py
+++ b/src/aleph/services/ipfs/storage.py
@@ -2,7 +2,7 @@ import asyncio
 import concurrent
 import json
 import logging
-from typing import Optional
+from typing import IO, Optional
 
 import aiohttp
 import aioipfs
@@ -106,13 +106,13 @@ async def pin_add(hash: str, timeout: int = 2, tries: int = 1):
     return result
 
 
-async def add_file(fileobject, filename):
+async def add_file(fileobject: IO):
     config = get_config()
 
     async with aiohttp.ClientSession() as session:
         url = "%s/api/v0/add" % (await get_base_url(config))
         data = aiohttp.FormData()
-        data.add_field("path", fileobject, filename=filename)
+        data.add_field("path", fileobject)
 
         resp = await session.post(url, data=data)
         return await resp.json()

--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -259,12 +259,10 @@ async def add_json(value: Any, engine: ItemType = ItemType.IPFS) -> str:
     return chash
 
 
-async def add_file(
-    fileobject: IO, filename: Optional[str] = None, engine: ItemType = ItemType.IPFS
-) -> str:
+async def add_file(fileobject: IO, engine: ItemType = ItemType.IPFS) -> str:
 
     if engine == ItemType.IPFS:
-        output = await ipfs_add_file(fileobject, filename)
+        output = await ipfs_add_file(fileobject)
         file_hash = output["Hash"]
         fileobject.seek(0)
         file_content = fileobject.read()

--- a/src/aleph/web/controllers/ipfs.py
+++ b/src/aleph/web/controllers/ipfs.py
@@ -7,7 +7,7 @@ async def ipfs_add_file(request):
     # No need to pin it here anymore.
     # TODO: find a way to specify linked ipfs hashes in posts/aggr.
     post = await request.post()
-    output = await add_file(post["file"].file, post["file"].filename)
+    output = await add_file(post["file"].file)
 
     output = {
         "status": "success",

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -32,9 +32,7 @@ async def storage_add_file(request):
     # No need to pin it here anymore.
     # TODO: find a way to specify linked ipfs hashes in posts/aggr.
     post = await request.post()
-    file_hash = await add_file(
-        post["file"].file, filename=post["file"].filename, engine=ItemType.Storage
-    )
+    file_hash = await add_file(post["file"].file, engine=ItemType.Storage)
 
     output = {"status": "success", "hash": file_hash}
     return web.json_response(output)


### PR DESCRIPTION
The name of the file uploaded through IPFS and storage endpoints
is useless because we only rely on hashes.