### PR TITLE
[Forget] Fetch less data

### DIFF
--- a/src/aleph/handlers/forget.py
+++ b/src/aleph/handlers/forget.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
 from typing import Dict, Optional, List
@@ -25,7 +27,7 @@ class TargetMessageInfo:
     content_item_type: Optional[ItemType]
 
     @classmethod
-    def from_db_object(cls, message_dict: Dict) -> "TargetMessageInfo":
+    def from_db_object(cls, message_dict: Dict) -> TargetMessageInfo:
         content = message_dict.get("content", {})
         content_item_type = content.get("item_type")
 

--- a/tests/storage/forget/test_forget_message.py
+++ b/tests/storage/forget/test_forget_message.py
@@ -1,6 +1,6 @@
 import pytest
 from aleph_message.models import ForgetMessage
-from aleph.handlers.forget import forget_if_allowed
+from aleph.handlers.forget import forget_if_allowed, TargetMessageInfo
 
 
 @pytest.mark.asyncio
@@ -46,7 +46,8 @@ async def test_forget_inline_message(mocker):
     message_mock = mocker.patch("aleph.handlers.forget.Message")
     message_mock.collection.update_many = mocker.AsyncMock()
 
-    await forget_if_allowed(target_message, forget_message)
+    target_info = TargetMessageInfo.from_db_object(target_message)
+    await forget_if_allowed(target_info, forget_message)
 
     message_mock.collection.update_many.assert_called_once_with(
         filter={"item_hash": target_message["item_hash"]},
@@ -106,7 +107,8 @@ async def test_forget_store_message(mocker):
     message_mock = mocker.patch("aleph.handlers.forget.Message")
     message_mock.collection.update_many = mocker.AsyncMock()
 
-    await forget_if_allowed(target_message, forget_message)
+    target_info = TargetMessageInfo.from_db_object(target_message)
+    await forget_if_allowed(target_info, forget_message)
 
     message_mock.collection.update_many.assert_called_once_with(
         filter={"item_hash": target_message["item_hash"]},
@@ -171,7 +173,8 @@ async def test_forget_forget_message(mocker):
     message_mock = mocker.patch("aleph.handlers.forget.Message")
     message_mock.collection.update_many = mocker.AsyncMock()
 
-    await forget_if_allowed(target_message, forget_message)
+    target_info = TargetMessageInfo.from_db_object(target_message)
+    await forget_if_allowed(target_info, forget_message)
 
     assert not message_mock.collection.update_many.called
     assert not garbage_collect_mock.called


### PR DESCRIPTION
Reduced the data usage of the forget handler in two ways.

1. Stop relying on `get_message_content` to retrieve the content
of a message. As the message is guaranteed to already be on
the node, we can directly get the parts of interest from the DB.

2. Only retrieve the fields relevant to the handling of the forget
message from the DB. Rather than retrieving the whole content,
which can be quite large, we now only retrieve the address, item
type and item hash from the DB. This should improve the performance
of the handler. Introduced a new class, `TargetMessageInfo`, to
represent the data we fetch from the DB.