### PR TITLE
[Chains] Use pending message model in signature verification

### DIFF
--- a/src/aleph/chains/avalanche.py
+++ b/src/aleph/chains/avalanche.py
@@ -8,6 +8,8 @@ from aleph.register_chain import register_verifier
 
 import logging
 
+from aleph.schemas.pending_messages import BasePendingMessage
+
 LOGGER = logging.getLogger("chains.avalanche")
 CHAIN_NAME = "AVAX"
 MESSAGE_TEMPLATE = b"\x1AAvalanche Signed Message:\n%b"
@@ -49,16 +51,16 @@ async def get_chain_info(address):
     return chain_id, hrp
 
 
-async def verify_signature(message):
+async def verify_signature(message: BasePendingMessage):
     """Verifies a signature of a message, return True if verified, false if not"""
     try:
-        chain_id, hrp = await get_chain_info(message["sender"])
+        chain_id, hrp = await get_chain_info(message.sender)
     except Exception:
         LOGGER.exception("Avalanche sender address deserialization error")
         return False
 
     try:
-        signature = base58.b58decode(message["signature"])
+        signature = base58.b58decode(message.signature)
         signature, status = await validate_checksum(signature)
         if not status:
             LOGGER.exception("Avalanche signature checksum error")
@@ -76,10 +78,10 @@ async def verify_signature(message):
         address = await address_from_public_key(public_key.format())
         address = await address_to_string(chain_id, hrp, address)
 
-        result = address == message["sender"]
+        result = address == message.sender
 
     except Exception as e:
-        LOGGER.exception("Error processing signature for %s" % message["sender"])
+        LOGGER.exception("Error processing signature for %s" % message.sender)
         result = False
 
     return result

--- a/src/aleph/chains/common.py
+++ b/src/aleph/chains/common.py
@@ -27,15 +27,17 @@ from aleph.network import check_message as check_message_fn
 from aleph.permissions import check_sender_authorization
 from aleph.storage import get_json, pin_hash, add_json, get_message_content
 from .tx_context import TxContext
+from ..schemas.pending_messages import BasePendingMessage
 
 LOGGER = logging.getLogger("chains.common")
 
 
-async def get_verification_buffer(message: Dict) -> bytes:
+async def get_verification_buffer(message: BasePendingMessage) -> bytes:
     """Returns a serialized string to verify the message integrity
     (this is was it signed)
     """
-    return "{chain}\n{sender}\n{type}\n{item_hash}".format(**message).encode("utf-8")
+    buffer = f"{message.chain}\n{message.sender}\n{message.type}\n{message.item_hash}"
+    return buffer.encode("utf-8")
 
 
 async def mark_confirmed_data(chain_name, tx_hash, height):

--- a/src/aleph/chains/ethereum.py
+++ b/src/aleph/chains/ethereum.py
@@ -29,12 +29,13 @@ from aleph.register_chain import (
 )
 from aleph.utils import run_in_executor
 from .tx_context import TxContext
+from ..schemas.pending_messages import BasePendingMessage
 
 LOGGER = logging.getLogger("chains.ethereum")
 CHAIN_NAME = "ETH"
 
 
-async def verify_signature(message):
+async def verify_signature(message: BasePendingMessage) -> bool:
     """Verifies a signature of a message, return True if verified, false if not"""
 
     # w3 = await loop.run_in_executor(None, get_web3, config)
@@ -52,7 +53,7 @@ async def verify_signature(message):
         address = await run_in_executor(
             None,
             functools.partial(
-                Account.recover_message, message_hash, signature=message["signature"]
+                Account.recover_message, message_hash, signature=message.signature
             ),
         )
         # address = Account.recover_message(message_hash, signature=message['signature'])
@@ -63,16 +64,16 @@ async def verify_signature(message):
         #                       signature=message['signature']))
         # address = w3.eth.account.recoverHash(message_hash,
         #                                      signature=message['signature'])
-        if address == message["sender"]:
+        if address == message.sender:
             verified = True
         else:
             LOGGER.warning(
-                "Received bad signature from %s for %s" % (address, message["sender"])
+                "Received bad signature from %s for %s" % (address, message.sender)
             )
             return False
 
     except Exception as e:
