### PR TITLE
[Tests] Fixture to generate the test API client

### DIFF
--- a/tests/api/test_messages.py
+++ b/tests/api/test_messages.py
@@ -7,7 +7,6 @@ import pytest
 import pytest_asyncio
 
 from aleph.model.messages import Message
-from aleph.web import create_app
 
 MESSAGES_URI = "/api/v0/messages.json"
 
@@ -41,11 +40,8 @@ async def fixture_messages(test_db):
 
 
 @pytest.mark.asyncio
-async def test_get_messages(fixture_messages, aiohttp_client):
-    app = create_app()
-    client = await aiohttp_client(app)
-
-    response = await client.get(MESSAGES_URI)
+async def test_get_messages(fixture_messages, ccn_api_client):
+    response = await ccn_api_client.get(MESSAGES_URI)
     assert response.status == 200, await response.text()
 
     data = await response.json()
@@ -59,12 +55,9 @@ async def test_get_messages(fixture_messages, aiohttp_client):
 
 
 @pytest.mark.asyncio
-async def test_get_messages_filter_by_channel(fixture_messages, aiohttp_client):
-    app = create_app()
-    client = await aiohttp_client(app)
-
+async def test_get_messages_filter_by_channel(fixture_messages, ccn_api_client):
     async def fetch_messages_by_channel(channel: str) -> Dict:
-        response = await client.get(MESSAGES_URI, params={"channels": channel})
+        response = await ccn_api_client.get(MESSAGES_URI, params={"channels": channel})
         assert response.status == 200, await response.text()
         return await response.json()
 

--- a/tests/api/test_version.py
+++ b/tests/api/test_version.py
@@ -1,15 +1,11 @@
 import pytest
 
 from aleph import __version__
-from aleph.web import create_app
 
 
 @pytest.mark.asyncio
-async def test_get_version(aiohttp_client):
-    app = create_app()
-    client = await aiohttp_client(app)
-
-    response = await client.get("/api/v0/version")
+async def test_get_version(ccn_api_client):
+    response = await ccn_api_client.get("/api/v0/version")
     assert response.status == 200, await response.text()
 
     data = await response.json()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,13 @@
-import pytest
-from aleph.model import init_db
-from aleph.config import get_defaults
-from configmanager import Config
+import asyncio
+import os
+
 import pymongo
 import pytest_asyncio
+from configmanager import Config
 
+from aleph.config import get_defaults
+from aleph.model import init_db
+from aleph.web import create_app
 
 TEST_DB = "ccn_automated_tests"
 
@@ -28,3 +31,15 @@ async def test_db():
 
     from aleph.model import db
     yield db
+
+
+@pytest_asyncio.fixture
+async def ccn_api_client(aiohttp_client):
+    # Make aiohttp return the stack trace on 500 errors
+    event_loop = asyncio.get_event_loop()
+    event_loop.set_debug(True)
+
+    app = create_app()
+    client = await aiohttp_client(app)
+
+    return client


### PR DESCRIPTION
Added the new `ccn_api_client` fixture to put the API test client
code in one place. We now set the event loop in debug mode
to return the stack trace on 500 errors.