### PR TITLE
[API] Remove MongoDB object ID from responses

### DIFF
--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -128,7 +128,8 @@ async def view_messages_list(request):
     messages = [
         msg
         async for msg in Message.collection.find(
-            find_filters,
+            filter=find_filters,
+            projection={"_id": 0},
             limit=pagination_per_page,
             skip=pagination_skip,
             sort=[("time", int(request.query.get("sort_order", "-1")))],

--- a/src/aleph/web/controllers/posts.py
+++ b/src/aleph/web/controllers/posts.py
@@ -85,7 +85,10 @@ async def view_posts_list(request):
     context = {"posts": posts}
 
     if pagination_per_page is not None:
-        total_msgs = await Message.collection.count_documents(find_filters)
+        total_msgs = await Message.collection.count_documents(
+            filter=find_filters,
+            projection={"_id": 0},
+        )
 
         pagination = Pagination(
             pagination_page,

--- a/tests/api/test_messages.py
+++ b/tests/api/test_messages.py
@@ -15,6 +15,15 @@ def get_messages_by_keys(messages: Iterable[Dict], **keys) -> List[Dict]:
     return [msg for msg in messages if all(msg[k] == v for k, v in keys.items())]
 
 
+def check_message_fields(messages: Iterable[Dict]):
+    """
+    Basic checks on fields. For example, check that we do not expose internal data
+    like MongoDB object IDs.
+    """
+    for message in messages:
+        assert "_id" not in message
+
+
 def assert_messages_equal(messages: Iterable[Dict], expected_messages: Iterable[Dict]):
     messages_by_hash = {msg["item_hash"]: msg for msg in messages}
 
@@ -50,6 +59,7 @@ async def test_get_messages(fixture_messages, ccn_api_client):
 
     messages = data["messages"]
     assert len(messages) == len(fixture_messages)
+    check_message_fields(messages)
     assert_messages_equal(messages, fixture_messages)
 
     assert data["pagination_total"] == len(messages)


### PR DESCRIPTION
The _id field no longer appears in the response of the messages
and posts endpoints.

Resolves #264.