-        LOGGER.exception("Error processing signature for %s" % message["sender"])
+        LOGGER.exception("Error processing signature for %s" % message.sender)
         verified = False
 
     return verified

--- a/src/aleph/chains/nuls.py
+++ b/src/aleph/chains/nuls.py
@@ -16,26 +16,27 @@ from aleph.register_chain import register_verifier
 #     NulsSignature, public_key_to_hash, address_from_hash, hash_from_address,
 #     CHEAP_UNIT_FEE)
 # from nulsexplorer.protocol.transaction import Transaction
+from aleph.schemas.pending_messages import BasePendingMessage
 from aleph.utils import run_in_executor
 
 LOGGER = logging.getLogger("chains.nuls")
 CHAIN_NAME = "NULS"
 
 
-async def verify_signature(message):
+async def verify_signature(message: BasePendingMessage) -> bool:
     """Verifies a signature of a message, return True if verified, false if not"""
-    sig_raw = bytes(bytearray.fromhex(message["signature"]))
+    sig_raw = bytes(bytearray.fromhex(message.signature))
     sig = NulsSignature(sig_raw)
 
-    sender_hash = hash_from_address(message["sender"])
+    sender_hash = hash_from_address(message.sender)
     (sender_chain_id,) = struct.unpack("h", sender_hash[:2])
 
     hash = public_key_to_hash(sig.pub_key, sender_chain_id)
 
     address = address_from_hash(hash)
-    if address != message["sender"]:
+    if address != message.sender:
         LOGGER.warning(
-            "Received bad signature from %s for %s" % (address, message["sender"])
+            "Received bad signature from %s for %s" % (address, message.sender)
         )
         return False
 

--- a/src/aleph/chains/nuls2.py
+++ b/src/aleph/chains/nuls2.py
@@ -36,6 +36,7 @@ from aleph.register_chain import (
 )
 from aleph.utils import run_in_executor
 from .tx_context import TxContext
+from ..schemas.pending_messages import BasePendingMessage
 
 LOGGER = logging.getLogger("chains.nuls2")
 CHAIN_NAME = "NULS2"
@@ -44,11 +45,11 @@ PAGINATION = 500
 DECIMALS = None  # will get populated later... bad?
 
 
-async def verify_signature(message):
+async def verify_signature(message: BasePendingMessage) -> bool:
     """Verifies a signature of a message, return True if verified, false if not"""
-    sig_raw = base64.b64decode(message["signature"])
+    sig_raw = base64.b64decode(message.signature)
 
-    sender_hash = hash_from_address(message["sender"])
+    sender_hash = hash_from_address(message.sender)
     (sender_chain_id,) = struct.unpack("h", sender_hash[:2])
     verification = await get_verification_buffer(message)
     try:
@@ -64,9 +65,9 @@ async def verify_signature(message):
         LOGGER.exception("NULS Signature verification error")
         return False
 
-    if address != message["sender"]:
+    if address != message.sender:
         LOGGER.warning(
-            "Received bad signature from %s for %s" % (address, message["sender"])
+            "Received bad signature from %s for %s" % (address, message.sender)
         )
         return False
     else:

--- a/src/aleph/chains/solana.py
+++ b/src/aleph/chains/solana.py
@@ -7,15 +7,17 @@ from nacl.signing import VerifyKey
 
 import logging
 
+from aleph.schemas.pending_messages import BasePendingMessage
+
 LOGGER = logging.getLogger("chains.solana")
 CHAIN_NAME = "SOL"
 
 
-async def verify_signature(message):
+async def verify_signature(message: BasePendingMessage) -> bool:
     """Verifies a signature of a message, return True if verified, false if not"""
 
     try:
-        signature = json.loads(message["signature"])
+        signature = json.loads(message.signature)
         sigdata = base58.b58decode(signature["signature"])
         public_key = base58.b58decode(signature["publicKey"])
     except Exception:
@@ -31,7 +33,7 @@ async def verify_signature(message):
         LOGGER.exception("Solana signature version error")
         return False
 
-    if message["sender"] != signature["publicKey"]:
+    if message.sender != signature["publicKey"]:
         LOGGER.exception("Solana signature source error")
         return False
 

--- a/src/aleph/chains/substrate.py
+++ b/src/aleph/chains/substrate.py
@@ -5,16 +5,17 @@ from substrateinterface import Keypair
 
 from aleph.chains.common import get_verification_buffer
 from aleph.register_chain import register_verifier
