### PR TITLE
Internal: store the full TX context in confirmations

### DIFF
--- a/deployment/migrations/scripts/0003-retrieve-confirmation-time.py
+++ b/deployment/migrations/scripts/0003-retrieve-confirmation-time.py
@@ -1,0 +1,48 @@
+"""
+This migration retrieves additional metadata regarding chain confirmation of messages,
+including the block timestamp. We reset the TX height of the node to reprocess
+all the chain data messages and insert additional values
+"""
+
+
+import logging
+import os
+from configmanager import Config
+from aleph.model.chains import Chain
+from aleph.model.pending import PendingMessage, PendingTX
+from aleph.model.messages import Message
+
+logger = logging.getLogger(os.path.basename(__file__))
+
+
+async def upgrade(config: Config, **kwargs):
+    logger.info("Resetting chain height to re-fetch all chaindata...")
+    start_height = config.ethereum.start_height.value
+    await Chain.set_last_height("ETH", start_height)
+
+    logger.info("Dropping all pending transactions...")
+    await PendingTX.collection.delete_many({})
+
+    logger.info(
+        "Dropping all pending confirmation messages "
+        "(they will be reinserted automatically)..."
+    )
+    await PendingMessage.collection.delete_many({"source.chain_name": {"$ne": None}})
+
+    logger.info("Removing confirmation data for all messages...")
+    # Confirmations will be automatically added again by the pending TX processor.
+    # By removing the confirmation entirely, we make sure to avoid intermediate states
+    # if a message was confirmed in an unexpected way.
+    await Message.collection.update_many(
+        {"confirmed": True},
+        {
+            "$set": {
+                "confirmed": False,
+            },
+            "$unset": {"confirmations": 1},
+        },
+    )
+
+
+async def downgrade(**kwargs):
+    raise NotImplementedError("Downgrading this migration is not supported.")

--- a/src/aleph/chains/common.py
+++ b/src/aleph/chains/common.py
@@ -5,7 +5,6 @@ from dataclasses import asdict
 from enum import IntEnum
 from typing import Dict, Optional, Tuple, List
 
-from aleph_message.models import MessageConfirmation
 from bson import ObjectId
 from pymongo import UpdateOne
 
@@ -25,18 +24,17 @@ from aleph.model.messages import CappedMessage, Message
 from aleph.model.pending import PendingMessage, PendingTX
 from aleph.network import verify_signature
 from aleph.permissions import check_sender_authorization
-from aleph.storage import get_json, pin_hash, add_json, get_message_content
-from .tx_context import TxContext
-from aleph.schemas.pending_messages import (
-    BasePendingMessage,
-)
+from aleph.schemas.pending_messages import BasePendingMessage
 from aleph.schemas.validated_message import (
     validate_pending_message,
+    MessageConfirmation,
     ValidatedStoreMessage,
     ValidatedForgetMessage,
     make_confirmation_update_query,
-make_message_upsert_query,
+    make_message_upsert_query,
 )
+from aleph.storage import get_json, pin_hash, add_json, get_message_content
+from .tx_context import TxContext
 
 LOGGER = logging.getLogger("chains.common")
 
@@ -64,21 +62,17 @@ async def mark_confirmed_data(chain_name, tx_hash, height):
 
 async def delayed_incoming(
     message: BasePendingMessage,
-    chain_name: Optional[str] = None,
-    tx_hash: Optional[str] = None,
-    height: Optional[int] = None,
+    tx_context: Optional[TxContext] = None,
+    check_message: bool = True,
 ):
     if message is None:
         return
+
     await PendingMessage.collection.insert_one(
         {
             "message": message.dict(exclude={"content"}),
-            "source": dict(
-                chain_name=chain_name,
-                tx_hash=tx_hash,
-                height=height,
-                check_message=True,  # should we store this?
-            ),
+            "tx_context": asdict(tx_context) if tx_context is not None else None,
+            "check_message": check_message,
         }
     )
 
