### PR TITLE
[Types] Use ItemType defined in aleph-message

### DIFF
--- a/src/aleph/handlers/storage.py
+++ b/src/aleph/handlers/storage.py
@@ -14,13 +14,14 @@ from typing import Dict
 
 import aioipfs
 from aioipfs import InvalidCIDError
+from aleph_message.models import ItemType, StoreMessage
+from pydantic import ValidationError
+
 from aleph.config import get_config
 from aleph.exceptions import AlephStorageException, UnknownHashError
 from aleph.services.ipfs.common import get_ipfs_api
 from aleph.storage import get_hash_content
-from aleph.types import ItemType
-from aleph_message.models import StoreMessage
-from pydantic import ValidationError
+from aleph.utils import item_type_from_hash
 
 LOGGER = logging.getLogger("HANDLERS.STORAGE")
 
@@ -52,8 +53,8 @@ async def handle_new_storage(message: Dict, content: Dict):
     do_standard_lookup = True
     size = 0
 
-    if engine == ItemType.IPFS and ipfs_enabled:
-        if ItemType.from_hash(item_hash) != ItemType.IPFS:
+    if engine == ItemType.ipfs and ipfs_enabled:
+        if item_type_from_hash(item_hash) != ItemType.ipfs:
             LOGGER.warning("Invalid IPFS hash: '%s'", item_hash)
             raise UnknownHashError(f"Invalid IPFS hash: '{item_hash}'")
 

--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -8,7 +8,7 @@ from logging import getLogger
 from typing import List, Dict, Tuple
 
 import sentry_sdk
-from aleph_message.models import MessageType
+from aleph_message.models import ItemType, MessageType
 from pymongo import DeleteOne, DeleteMany, ASCENDING
 from setproctitle import setproctitle
 
@@ -17,7 +17,6 @@ from aleph.logging import setup_logging
 from aleph.model.db_bulk_operation import DbBulkOperation
 from aleph.model.pending import PendingMessage
 from aleph.services.p2p import singleton
-from aleph.types import ItemType
 from .job_utils import prepare_loop, gather_and_perform_db_operations
 
 LOGGER = getLogger("jobs.pending_messages")
@@ -94,7 +93,7 @@ async def process_pending_messages(shared_stats: Dict):
                 )
 
             if (
-                pending["message"]["item_type"] == ItemType.IPFS
+                pending["message"]["item_type"] == ItemType.ipfs
                 or pending["message"]["type"] == MessageType.store
             ):
                 i += 15

--- a/src/aleph/network.py
+++ b/src/aleph/network.py
@@ -1,16 +1,17 @@
 import asyncio
 import json
 import logging
-from typing import Coroutine, Dict, List, Optional
+from typing import Coroutine, Dict, List
 from urllib.parse import unquote
 
+from aleph_message.models import ItemType
 from p2pclient import Client as P2PClient
 
+from aleph.exceptions import InvalidMessageError
 from aleph.register_chain import VERIFIER_REGISTER
 from aleph.services.ipfs.pubsub import incoming_channel as incoming_ipfs_channel
-from aleph.types import ItemType
-from aleph.exceptions import InvalidMessageError
 from aleph.utils import get_sha256
+from aleph.utils import item_type_from_hash
 
 LOGGER = logging.getLogger("NETWORK")
 
@@ -116,11 +117,11 @@ async def check_message(
         else:
             raise InvalidMessageError("Unknown hash type %s" % message["hash_type"])
 
-        message["item_type"] = ItemType.Inline.value
+        message["item_type"] = ItemType.inline.value
 
     else:
         try:
-            message["item_type"] = ItemType.from_hash(message["item_hash"]).value
+            message["item_type"] = item_type_from_hash(message["item_hash"]).value
         except ValueError as error:
             LOGGER.warning(error)
 

--- a/src/aleph/types.py
+++ b/src/aleph/types.py
@@ -1,27 +1,6 @@
 from __future__ import annotations
+
 from enum import Enum
-
-from aleph.exceptions import UnknownHashError
-
-
-class ItemType(str, Enum):
-    """Item storage options"""
-    Inline = "inline"
-    IPFS = "ipfs"
-    Storage = "storage"
-
-    @classmethod
-    def from_hash(cls, hash: str) -> ItemType:
-        assert isinstance(hash, str)
-        # https://docs.ipfs.io/concepts/content-addressing/#identifier-formats
-        if hash.startswith("Qm") and 44 <= len(hash) <= 46: # CIDv0
-            return cls.IPFS
-        elif hash.startswith("bafy") and len(hash) == 59:  # CIDv1
-            return cls.IPFS
-        elif len(hash) == 64:
-            return cls.Storage
-        else:
-            raise UnknownHashError(f"Unknown hash {len(hash)} {hash}")
 
 
 class Protocol(str, Enum):

--- a/tests/storage/test_get_content.py
+++ b/tests/storage/test_get_content.py
@@ -4,7 +4,7 @@ import pytest
 
 from aleph.exceptions import InvalidContent, ContentCurrentlyUnavailable
 from aleph.storage import ContentSource, get_hash_content, get_json, get_message_content
-from aleph.types import ItemType
+from aleph_message.models import ItemType
 
 
 @pytest.mark.asyncio
@@ -139,7 +139,7 @@ async def test_get_inline_content(mock_config):
     ]
     json_bytes = json.dumps(json_content).encode("utf-8")
     message = {
-        "item_type": ItemType.Inline.value,
+        "item_type": ItemType.inline.value,
         "item_hash": content_hash,
         "item_content": json_bytes,
     }
@@ -185,7 +185,7 @@ async def test_get_stored_message_content(mocker, mock_config):
     mocker.patch("aleph.storage.get_value", return_value=json_bytes)
 
     message = {
-        "item_type": ItemType.IPFS.value,
+        "item_type": ItemType.ipfs.value,
         "item_hash": content_hash,
     }
 


### PR DESCRIPTION
Removed the `ItemType` enum and replaced all usages by the equivalent
class in aleph-message.