+from aleph.schemas.pending_messages import BasePendingMessage
 
 LOGGER = logging.getLogger("chains.substrate")
 CHAIN_NAME = "DOT"
 
 
-async def verify_signature(message):
+async def verify_signature(message: BasePendingMessage) -> bool:
     """Verifies a signature of a message, return True if verified, false if not"""
 
     try:
-        signature = json.loads(message["signature"])
+        signature = json.loads(message.signature)
     except Exception:
         LOGGER.exception("Substrate signature deserialization error")
         return False
@@ -27,7 +28,7 @@ async def verify_signature(message):
         return False
 
     try:
-        keypair = Keypair(ss58_address=message["sender"])
+        keypair = Keypair(ss58_address=message.sender)
         verif = (await get_verification_buffer(message)).decode("utf-8")
         result = keypair.verify(verif, signature["data"])
     except Exception:

--- a/src/aleph/network.py
+++ b/src/aleph/network.py
@@ -51,7 +51,7 @@ async def incoming_check(ipfs_pubsub_message: Dict) -> Dict:
 
 
 async def check_message(
-    message: Dict,
+    message_dict: Dict,
     from_chain: bool = False,
     from_network: bool = False,
     trusted: bool = False,
@@ -67,24 +67,20 @@ async def check_message(
     TODO: Implement it fully! Dangerous!
     """
 
-    _ = parse_message(message)
+    message = parse_message(message_dict)
 
     if trusted:
         # only in the case of a message programmatically built here
         # from legacy native chain signing for example (signing offloaded)
-        return message
+        return message_dict
     else:
-        message = {
-            k: v for k, v in message.items() if k in INCOMING_MESSAGE_AUTHORIZED_FIELDS
-        }
-        await asyncio.sleep(0)
-        chain = message.get("chain", None)
+        chain = message.chain
         signer = VERIFIER_REGISTER.get(chain, None)
         if signer is None:
             raise InvalidMessageError("Unknown chain for validation %r" % chain)
         try:
             if await signer(message):
-                return message
+                return message_dict
             else:
                 raise InvalidMessageError("The signature of the message is invalid")
         except ValueError:

--- a/src/aleph/register_chain.py
+++ b/src/aleph/register_chain.py
@@ -1,11 +1,17 @@
+from typing import Awaitable, Callable, Dict
+
+from aleph.schemas.pending_messages import BasePendingMessage
+
+Verifier = Callable[[BasePendingMessage], Awaitable[bool]]
+
 # We will register here processors for the chains by name
-VERIFIER_REGISTER = dict()
+VERIFIER_REGISTER: Dict[str, Verifier] = dict()
 INCOMING_WORKERS = dict()
 OUTGOING_WORKERS = dict()
 BALANCE_GETTERS = dict()
 
 
-def register_verifier(chain_name, handler):
+def register_verifier(chain_name: str, handler: Verifier):
     VERIFIER_REGISTER[chain_name] = handler
 
 

--- a/tests/chains/test_common.py
+++ b/tests/chains/test_common.py
@@ -17,7 +17,7 @@ async def test_get_verification_buffer():
     item_hash = "7e4f914865028356704919810073ec5690ecc4bb0ee3bd6bdb24829fd532398f"
 
     message = BasePendingMessage(
-        chain="CHAIN",
+        chain="ETH",
         sender="SENDER",
         type=MessageType.store,
         item_hash=item_hash,
@@ -28,7 +28,7 @@ async def test_get_verification_buffer():
     )
 
     buffer = await get_verification_buffer(message)
-    expected_buffer = f"CHAIN\nSENDER\nSTORE\n{item_hash}".encode("utf-8")
+    expected_buffer = f"ETH\nSENDER\nSTORE\n{item_hash}".encode("utf-8")
     assert buffer == expected_buffer
 
 

--- a/tests/chains/test_common.py
+++ b/tests/chains/test_common.py
@@ -1,28 +1,45 @@
 import pytest
+from aleph_message.models import MessageType, ItemType
 
-from aleph.chains.common import IncomingStatus, get_verification_buffer, mark_confirmed_data, incoming
+from aleph.chains.common import (
+    IncomingStatus,
+    get_verification_buffer,
+    mark_confirmed_data,
+    incoming,
+)
 from unittest.mock import MagicMock
+
+from aleph.schemas.pending_messages import BasePendingMessage
 
 
 @pytest.mark.asyncio
 async def test_get_verification_buffer():
-    buffer = await get_verification_buffer({
-        'chain': 'CHAIN',
-        'sender': 'SENDER',
-        'type': 'TYPE',
-        'item_hash': 'ITEM_HASH'
-    })
-    assert buffer == b'CHAIN\nSENDER\nTYPE\nITEM_HASH'
+    item_hash = "7e4f914865028356704919810073ec5690ecc4bb0ee3bd6bdb24829fd532398f"
+
+    message = BasePendingMessage(
+        chain="CHAIN",
+        sender="SENDER",
+        type=MessageType.store,
+        item_hash=item_hash,
+        signature="1234",
+        item_content=None,
+        item_type=ItemType.storage,
+        time=1000000,
+    )
+
+    buffer = await get_verification_buffer(message)
+    expected_buffer = f"CHAIN\nSENDER\nSTORE\n{item_hash}".encode("utf-8")
+    assert buffer == expected_buffer
 
 
 @pytest.mark.asyncio
 async def test_mark_confirmed_data():
-    value = await mark_confirmed_data('CHAIN', 'TXHASH', 99999999)
-    assert value['confirmed'] is True
-    assert len(value['confirmations']) == 1
-    assert value['confirmations'][0]['chain'] == 'CHAIN'
-    assert value['confirmations'][0]['height'] == 99999999
-    assert value['confirmations'][0]['hash'] == 'TXHASH'
+    value = await mark_confirmed_data("CHAIN", "TXHASH", 99999999)
+    assert value["confirmed"] is True
+    assert len(value["confirmations"]) == 1
+    assert value["confirmations"][0]["chain"] == "CHAIN"
+    assert value["confirmations"][0]["height"] == 99999999
+    assert value["confirmations"][0]["hash"] == "TXHASH"
 
 
 @pytest.mark.skip("Signature verification of the fixture fails")
@@ -35,19 +52,19 @@ async def test_incoming_inline(mocker):
         pass
 
     MagicMock.__await__ = lambda x: async_magic().__await__()
-    
-    mocker.patch('aleph.model.db')
-    
-    
-    msg = {'chain': 'NULS',
-           'channel': 'SYSINFO',
-           'sender': 'TTapAav8g3fFjxQQCjwPd4ERPnai9oya',
-           'type': 'AGGREGATE',
-           'time': 1564581054.0532622,
-           'item_content': '{"key":"metrics","address":"TTapAav8g3fFjxQQCjwPd4ERPnai9oya","content":{"memory":{"total":12578275328,"available":5726081024,"percent":54.5,"used":6503415808,"free":238661632,"active":8694841344,"inactive":2322239488,"buffers":846553088,"cached":4989644800,"shared":172527616,"slab":948609024},"swap":{"total":7787769856,"free":7787495424,"used":274432,"percent":0.0,"swapped_in":0,"swapped_out":16384},"cpu":{"user":9.0,"nice":0.0,"system":3.1,"idle":85.4,"iowait":0.0,"irq":0.0,"softirq":2.5,"steal":0.0,"guest":0.0,"guest_nice":0.0},"cpu_cores":[{"user":8.9,"nice":0.0,"system":2.4,"idle":82.2,"iowait":0.0,"irq":0.0,"softirq":6.4,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":9.6,"nice":0.0,"system":2.9,"idle":84.6,"iowait":0.0,"irq":0.0,"softirq":2.9,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":7.2,"nice":0.0,"system":3.0,"idle":86.8,"iowait":0.0,"irq":0.0,"softirq":3.0,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":11.4,"nice":0.0,"system":3.0,"idle":84.8,"iowait":0.1,"irq":0.0,"softirq":0.7,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":9.3,"nice":0.0,"system":3.3,"idle":87.0,"iowait":0.1,"irq":0.0,"softirq":0.3,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":5.5,"nice":0.0,"system":4.4,"idle":89.9,"iowait":0.0,"irq":0.0,"softirq":0.1,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":8.7,"nice":0.0,"system":3.3,"idle":87.9,"iowait":0.0,"irq":0.0,"softirq":0.1,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":11.4,"nice":0.0,"system":2.3,"idle":80.3,"iowait":0.0,"irq":0.0,"softirq":6.1,"steal":0.0,"guest":0.0,"guest_nice":0.0}]},"time":1564581054.0358574}',
-           'item_hash': '84afd8484912d3fa11a402e480d17e949fbf600fcdedd69674253be0320fa62c',
-           'signature': '21027c108022f992f090bbe5c78ca8822f5b7adceb705ae2cd5318543d7bcdd2a74700473045022100b59f7df5333d57080a93be53b9af74e66a284170ec493455e675eb2539ac21db022077ffc66fe8dde7707038344496a85266bf42af1240017d4e1fa0d7068c588ca7'
-           }
-    msg['item_type'] = 'inline'
+
+    mocker.patch("aleph.model.db")
+
+    msg = {
+        "chain": "NULS",
+        "channel": "SYSINFO",
+        "sender": "TTapAav8g3fFjxQQCjwPd4ERPnai9oya",
+        "type": "AGGREGATE",
+        "time": 1564581054.0532622,
+        "item_content": '{"key":"metrics","address":"TTapAav8g3fFjxQQCjwPd4ERPnai9oya","content":{"memory":{"total":12578275328,"available":5726081024,"percent":54.5,"used":6503415808,"free":238661632,"active":8694841344,"inactive":2322239488,"buffers":846553088,"cached":4989644800,"shared":172527616,"slab":948609024},"swap":{"total":7787769856,"free":7787495424,"used":274432,"percent":0.0,"swapped_in":0,"swapped_out":16384},"cpu":{"user":9.0,"nice":0.0,"system":3.1,"idle":85.4,"iowait":0.0,"irq":0.0,"softirq":2.5,"steal":0.0,"guest":0.0,"guest_nice":0.0},"cpu_cores":[{"user":8.9,"nice":0.0,"system":2.4,"idle":82.2,"iowait":0.0,"irq":0.0,"softirq":6.4,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":9.6,"nice":0.0,"system":2.9,"idle":84.6,"iowait":0.0,"irq":0.0,"softirq":2.9,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":7.2,"nice":0.0,"system":3.0,"idle":86.8,"iowait":0.0,"irq":0.0,"softirq":3.0,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":11.4,"nice":0.0,"system":3.0,"idle":84.8,"iowait":0.1,"irq":0.0,"softirq":0.7,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":9.3,"nice":0.0,"system":3.3,"idle":87.0,"iowait":0.1,"irq":0.0,"softirq":0.3,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":5.5,"nice":0.0,"system":4.4,"idle":89.9,"iowait":0.0,"irq":0.0,"softirq":0.1,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":8.7,"nice":0.0,"system":3.3,"idle":87.9,"iowait":0.0,"irq":0.0,"softirq":0.1,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":11.4,"nice":0.0,"system":2.3,"idle":80.3,"iowait":0.0,"irq":0.0,"softirq":6.1,"steal":0.0,"guest":0.0,"guest_nice":0.0}]},"time":1564581054.0358574}',
+        "item_hash": "84afd8484912d3fa11a402e480d17e949fbf600fcdedd69674253be0320fa62c",
+        "signature": "21027c108022f992f090bbe5c78ca8822f5b7adceb705ae2cd5318543d7bcdd2a74700473045022100b59f7df5333d57080a93be53b9af74e66a284170ec493455e675eb2539ac21db022077ffc66fe8dde7707038344496a85266bf42af1240017d4e1fa0d7068c588ca7",
+    }
+    msg["item_type"] = "inline"
     status, ops = await incoming(msg, check_message=True)
     assert status == IncomingStatus.MESSAGE_HANDLED

--- a/tests/chains/test_substrate.py
+++ b/tests/chains/test_substrate.py
@@ -1,43 +1,40 @@
-import pytest
 import json
 
-import aleph.chains
-from aleph.chains.substrate import verify_signature
+import pytest
 
-TEST_MESSAGE = '{"chain": "DOT", "channel": "TEST", "sender": "5CGNMKCscqN2QNcT7Jtuz23ab7JUxh8wTEtXhECZLJn5vCGX", "type": "AGGREGATE", "time": 1601913525.231501, "item_content": "{\\"key\\":\\"test\\",\\"address\\":\\"5CGNMKCscqN2QNcT7Jtuz23ab7JUxh8wTEtXhECZLJn5vCGX\\",\\"content\\":{\\"a\\":1},\\"time\\":1601913525.231498}", "item_hash": "bfbc94fae6336d52ab65a4d907d399a0c16222bd944b3815faa08ad0e039ca1d", "signature": "{\\"curve\\": \\"sr25519\\", \\"data\\": \\"0x1ccefb257e89b4e3ecb7d71c8dc1d6e286290b9e32d2a11bf3f9d425c5790f4bff0b324dc774d20a13e38a340d1a48fada71fb0c68690c3adb8f0cc695b0eb83\\"}", "content": {"key": "test", "address": "5CGNMKCscqN2QNcT7Jtuz23ab7JUxh8wTEtXhECZLJn5vCGX", "content": {"a": 1}, "time": 1601913525.231498}}'
+from aleph.chains.substrate import verify_signature
+from aleph.schemas.pending_messages import parse_message
+
+TEST_MESSAGE = '{"chain": "DOT", "channel": "TEST", "sender": "5CGNMKCscqN2QNcT7Jtuz23ab7JUxh8wTEtXhECZLJn5vCGX", "type": "AGGREGATE", "item_type": "inline", "time": 1601913525.231501, "item_content": "{\\"key\\":\\"test\\",\\"address\\":\\"5CGNMKCscqN2QNcT7Jtuz23ab7JUxh8wTEtXhECZLJn5vCGX\\",\\"content\\":{\\"a\\":1},\\"time\\":1601913525.231498}", "item_hash": "bfbc94fae6336d52ab65a4d907d399a0c16222bd944b3815faa08ad0e039ca1d", "signature": "{\\"curve\\": \\"sr25519\\", \\"data\\": \\"0x1ccefb257e89b4e3ecb7d71c8dc1d6e286290b9e32d2a11bf3f9d425c5790f4bff0b324dc774d20a13e38a340d1a48fada71fb0c68690c3adb8f0cc695b0eb83\\"}", "content": {"key": "test", "address": "5CGNMKCscqN2QNcT7Jtuz23ab7JUxh8wTEtXhECZLJn5vCGX", "content": {"a": 1}, "time": 1601913525.231498}}'
+
 
 @pytest.mark.asyncio
 async def test_verify_signature_real():
-    message = json.loads(TEST_MESSAGE)
-    result = await verify_signature(message)
-    assert result == True
-    
-@pytest.mark.asyncio
-async def test_verify_signature_nonexistent():
-    result = await verify_signature({
-        'chain': 'CHAIN',
-        'sender': 'SENDER',
-        'type': 'TYPE',
-        'item_hash': 'ITEM_HASH'
-    })
-    assert result == False
-    
+    message_dict = json.loads(TEST_MESSAGE)
+    raw_message = parse_message(message_dict)
+
+    result = await verify_signature(raw_message)
+    assert result is True
+
+
 @pytest.mark.asyncio
 async def test_verify_signature_bad_json():
-    result = await verify_signature({
-        'chain': 'CHAIN',
-        'sender': 'SENDER',
-        'type': 'TYPE',
-        'item_hash': 'ITEM_HASH',
-        'signature': 'baba'
-    })
-    assert result == False
-    
+    message_dict = json.loads(TEST_MESSAGE)
+    raw_message = parse_message(message_dict)
+    raw_message.signature = "baba"
+
+    result = await verify_signature(raw_message)
+    assert result is False
+
+
 @pytest.mark.asyncio
 async def test_verify_signature_no_data():
-    message = json.loads(TEST_MESSAGE)
-    signature = json.loads(message['signature'])
-    del signature['data']
-    message['signature'] = json.dumps(signature)
-    result = await verify_signature(message)
-    assert result == False
+    message_dict = json.loads(TEST_MESSAGE)
+    raw_message = parse_message(message_dict)
+
+    signature = json.loads(raw_message.signature)
+    del signature["data"]
+
+    raw_message.signature = json.dumps(signature)
+    result = await verify_signature(raw_message)
+    assert result is False


### PR DESCRIPTION
We now use the `BasePendingMessage` class in the signature verifiers
for all supported chains.

Modified some tests since we can now make some hypotheses about
fields being present (and valid) in the message object.