@@ -91,9 +85,7 @@ class IncomingStatus(IntEnum):
 
 async def mark_message_for_retry(
     message: BasePendingMessage,
-    chain_name: Optional[str],
-    tx_hash: Optional[str],
-    height: Optional[int],
+    tx_context: Optional[TxContext],
     check_message: bool,
     retrying: bool,
     existing_id,
@@ -101,17 +93,7 @@ async def mark_message_for_retry(
     message_dict = message.dict(exclude={"content"})
 
     if not retrying:
-        await PendingMessage.collection.insert_one(
-            {
-                "message": message_dict,
-                "source": dict(
-                    chain_name=chain_name,
-                    tx_hash=tx_hash,
-                    height=height,
-                    check_message=check_message,  # should we store this?
-                ),
-            }
-        )
+        await delayed_incoming(message, tx_context, check_message)
     else:
         LOGGER.debug(f"Incrementing for {existing_id}")
         result = await PendingMessage.collection.update_one(
@@ -122,9 +104,7 @@ async def mark_message_for_retry(
 
 async def incoming(
     pending_message: BasePendingMessage,
-    chain_name: Optional[str] = None,
-    tx_hash: Optional[str] = None,
-    height: Optional[int] = None,
+    tx_context: Optional[TxContext] = None,
     seen_ids: Optional[Dict[Tuple, int]] = None,
     check_message: bool = False,
     retrying: bool = False,
@@ -139,16 +119,23 @@ async def incoming(
     item_hash = pending_message.item_hash
     sender = pending_message.sender
     confirmations = []
+    chain_name = tx_context.chain if tx_context is not None else None
     ids_key = (item_hash, sender, chain_name)
 
-    if chain_name and tx_hash and height:
+    if tx_context is not None:
         if seen_ids is not None:
             if ids_key in seen_ids.keys():
-                if height > seen_ids[ids_key]:
+                if tx_context.height > seen_ids[ids_key]:
                     return IncomingStatus.MESSAGE_HANDLED, []
 
         confirmations.append(
-            MessageConfirmation(chain=chain_name, hash=tx_hash, height=height)
+            MessageConfirmation(
+                chain=tx_context.chain,
+                hash=tx_context.hash,
+                height=tx_context.height,
+                time=tx_context.time,
+                publisher=tx_context.publisher,
+            )
         )
 
     filters = {
@@ -178,14 +165,14 @@ async def incoming(
     updates: Dict[str, Dict] = {}
 
     if existing:
-        if seen_ids is not None and height is not None:
+        if seen_ids is not None and tx_context is not None:
             if ids_key in seen_ids.keys():
-                if height > seen_ids[ids_key]:
+                if tx_context.height > seen_ids[ids_key]:
                     return IncomingStatus.MESSAGE_HANDLED, []
                 else:
-                    seen_ids[ids_key] = height
+                    seen_ids[ids_key] = tx_context.height
             else:
-                seen_ids[ids_key] = height
+                seen_ids[ids_key] = tx_context.height
 
         LOGGER.debug("Updating %s." % item_hash)
 
@@ -205,9 +192,7 @@ async def incoming(
                 LOGGER.exception("Can't get content of object %r" % item_hash)
             await mark_message_for_retry(
                 message=pending_message,
-                chain_name=chain_name,
-                tx_hash=tx_hash,
-                height=height,
+                tx_context=tx_context,
                 check_message=check_message,
                 retrying=retrying,
                 existing_id=existing_id,
@@ -215,7 +200,9 @@ async def incoming(
             return IncomingStatus.RETRYING_LATER, []
 
         validated_message = validate_pending_message(
-            pending_message=pending_message, content=content, confirmations=confirmations
+            pending_message=pending_message,
+            content=content,
+            confirmations=confirmations,
         )
 
         # warning: those handlers can modify message and content in place
@@ -244,9 +231,7 @@ async def incoming(
             LOGGER.debug("Message type handler has failed, retrying later.")
             await mark_message_for_retry(
                 message=pending_message,
-                chain_name=chain_name,
-                tx_hash=tx_hash,
-                height=height,
+                tx_context=tx_context,
                 check_message=check_message,
                 retrying=retrying,
                 existing_id=existing_id,
@@ -264,14 +249,14 @@ async def incoming(
             LOGGER.warning("Invalid sender for %s" % item_hash)
             return IncomingStatus.MESSAGE_HANDLED, []
 
-        if seen_ids is not None and height is not None:
+        if seen_ids is not None and tx_context is not None:
             if ids_key in seen_ids.keys():
-                if height > seen_ids[ids_key]:
+                if tx_context.height > seen_ids[ids_key]:
                     return IncomingStatus.MESSAGE_HANDLED, []
                 else:
-                    seen_ids[ids_key] = height
+                    seen_ids[ids_key] = tx_context.height
             else:
-                seen_ids[ids_key] = height
+                seen_ids[ids_key] = tx_context.height
 
         LOGGER.debug("New message to store for %s." % item_hash)
 

--- a/src/aleph/chains/ethereum.py
+++ b/src/aleph/chains/ethereum.py
@@ -197,8 +197,8 @@ async def request_transactions(
         try:
             jdata = json.loads(message)
             context = TxContext(
-                chain_name=CHAIN_NAME,
-                tx_hash=event_data.transactionHash.hex(),
+                chain=CHAIN_NAME,
+                hash=event_data.transactionHash.hex(),
                 time=timestamp,
                 height=event_data.blockNumber,
                 publisher=publisher,

--- a/src/aleph/chains/nuls2.py
+++ b/src/aleph/chains/nuls2.py
@@ -175,8 +175,8 @@ async def request_transactions(config, session, start_height) -> AsyncIterator[T
             jdata = json.loads(ddata)
 
             context = TxContext(
-                chain_name=CHAIN_NAME,
-                tx_hash=tx["hash"],
+                chain=CHAIN_NAME,
+                hash=tx["hash"],
                 height=tx["height"],
                 time=tx["createTime"],
                 publisher=tx["coinFroms"][0]["address"],

--- a/src/aleph/chains/tx_context.py
+++ b/src/aleph/chains/tx_context.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass
 
 @dataclass
 class TxContext:
-    chain_name: str
-    tx_hash: str
+    chain: str
+    hash: str
     height: int
     # Transaction timestamp, in Unix time (number of seconds since epoch).
     time: int

--- a/src/aleph/chains/tx_context.py
+++ b/src/aleph/chains/tx_context.py
@@ -1,11 +1,7 @@
-from dataclasses import dataclass
+from aleph.schemas.message_confirmation import MessageConfirmation
 
 
-@dataclass
-class TxContext:
-    chain: str
-    hash: str
-    height: int
-    # Transaction timestamp, in Unix time (number of seconds since epoch).
-    time: int
-    publisher: str
+# At the moment, confirmation = chain transaction. This might change, but in the meantime
+# having TxContext inherit MessageConfirmation avoids code duplication.
+class TxContext(MessageConfirmation):
+    pass

--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -21,6 +21,7 @@ from aleph.model.pending import PendingMessage
 from aleph.schemas.pending_messages import parse_message
 from aleph.services.p2p import singleton
 from .job_utils import prepare_loop, process_job_results
+from ..chains.tx_context import TxContext
 
 LOGGER = getLogger("jobs.pending_messages")
 
@@ -60,7 +61,8 @@ async def handle_pending_message(
         # If an invalid message somehow ended in pending messages, drop it.
         return [delete_pending_message_op]
 
-    tx_context = pending.get("tx_context")
+    tx_context_dict = pending.get("tx_context")
+    tx_context = TxContext.parse_obj(tx_context_dict) if tx_context_dict else None
 
     async with sem:
         status, operations = await incoming(

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -4,7 +4,6 @@ Job in charge of loading messages stored on-chain and put them in the pending me
 
 import asyncio
 import logging
-from dataclasses import asdict
 from typing import List, Dict, Optional
 from typing import Set
 
@@ -57,7 +56,7 @@ async def handle_pending_tx(
                     operation=InsertOne(
                         {
                             "message": message.dict(exclude={"content"}),
-                            "tx_context": asdict(tx_context),
+                            "tx_context": tx_context.dict(),
                             "check_message": True,
                         }
                     ),

--- a/src/aleph/schemas/message_confirmation.py
+++ b/src/aleph/schemas/message_confirmation.py
@@ -1,0 +1,16 @@
+from aleph_message.models import Chain
+from pydantic import BaseModel, Field
+
+
+class MessageConfirmation(BaseModel):
+    chain: Chain = Field(..., description="Chain from which the confirmation was fetched.")
+    height: int = Field(..., description="Block in which the confirmation was published.")
+    hash: str = Field(
+        ...,
+        description="Hash of the transaction/block in which the confirmation was published.",
+    )
+    time: float = Field(
+        ...,
+        description="Transaction timestamp, in Unix time (number of seconds since epoch).",
+    )
+    publisher: str = Field(..., description="Publisher of the confirmation on chain.")

--- a/src/aleph/schemas/validated_message.py
+++ b/src/aleph/schemas/validated_message.py
@@ -7,13 +7,12 @@ always present, unlike pending messages.
 from typing import List, Literal, Optional, Generic, Dict, Type, Any
 
 from aleph_message.models import (
-    MessageConfirmation,
     AggregateContent,
     ForgetContent,
     MessageType,
     PostContent,
     ProgramContent,
-    StoreContent,
+    StoreContent, Chain,
 )
 from pydantic import BaseModel, Field
 
@@ -27,6 +26,14 @@ from aleph.schemas.pending_messages import (
     PendingStoreMessage,
 )
 from .message_content import MessageContent
+
+
+class MessageConfirmation(BaseModel):
+    chain: Chain
+    height: int
+    hash: str
+    time: float
+    publisher: str
 
 
 class EngineInfo(BaseModel):

--- a/src/aleph/schemas/validated_message.py
+++ b/src/aleph/schemas/validated_message.py
@@ -12,8 +12,7 @@ from aleph_message.models import (
     MessageType,
     PostContent,
     ProgramContent,
-    StoreContent, Chain,
-)
+    StoreContent, )
 from pydantic import BaseModel, Field
 
 from aleph.schemas.base_messages import AlephBaseMessage, ContentType, MType
@@ -25,15 +24,8 @@ from aleph.schemas.pending_messages import (
     PendingProgramMessage,
     PendingStoreMessage,
 )
+from .message_confirmation import MessageConfirmation
 from .message_content import MessageContent
-
-
-class MessageConfirmation(BaseModel):
-    chain: Chain
-    height: int
-    hash: str
-    time: float
-    publisher: str
 
 
 class EngineInfo(BaseModel):

--- a/tests/chains/test_confirmation.py
+++ b/tests/chains/test_confirmation.py
@@ -1,5 +1,4 @@
 import json
-from dataclasses import asdict
 from typing import Dict
 
 import pytest
@@ -72,7 +71,7 @@ async def test_confirm_message(test_db):
 
     assert message_in_db is not None
     assert message_in_db["confirmed"]
-    expected_confirmations = [asdict(tx_context)]
+    expected_confirmations = [tx_context.dict()]
     assert message_in_db["confirmations"] == expected_confirmations
 
     capped_message_after_confirmation = await CappedMessage.collection.find_one(
@@ -111,7 +110,7 @@ async def test_process_confirmed_message(test_db):
     assert message_in_db is not None
     assert message_in_db["confirmed"]
 
-    expected_confirmations = [asdict(tx_context)]
+    expected_confirmations = [tx_context.dict()]
     assert message_in_db["confirmations"] == expected_confirmations
 
     capped_message_in_db = await CappedMessage.collection.find_one(
@@ -120,4 +119,4 @@ async def test_process_confirmed_message(test_db):
 
     assert remove_id_key(message_in_db) == remove_id_key(capped_message_in_db)
     assert capped_message_in_db["confirmed"]
-    assert capped_message_in_db["confirmations"] == [asdict(tx_context)]
+    assert capped_message_in_db["confirmations"] == [tx_context.dict()]

--- a/tests/chains/test_confirmation.py
+++ b/tests/chains/test_confirmation.py
@@ -1,9 +1,11 @@
 import json
+from dataclasses import asdict
 from typing import Dict
 
 import pytest
 
 from aleph.chains.common import process_one_message
+from aleph.chains.tx_context import TxContext
 from aleph.model.messages import CappedMessage, Message
 from aleph.schemas.pending_messages import parse_message
 
@@ -56,18 +58,22 @@ async def test_confirm_message(test_db):
     assert remove_id_key(message_in_db) == remove_id_key(capped_message_in_db)
 
     # Now, confirm the message
-    chain_name, tx_hash, height = "ETH", "123", 8000
-    await process_one_message(
-        message, chain_name=chain_name, tx_hash=tx_hash, height=height
+    tx_context = TxContext(
+        chain="ETH",
+        hash="123",
+        height=8000,
+        time=120000,
+        publisher="0xdeadbeef",
     )
+
+    await process_one_message(message, tx_context)
 
     message_in_db = await Message.collection.find_one({"item_hash": item_hash})
 
     assert message_in_db is not None
     assert message_in_db["confirmed"]
-    assert {"chain": chain_name, "hash": tx_hash, "height": height} in message_in_db[
-        "confirmations"
-    ]
+    expected_confirmations = [asdict(tx_context)]
+    assert message_in_db["confirmations"] == expected_confirmations
 
     capped_message_after_confirmation = await CappedMessage.collection.find_one(
         {"item_hash": item_hash}
@@ -89,18 +95,23 @@ async def test_process_confirmed_message(test_db):
     item_hash = MESSAGE_DICT["item_hash"]
 
     # Confirm the message
-    chain_name, tx_hash, height = "ETH", "123", 8000
     message = parse_message(MESSAGE_DICT)
-    await process_one_message(
-        message, chain_name=chain_name, tx_hash=tx_hash, height=height
+    tx_context = TxContext(
+        chain="ETH",
+        hash="123",
+        height=8000,
+        time=120000,
+        publisher="0xdeadbeef",
     )
+    await process_one_message(message, tx_context)
 
+    # Now, confirm the message
     message_in_db = await Message.collection.find_one({"item_hash": item_hash})
 
     assert message_in_db is not None
     assert message_in_db["confirmed"]
 
-    expected_confirmations = [{"chain": chain_name, "hash": tx_hash, "height": height}]
+    expected_confirmations = [asdict(tx_context)]
     assert message_in_db["confirmations"] == expected_confirmations
 
     capped_message_in_db = await CappedMessage.collection.find_one(
@@ -109,4 +120,4 @@ async def test_process_confirmed_message(test_db):
 
     assert remove_id_key(message_in_db) == remove_id_key(capped_message_in_db)
     assert capped_message_in_db["confirmed"]
-    assert capped_message_in_db["confirmations"] == expected_confirmations
+    assert capped_message_in_db["confirmations"] == [asdict(tx_context)]

--- a/tests/message_processing/test_process_pending_txs.py
+++ b/tests/message_processing/test_process_pending_txs.py
@@ -33,8 +33,8 @@ async def test_process_pending_tx(mocker, test_db):
             "content": "test-data-pending-tx-messages",
         },
         "context": {
-            "chain_name": "ETH",
-            "tx_hash": "0xf49cb176c1ce4f6eb7b9721303994b05074f8fadc37b5f41ac6f78bdf4b14b6c",
+            "chain": "ETH",
+            "hash": "0xf49cb176c1ce4f6eb7b9721303994b05074f8fadc37b5f41ac6f78bdf4b14b6c",
             "time": 1632835747,
             "height": 13314512,
             "publisher": "0x23eC28598DCeB2f7082Cc3a9D670592DfEd6e0dC",

--- a/tests/schemas/test_validated_messages.py
+++ b/tests/schemas/test_validated_messages.py
@@ -6,8 +6,6 @@ as the tests for the pending message schemas and check additional features.
 import json
 from typing import Dict
 
-from aleph_message.models import MessageConfirmation
-
 from aleph.schemas.message_content import MessageContent, ContentSource
 from aleph.schemas.pending_messages import (
     PendingAggregateMessage,
@@ -18,6 +16,7 @@ from aleph.schemas.pending_messages import (
 from aleph.schemas.validated_message import (
     validate_pending_message,
     BaseValidatedMessage,
+    MessageConfirmation,
     ValidatedAggregateMessage,
     ValidatedStoreMessage,
 )
@@ -132,7 +131,7 @@ def test_parse_store_message_inline_content():
     pending_message = parse_message(message_dict)
     assert isinstance(pending_message, PendingStoreMessage)
 
-    confirmations = [MessageConfirmation(chain="ETH", height=1234, hash="abcd")]
+    confirmations = [MessageConfirmation(chain="ETH", height=1234, hash="abcd", time=8000, publisher="0xsomething")]
     message_content = MessageContent(
         pending_message.item_hash, ContentSource.INLINE, content, item_content
     )

--- a/tests/schemas/test_validated_messages.py
+++ b/tests/schemas/test_validated_messages.py
@@ -16,10 +16,10 @@ from aleph.schemas.pending_messages import (
 from aleph.schemas.validated_message import (
     validate_pending_message,
     BaseValidatedMessage,
-    MessageConfirmation,
     ValidatedAggregateMessage,
     ValidatedStoreMessage,
 )
+from aleph.schemas.message_confirmation import MessageConfirmation
 
 
 def check_basic_message_fields(message: BaseValidatedMessage, message_dict: Dict):

--- a/tests/storage/test_store_message.py
+++ b/tests/storage/test_store_message.py
@@ -1,11 +1,11 @@
 import json
 
 import pytest
-from aleph_message.models import MessageConfirmation
 
 from aleph.handlers.storage import handle_new_storage
 from aleph.schemas.message_content import ContentSource, RawContent
 from aleph.schemas.validated_message import (
+    MessageConfirmation,
     ValidatedStoreMessage,
     StoreContentWithMetadata,
 )
@@ -33,6 +33,8 @@ def fixture_message_file():
                 chain="ETH",
                 hash="0x28fd852984b1f2222ca1870a97f44cc34b535a49d2618f5689a10a67985935d5",
                 height=14276536,
+                time=9000,
+                publisher="0xsomething",
             )
         ],
     )

--- a/tests/storage/test_store_message.py
+++ b/tests/storage/test_store_message.py
@@ -5,10 +5,10 @@ import pytest
 from aleph.handlers.storage import handle_new_storage
 from aleph.schemas.message_content import ContentSource, RawContent
 from aleph.schemas.validated_message import (
-    MessageConfirmation,
     ValidatedStoreMessage,
     StoreContentWithMetadata,
 )
+from aleph.schemas.message_confirmation import MessageConfirmation
 from message_test_helpers import make_validated_message_from_dict
 
 


### PR DESCRIPTION
Problem: a part of the information regarding on-chain confirmations
is dropped, thereby losing useful metadata for use in later processes.
Example: the time field of confirmations could be used to determine
when confirmations were received.

Solution: store the entire transaction context in the confirmations
array of messages. This means that two additional fields are now
preserved: the transaction block timestamp and the publisher.

As we need to re-fetch this data from chain data, a new migration
script resets the chain height to re-process all transactions.
We reset the confirmation status of all messages to unconfirmed
and deleted their confirmations array to let the node automatically
migrate to the new format.