### PR TITLE
[Messages] Use pending message model everywhere

### DIFF
--- a/src/aleph/handlers/storage.py
+++ b/src/aleph/handlers/storage.py
@@ -19,6 +19,7 @@ from pydantic import ValidationError
 
 from aleph.config import get_config
 from aleph.exceptions import AlephStorageException, UnknownHashError
+from aleph.schemas.pending_messages import PendingStoreMessage
 from aleph.services.ipfs.common import get_ipfs_api
 from aleph.storage import get_hash_content
 from aleph.utils import item_type_from_hash
@@ -26,7 +27,7 @@ from aleph.utils import item_type_from_hash
 LOGGER = logging.getLogger("HANDLERS.STORAGE")
 
 
-async def handle_new_storage(message: Dict, content: Dict):
+async def handle_new_storage(message: PendingStoreMessage, content: Dict):
     config = get_config()
     if not config.storage.store_files.value:
         return True  # Ignore
@@ -34,7 +35,7 @@ async def handle_new_storage(message: Dict, content: Dict):
     # TODO: ideally the content should be transformed earlier, but this requires more clean up
     #       (ex: no more in place modification of content, simplification of the flow)
     try:
-        store_message = StoreMessage(**message, content=content)
+        store_message = StoreMessage(**message.dict(exclude={"content"}), content=content)
     except ValidationError as e:
         print(e)
         return -1  # Invalid store message, discard

--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -19,6 +19,7 @@ from aleph.model.db_bulk_operation import DbBulkOperation
 from aleph.model.pending import PendingMessage
 from aleph.services.p2p import singleton
 from .job_utils import prepare_loop, process_job_results
+from ..schemas.pending_messages import parse_message
 
 LOGGER = getLogger("jobs.pending_messages")
 
@@ -48,9 +49,11 @@ async def handle_pending_message(
     seen_ids: Dict[Tuple, int],
 ) -> List[DbBulkOperation]:
 
+    message = parse_message(pending["message"])
+
     async with sem:
         status, operations = await incoming(
-            pending["message"],
+            message=message,
             chain_name=pending["source"].get("chain_name"),
             tx_hash=pending["source"].get("tx_hash"),
             height=pending["source"].get("height"),

--- a/src/aleph/permissions.py
+++ b/src/aleph/permissions.py
@@ -1,15 +1,16 @@
 from typing import Dict
 
 from aleph.model.messages import get_computed_address_aggregates
+from aleph.schemas.pending_messages import BasePendingMessage
 
 
-async def check_sender_authorization(message: Dict, content: Dict) -> bool:
+async def check_sender_authorization(message: BasePendingMessage, content: Dict) -> bool:
     """Checks a content against a message to verify if sender is authorized.
 
     TODO: implement "security" aggregate key check.
     """
 
-    sender = message["sender"]
+    sender = message.sender
     address = content["address"]
 
     # if sender is the content address, all good.
@@ -28,7 +29,7 @@ async def check_sender_authorization(message: Dict, content: Dict) -> bool:
         if auth.get("address", "") != sender:
             continue  # not applicable, move on.
 
-        if auth.get("chain") and message["chain"] != auth.get("chain"):
+        if auth.get("chain") and message.chain != auth.get("chain"):
             continue
 
         channels = auth.get("channels", [])
@@ -36,17 +37,17 @@ async def check_sender_authorization(message: Dict, content: Dict) -> bool:
         ptypes = auth.get("post_types", [])
         akeys = auth.get("aggregate_keys", [])
 
-        if len(channels) and message["channel"] not in channels:
+        if len(channels) and message.channel not in channels:
             continue
 
-        if len(mtypes) and message["type"] not in mtypes:
+        if len(mtypes) and message.type not in mtypes:
             continue
 
-        if message["type"] == "POST":
+        if message.type == "POST":
             if len(ptypes) and content["type"] not in ptypes:
                 continue
 
-        if message["type"] == "AGGREGATE":
+        if message.type == "AGGREGATE":
             if len(akeys) and content["key"] not in akeys:
                 continue
 

--- a/src/aleph/services/ipfs/pubsub.py
+++ b/src/aleph/services/ipfs/pubsub.py
@@ -41,14 +41,14 @@ async def pub(topic: str, message: Union[str, bytes]):
 
 
 async def incoming_channel(topic) -> None:
-    from aleph.network import incoming_check
+    from aleph.network import get_pubsub_message
     from aleph.chains.common import process_one_message
 
     while True:
         try:
             async for mvalue in sub(topic):
                 try:
-                    message = await incoming_check(mvalue)
+                    message = await get_pubsub_message(mvalue)
                     LOGGER.debug("New message %r" % message)
                     asyncio.create_task(process_one_message(message))
                 except InvalidMessageError:

--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -14,7 +14,7 @@ from p2pclient.libp2p_stubs.peer.id import ID
 
 from aleph import __version__
 from aleph.exceptions import AlephStorageException, InvalidMessageError
-from aleph.network import incoming_check
+from aleph.network import get_pubsub_message
 from aleph.services.utils import pubsub_msg_to_dict
 from .pubsub import receive_pubsub_messages, subscribe
 
@@ -191,7 +191,7 @@ async def incoming_channel(p2p_client: P2PClient, topic: str) -> None:
                     # we should check the sender here to avoid spam
                     # and such things...
                     try:
-                        message = await incoming_check(msg_dict)
+                        message = await get_pubsub_message(msg_dict)
                     except InvalidMessageError:
                         continue
 

--- a/tests/chains/test_common.py
+++ b/tests/chains/test_common.py
@@ -9,7 +9,7 @@ from aleph.chains.common import (
 )
 from unittest.mock import MagicMock
 
-from aleph.schemas.pending_messages import BasePendingMessage
+from aleph.schemas.pending_messages import BasePendingMessage, parse_message
 
 
 @pytest.mark.asyncio
@@ -55,7 +55,7 @@ async def test_incoming_inline(mocker):
 
     mocker.patch("aleph.model.db")
 
-    msg = {
+    message_dict = {
         "chain": "NULS",
         "channel": "SYSINFO",
         "sender": "TTapAav8g3fFjxQQCjwPd4ERPnai9oya",
@@ -65,6 +65,8 @@ async def test_incoming_inline(mocker):
         "item_hash": "84afd8484912d3fa11a402e480d17e949fbf600fcdedd69674253be0320fa62c",
         "signature": "21027c108022f992f090bbe5c78ca8822f5b7adceb705ae2cd5318543d7bcdd2a74700473045022100b59f7df5333d57080a93be53b9af74e66a284170ec493455e675eb2539ac21db022077ffc66fe8dde7707038344496a85266bf42af1240017d4e1fa0d7068c588ca7",
     }
-    msg["item_type"] = "inline"
-    status, ops = await incoming(msg, check_message=True)
+    message_dict["item_type"] = "inline"
+
+    message = parse_message(message_dict)
+    status, ops = await incoming(message, check_message=True)
     assert status == IncomingStatus.MESSAGE_HANDLED

--- a/tests/permissions/test_check_sender_authorization.py
+++ b/tests/permissions/test_check_sender_authorization.py
@@ -1,34 +1,30 @@
 from aleph.permissions import check_sender_authorization
 import pytest
 from aleph.model.messages import Message
+from aleph.schemas.pending_messages import parse_message, PendingStoreMessage
 
 
 @pytest.mark.asyncio
 async def test_owner_is_sender():
-    message = {
+    message_dict = {
         "_id": {"$oid": "6278d1f451c0b9a4fb11c8a9"},
         "chain": "ETH",
         "item_hash": "2a5aaf71c8767bda8eb235223a3387b310af117f42fac08f02461e90aee073b0",
         "sender": "0xdeF61fAadE93a8aaE303D083Ead5BF7a25E55a23",
         "type": "STORE",
         "channel": "TEST",
-        "confirmed": False,
-        "content": {
-            "address": "0xdeF61fAadE93a8aaE303D083Ead5BF7a25E55a23",
-            "item_type": "storage",
-            "item_hash": "e916165d63c9b1d455dc415859ec3e1da5a3c6c86cc743cbedf2203fd92a2b1b",
-            "time": 1652085236.777,
-            "size": 2780,
-            "content_type": "file",
-        },
         "item_content": '{"address":"0xdeF61fAadE93a8aaE303D083Ead5BF7a25E55a23","item_type":"storage","item_hash":"e916165d63c9b1d455dc415859ec3e1da5a3c6c86cc743cbedf2203fd92a2b1b","time":1652085236.777}',
         "item_type": "inline",
         "signature": "0x51383ef8823665bd8ea1150175be0c3745a36ea1f0d503ceb51e0d7ff1fd88a5290665564bf9c2315d97884e7448efdb8d4b4f8293b47a641c2ff43f21b6c5b61c",
-        "size": 179,
         "time": 1652085236.777,
     }
 
-    is_authorized = await check_sender_authorization(message, message["content"])
+    message = parse_message(message_dict)
+
+    # For mypy
+    assert message.content is not None
+
+    is_authorized = await check_sender_authorization(message, message.content.dict())
     assert is_authorized
 
 
@@ -36,7 +32,7 @@ async def test_owner_is_sender():
 async def test_store_unauthorized(mocker):
     mocker.patch("aleph.permissions.get_computed_address_aggregates", return_value={})
 
-    message = {
+    message_dict = {
         "chain": "ETH",
         "channel": "TEST",
         "item_content": '{"address":"VM on executor","time":1651050219.3481126,"content":{"date":"2022-04-27T09:03:38.361081","test":true,"answer":42,"something":"interesting"},"type":"test"}',
@@ -48,19 +44,12 @@ async def test_store_unauthorized(mocker):
         "type": "POST",
     }
 
-    content = {
-        "address": "VM on executor",
-        "content": {
-            "answer": 42,
-            "date": "2022-04-27T09:03:38.361081",
-            "something": "interesting",
-            "test": True,
-        },
-        "time": 1651050219.3481126,
-        "type": "test",
-    }
+    message = parse_message(message_dict)
 
-    is_authorized = await check_sender_authorization(message, content)
+    # For mypy
+    assert message.content is not None
+
+    is_authorized = await check_sender_authorization(message, message.content.dict())
     assert not is_authorized
 
 
@@ -68,20 +57,12 @@ AUTHORIZED_MESSAGE = {
     "chain": "ETH",
     "channel": "TEST",
     "item_content": '{"address":"0xA3c613b12e862EB6e0C9897E03F1deEb207b5B58","time":1651050219.3481126,"content":{"date":"2022-04-27T09:03:38.361081","test":true,"answer":42,"something":"interesting"},"type":"test"}',
-    "content": {
-        "address": "0xA3c613b12e862EB6e0C9897E03F1deEb207b5B58",
-        "content": {
-            "answer": 42,
-            "date": "2022-04-27T09:03:38.361081",
-            "something": "interesting",
-            "test": True,
-        },
-    },
-    "item_hash": "498a10255877a74609654b673af4f8f29eb8ef1aa5d6265d9a6bf9e342d352db",
+    "item_hash": "1d8c28dac67725dd9d0ed218127d5ef7870443c803cd35598bb6cbb03ec76383",
     "item_type": "inline",
     "sender": "0x86F39e17910E3E6d9F38412EB7F24Bf0Ba31eb2E",
     "time": 1651050219.3488848,
     "type": "POST",
+    "signature": "fake signature, not checked here<",
 }
 
 
@@ -100,9 +81,12 @@ async def test_authorized(mocker):
         },
     )
 
-    is_authorized = await check_sender_authorization(
-        AUTHORIZED_MESSAGE, AUTHORIZED_MESSAGE["content"]
-    )
+    message = parse_message(AUTHORIZED_MESSAGE)
+
+    # For mypy
+    assert message.content is not None
+
+    is_authorized = await check_sender_authorization(message, message.content.dict())
     assert is_authorized
 
 
@@ -141,7 +125,10 @@ async def test_authorized_with_db(test_db):
 
     await Message.collection.insert_one(security_message)
 
-    is_authorized = await check_sender_authorization(
-        AUTHORIZED_MESSAGE, AUTHORIZED_MESSAGE["content"]
-    )
+    message = parse_message(AUTHORIZED_MESSAGE)
+
+    # For mypy
+    assert message.content is not None
+
+    is_authorized = await check_sender_authorization(message, message.content.dict())
     assert is_authorized

--- a/tests/storage/forget/test_forget_multi_users.py
+++ b/tests/storage/forget/test_forget_multi_users.py
@@ -12,6 +12,7 @@ from aleph.model.hashes import (
     set_value as store_gridfs_file,
 )
 from aleph.model.messages import Message
+from aleph.schemas.pending_messages import parse_message
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -25,41 +26,38 @@ async def test_forget_multiusers_storage(mocker, test_db):
 
     file_hash = "05a123fe17aa6addeef5a97d1665878d10f076d84309d5ae674d4bb292b484c3"
 
-    message_user1 = {
+    message_user1_dict = {
         "chain": "ETH",
         "sender": "0x971300C78A38e0F85E60A3b04ae3fA70b4276B64",
         "type": "STORE",
         "channel": "TESTS_FORGET",
         "confirmed": False,
         "item_type": "inline",
-        "size": 202,
         "time": 1646123806,
         "item_content": '{"address": "0x971300C78A38e0F85E60A3b04ae3fA70b4276B64", "time": 1651757380.8522494, "item_type": "storage", "item_hash": "05a123fe17aa6addeef5a97d1665878d10f076d84309d5ae674d4bb292b484c3", "size": 220916, "content_type": "file"}',
         "item_hash": "50635384e43c7af6b3297f6571644c30f3f07ac681bfd14b9c556c63e661a69e",
         "signature": "0x71263de6b8d1ea4c0b028f5892287505f6ee73dfa165d1455ca665ffdf5318955345c193a5df2f5c4eb2185947689d7bf5be36155b00711572fec5f27764625c1b",
     }
 
-    message_user2 = {
+    message_user2_dict = {
         "chain": "ETH",
         "sender": "0xaC033C1cA5C49Eff98A1D9a56BeDBC4840010BA4",
         "type": "STORE",
         "channel": "TESTS_FORGET",
         "confirmed": False,
         "item_type": "inline",
-        "size": 202,
         "time": 1646123806,
         "item_content": '{"address": "0xaC033C1cA5C49Eff98A1D9a56BeDBC4840010BA4", "time": 1651757416.2203836, "item_type": "storage", "item_hash": "05a123fe17aa6addeef5a97d1665878d10f076d84309d5ae674d4bb292b484c3", "size": 220916, "content_type": "file"}',
         "item_hash": "dbe8199004b052108ec19618f43af1d2baf5c04974d0aec1c4de2d02c44a2483",
         "signature": "0x4c9ef501e1e4f4b0a05c1eebfa1063837a82788f80deeb59808d25ff481c855157dd65102eaa365e33c7572a78d551cf25075f49d00ebb60c8506c0a6647ab761b",
     }
 
-    forget_message_user1 = {
+    forget_message_user1_dict = {
         "chain": "ETH",
         "sender": "0x971300C78A38e0F85E60A3b04ae3fA70b4276B64",
         "type": "FORGET",
         "channel": "TESTS_FORGET",
         "item_type": "inline",
-        "size": 202,
         "time": 1651757583.497435,
         "item_content": '{"address": "0x971300C78A38e0F85E60A3b04ae3fA70b4276B64", "time": 1651757583.4974332, "hashes": ["50635384e43c7af6b3297f6571644c30f3f07ac681bfd14b9c556c63e661a69e"], "reason": "I do not like this file"}',
         "item_hash": "0223e74dbae53b45da6a443fa18fd2a25f88677c82ed2de93f17ab24f78f58cf",
@@ -71,35 +69,38 @@ async def test_forget_multiusers_storage(mocker, test_db):
         file_content = f.read()
     await store_gridfs_file(key=file_hash, value=file_content)
 
+    message_user1 = parse_message(message_user1_dict)
     await process_one_message(message_user1)
 
     message1_db = await Message.collection.find_one(
-        {"item_hash": message_user1["item_hash"]}
+        {"item_hash": message_user1.item_hash}
     )
     assert message1_db is not None
 
+    message_user2 = parse_message(message_user2_dict)
     await process_one_message(message_user2)
 
     # Sanity check: check that the file exists
     db_file_data = await read_gridfs_file(file_hash)
     assert db_file_data == file_content
 
+    forget_message_user1 = parse_message(forget_message_user1_dict)
     await process_one_message(forget_message_user1)
 
     # Check that the message was properly forgotten
     forgotten_message = await Message.collection.find_one(
-        {"item_hash": message_user1["item_hash"]}
+        {"item_hash": message_user1.item_hash}
     )
     assert forgotten_message is not None
-    assert forgotten_message["forgotten_by"] == [forget_message_user1["item_hash"]]
+    assert forgotten_message["forgotten_by"] == [forget_message_user1.item_hash]
 
     # Check that the message from user 2 is not affected
     message_user2_db = await Message.collection.find_one(
-        {"item_hash": message_user2["item_hash"]}
+        {"item_hash": message_user2.item_hash}
     )
     assert message_user2_db is not None
     assert "forgotten_by" not in message_user2_db
-    assert message_user2_db["item_content"] == message_user2["item_content"]
+    assert message_user2_db["item_content"] == message_user2.item_content
 
     # Check that the file still exists
     db_file_data = await read_gridfs_file(file_hash)

--- a/tests/storage/test_get_content.py
+++ b/tests/storage/test_get_content.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from aleph.exceptions import InvalidContent, ContentCurrentlyUnavailable
+from aleph.schemas.pending_messages import parse_message
 from aleph.storage import ContentSource, get_hash_content, get_json, get_message_content
 from aleph_message.models import ItemType
 
@@ -131,32 +132,12 @@ async def test_get_invalid_json(mocker, mock_config):
 
 
 @pytest.mark.asyncio
-async def test_get_inline_content(mock_config):
-    content_hash = "message-hash"
-    json_content = [
-        {"post": "The joys of JavaScript (JK)"},
-        {"post": "Does your cat plan to murder you?"},
-    ]
-    json_bytes = json.dumps(json_content).encode("utf-8")
-    message = {
-        "item_type": ItemType.inline.value,
-        "item_hash": content_hash,
-        "item_content": json_bytes,
-    }
-
-    content = await get_message_content(message)
-    assert content.value == json_content
-    assert content.hash == content_hash
-    assert content.raw_value == json_bytes
-
-
-@pytest.mark.asyncio
 async def test_get_inline_content_full_message():
     """
-    Same test as above, with a complete message. Reuse of an older test.
+    Get inline content from a message. Reuses an older test/fixture.
     """
 
-    msg = {
+    message_dict = {
         "chain": "NULS",
         "channel": "SYSINFO",
         "sender": "TTapAav8g3fFjxQQCjwPd4ERPnai9oya",
@@ -167,47 +148,37 @@ async def test_get_inline_content_full_message():
         "signature": "21027c108022f992f090bbe5c78ca8822f5b7adceb705ae2cd5318543d7bcdd2a74700473045022100b59f7df5333d57080a93be53b9af74e66a284170ec493455e675eb2539ac21db022077ffc66fe8dde7707038344496a85266bf42af1240017d4e1fa0d7068c588ca7",
         "item_type": "inline",
     }
-    content = await get_message_content(msg)
+
+    message = parse_message(message_dict)
+    content = await get_message_content(message)
     item_content = content.value
-    print(item_content)
-    assert len(content.raw_value) == len(msg['item_content'])
-    assert item_content['key'] == 'metrics'
-    assert item_content['address'] == 'TTapAav8g3fFjxQQCjwPd4ERPnai9oya'
-    assert 'memory' in item_content['content']
-    assert 'cpu_cores' in item_content['content']
+
+    assert len(content.raw_value) == len(message.item_content)
+    assert item_content["key"] == "metrics"
+    assert item_content["address"] == "TTapAav8g3fFjxQQCjwPd4ERPnai9oya"
+    assert "memory" in item_content["content"]
+    assert "cpu_cores" in item_content["content"]
 
 
 @pytest.mark.asyncio
 async def test_get_stored_message_content(mocker, mock_config):
-    content_hash = "message-hash"
+    message_dict = {
+        "chain": "ETH",
+        "channel": "TEST",
+        "sender": "0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106",
+        "type": "POST",
+        "item_type": "storage",
+        "item_hash": "315f7313eb97d2c8299e3ee9c19d81f226c44ccf81c387c9fb25c54fced245f5",
+        "item_content": None,
+        "signature": "unsigned fixture, deal with it",
+        "time": 1652805847.190618,
+    }
     json_content = {"I": "Inter", "P": "Planetary", "F": "File", "S": "System"}
     json_bytes = json.dumps(json_content).encode("utf-8")
     mocker.patch("aleph.storage.get_value", return_value=json_bytes)
 
-    message = {
-        "item_type": ItemType.ipfs.value,
-        "item_hash": content_hash,
-    }
+    message = parse_message(message_dict)
 
     content = await get_message_content(message)
     assert content.value == json_content
-    assert content.hash == content_hash
-
-
-@pytest.mark.asyncio
-async def test_get_message_content_unknown_item_type(mocker, mock_config):
-    """
-    Checks that an unknown item type field in a message will mark it as currently unavailable.
-    """
-
-    json_content = {"No more": "inspiration"}
-    json_bytes = json.dumps(json_content).encode("utf-8")
-    mocker.patch("aleph.storage.get_value", return_value=json_bytes)
-
-    message = {
-        "item_type": "invalid-item-type",
-        "item_hash": "message_hash",
-    }
-
-    with pytest.raises(ContentCurrentlyUnavailable):
-        _content = await get_message_content(message)
+    assert content.hash == message.item_hash

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -4,7 +4,8 @@ import pytest
 import aleph.chains
 from aleph.exceptions import InvalidMessageError
 from aleph.chains.common import IncomingStatus
-from aleph.network import check_message
+from aleph.network import verify_signature
+from aleph.schemas.pending_messages import parse_message
 
 __author__ = "Moshe Malawach"
 __copyright__ = "Moshe Malawach"
@@ -20,25 +21,28 @@ __license__ = "mit"
 #     assert msg['item_type'] == 'ipfs', "ipfs should be the default"
 #     assert msg is passed_msg, "same object should be returned"
 
+
 @pytest.mark.skip("TODO: NULS signature verification does not work with the fixture.")
 @pytest.mark.asyncio
 async def test_valid_message():
-    sample_message = {
+    sample_message_dict = {
         "item_hash": "QmfDkHXdGND7e8uwJr4yvXSAvbPc8rothM6UN5ABQPsLkF",
+        "item_type": "ipfs",
         "chain": "NULS",
         "channel": "SYSINFO",
         "sender": "TTanii7eCT93f45g2UpKH81mxpVNcCYw",
         "type": "AGGREGATE",
         "time": 1563279102.3155158,
-        "signature": "2103041b0b357446927d2c8c62fdddd27910d82f665f16a4907a2be927b5901f5e6c004730450221009a54ecaff6869664e94ad68554520c79c21d4f63822864bd910f9916c32c1b5602201576053180d225ec173fb0b6e4af5efb2dc474ce6aa77a3bdd67fd14e1d806b4"
+        "signature": "2103041b0b357446927d2c8c62fdddd27910d82f665f16a4907a2be927b5901f5e6c004730450221009a54ecaff6869664e94ad68554520c79c21d4f63822864bd910f9916c32c1b5602201576053180d225ec173fb0b6e4af5efb2dc474ce6aa77a3bdd67fd14e1d806b4",
     }
-    message = await check_message(sample_message)
-    assert message is not None
+
+    sample_message = parse_message(sample_message_dict)
+    await verify_signature(sample_message)
 
 
 @pytest.mark.asyncio
 async def test_invalid_chain_message():
-    sample_message = {
+    sample_message_dict = {
         "item_hash": "QmfDkHXdGND7e8uwJr4yvXSAvbPc8rothM6UN5ABQPsLkF",
         "item_type": "ipfs",
         "chain": "BAR",
@@ -46,15 +50,16 @@ async def test_invalid_chain_message():
         "sender": "TTanii7eCT93f45g2UpKH81mxpVNcCYw",
         "type": "AGGREGATE",
         "time": 1563279102.3155158,
-        "signature": "2103041b0b357446927d2c8c62fdddd27910d82f665f16a4907a2be927b5901f5e6c004730450221009a54ecaff6869664e94ad68554520c79c21d4f63822864bd910f9916c32c1b5602201576053180d225ec173fb0b6e4af5efb2dc474ce6aa77a3bdd67fd14e1d806b4"
+        "signature": "2103041b0b357446927d2c8c62fdddd27910d82f665f16a4907a2be927b5901f5e6c004730450221009a54ecaff6869664e94ad68554520c79c21d4f63822864bd910f9916c32c1b5602201576053180d225ec173fb0b6e4af5efb2dc474ce6aa77a3bdd67fd14e1d806b4",
     }
+
     with pytest.raises(InvalidMessageError):
-        _ = await check_message(sample_message)
+        _ = parse_message(sample_message_dict)
 
 
 @pytest.mark.asyncio
 async def test_invalid_signature_message():
-    sample_message = {
+    sample_message_dict = {
         "item_hash": "QmfDkHXdGND7e8uwJr4yvXSAvbPc8rothM6UN5ABQPsLkF",
         "item_type": "ipfs",
         "chain": "NULS",
@@ -62,86 +67,55 @@ async def test_invalid_signature_message():
         "sender": "TTanii7eCT93f45g2UpKH81mxpVNcCYw",
         "type": "AGGREGATE",
         "time": 1563279102.3155158,
-        "signature": "BAR"
+        "signature": "BAR",
     }
+
+    sample_message = parse_message(sample_message_dict)
     with pytest.raises(InvalidMessageError):
-        _ = await check_message(sample_message)
+        _ = await verify_signature(sample_message)
 
 
-@pytest.mark.skip("TODO: NULS signature verification does not fail as expected with this fixture.")
 @pytest.mark.asyncio
 async def test_invalid_signature_message_2():
-    sample_message = {
+    sample_message_dict = {
         "item_hash": "QmfDkHXdGND7e8uwJr4yvXSAvbPc8rothM6UN5ABQPsLkF",
+        "item_type": "ipfs",
         "chain": "NULS",
         "channel": "SYSINFO",
         "sender": "TTanii7eCT93f45g2UpKH81mxpVNcCYw",
         "type": "AGGREGATE",
         "time": 1563279102.3155158,
-        "signature": "2153041b0b357446927d2c8c62fdddd27910d82f665f16a4907a2be927b5901f5e6c004730450221009a54ecaff6869664e94ad68554525c79c21d4f63822864bd910f9916c32c1b5602201576053180d225ec173fb0b6e4af5efb2dc474ce6aa77a3bdd67fd14e1d806b4"
+        "signature": "2153041b0b357446927d2c8c62fdddd27910d82f665f16a4907a2be927b5901f5e6c004730450221009a54ecaff6869664e94ad68554525c79c21d4f63822864bd910f9916c32c1b5602201576053180d225ec173fb0b6e4af5efb2dc474ce6aa77a3bdd67fd14e1d806b4",
     }
-    # with pytest.raises(InvalidMessageError):
-    x = await check_message(sample_message)
-    print(x)
+
+    sample_message = parse_message(sample_message_dict)
+    with pytest.raises(InvalidMessageError):
+        _ = await verify_signature(sample_message)
 
 
-@pytest.mark.skip("TODO: NULS signature verification does not work with the fixture.")
-@pytest.mark.asyncio
-async def test_extraneous_fields():
-    sample_message = {
-        "item_hash": "QmfDkHXdGND7e8uwJr4yvXSAvbPc8rothM6UN5ABQPsLkF",
-        "chain": "NULS",
-        "channel": "SYSINFO",
-        "sender": "TTanii7eCT93f45g2UpKH81mxpVNcCYw",
-        "type": "AGGREGATE",
-        "foo": "bar",
-        "time": 1563279102.3155158,
-        "signature": "2103041b0b357446927d2c8c62fdddd27910d82f665f16a4907a2be927b5901f5e6c004730450221009a54ecaff6869664e94ad68554520c79c21d4f63822864bd910f9916c32c1b5602201576053180d225ec173fb0b6e4af5efb2dc474ce6aa77a3bdd67fd14e1d806b4"
-    }
-    message = await check_message(sample_message)
-    # assert "type" not in message
-    assert "foo" not in message
-
-# @pytest.mark.asyncio
-# async def test_inline_content():
-#     content = json.dumps({'foo': 'bar'})
-#     h = hashlib.sha256()
-#     h.update(content.encode('utf-8'))
-#     sample_message = {
-#         "item_hash": h.hexdigest(),
-#         "item_content": content,
-#         "chain": "NULS"
-#     }
-#     message = await check_message(sample_message, trusted=True)
-#     assert message is not None
-#     assert message['item_hash'] == h.hexdigest()
-#     assert message['item_content'] == content
-#     assert message['item_type'] == 'inline'
-
-
-@pytest.mark.skip("TODO: NULS signature verification does not work with the fixtures.")
 @pytest.mark.asyncio
 async def test_incoming_inline_content(mocker):
     from aleph.chains.common import incoming
     from unittest.mock import MagicMock
-    
+
     async def async_magic():
         pass
 
     MagicMock.__await__ = lambda x: async_magic().__await__()
-    
-    mocker.patch('aleph.model.db')
 
-    msg = {'chain': 'NULS',
-           'channel': 'SYSINFO',
-           'sender': 'TTapAav8g3fFjxQQCjwPd4ERPnai9oya',
-           'type': 'AGGREGATE',
-           'time': 1564581054.0532622,
-           'item_content': '{"key":"metrics","address":"TTapAav8g3fFjxQQCjwPd4ERPnai9oya","content":{"memory":{"total":12578275328,"available":5726081024,"percent":54.5,"used":6503415808,"free":238661632,"active":8694841344,"inactive":2322239488,"buffers":846553088,"cached":4989644800,"shared":172527616,"slab":948609024},"swap":{"total":7787769856,"free":7787495424,"used":274432,"percent":0.0,"swapped_in":0,"swapped_out":16384},"cpu":{"user":9.0,"nice":0.0,"system":3.1,"idle":85.4,"iowait":0.0,"irq":0.0,"softirq":2.5,"steal":0.0,"guest":0.0,"guest_nice":0.0},"cpu_cores":[{"user":8.9,"nice":0.0,"system":2.4,"idle":82.2,"iowait":0.0,"irq":0.0,"softirq":6.4,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":9.6,"nice":0.0,"system":2.9,"idle":84.6,"iowait":0.0,"irq":0.0,"softirq":2.9,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":7.2,"nice":0.0,"system":3.0,"idle":86.8,"iowait":0.0,"irq":0.0,"softirq":3.0,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":11.4,"nice":0.0,"system":3.0,"idle":84.8,"iowait":0.1,"irq":0.0,"softirq":0.7,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":9.3,"nice":0.0,"system":3.3,"idle":87.0,"iowait":0.1,"irq":0.0,"softirq":0.3,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":5.5,"nice":0.0,"system":4.4,"idle":89.9,"iowait":0.0,"irq":0.0,"softirq":0.1,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":8.7,"nice":0.0,"system":3.3,"idle":87.9,"iowait":0.0,"irq":0.0,"softirq":0.1,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":11.4,"nice":0.0,"system":2.3,"idle":80.3,"iowait":0.0,"irq":0.0,"softirq":6.1,"steal":0.0,"guest":0.0,"guest_nice":0.0}]},"time":1564581054.0358574}',
-           'item_hash': '84afd8484912d3fa11a402e480d17e949fbf600fcdedd69674253be0320fa62c',
-           'signature': '21027c108022f992f090bbe5c78ca8822f5b7adceb705ae2cd5318543d7bcdd2a74700473045022100b59f7df5333d57080a93be53b9af74e66a284170ec493455e675eb2539ac21db022077ffc66fe8dde7707038344496a85266bf42af1240017d4e1fa0d7068c588ca7'
-           }
-    # msg['item_type'] = 'inline'
-    msg = await check_message(msg)
-    status, ops = await incoming(msg)
+    mocker.patch("aleph.model.db")
+
+    message_dict = {
+        "chain": "NULS",
+        "channel": "SYSINFO",
+        "sender": "TTapAav8g3fFjxQQCjwPd4ERPnai9oya",
+        "type": "AGGREGATE",
+        "time": 1564581054.0532622,
+        "item_type": "inline",
+        "item_content": '{"key":"metrics","address":"TTapAav8g3fFjxQQCjwPd4ERPnai9oya","content":{"memory":{"total":12578275328,"available":5726081024,"percent":54.5,"used":6503415808,"free":238661632,"active":8694841344,"inactive":2322239488,"buffers":846553088,"cached":4989644800,"shared":172527616,"slab":948609024},"swap":{"total":7787769856,"free":7787495424,"used":274432,"percent":0.0,"swapped_in":0,"swapped_out":16384},"cpu":{"user":9.0,"nice":0.0,"system":3.1,"idle":85.4,"iowait":0.0,"irq":0.0,"softirq":2.5,"steal":0.0,"guest":0.0,"guest_nice":0.0},"cpu_cores":[{"user":8.9,"nice":0.0,"system":2.4,"idle":82.2,"iowait":0.0,"irq":0.0,"softirq":6.4,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":9.6,"nice":0.0,"system":2.9,"idle":84.6,"iowait":0.0,"irq":0.0,"softirq":2.9,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":7.2,"nice":0.0,"system":3.0,"idle":86.8,"iowait":0.0,"irq":0.0,"softirq":3.0,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":11.4,"nice":0.0,"system":3.0,"idle":84.8,"iowait":0.1,"irq":0.0,"softirq":0.7,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":9.3,"nice":0.0,"system":3.3,"idle":87.0,"iowait":0.1,"irq":0.0,"softirq":0.3,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":5.5,"nice":0.0,"system":4.4,"idle":89.9,"iowait":0.0,"irq":0.0,"softirq":0.1,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":8.7,"nice":0.0,"system":3.3,"idle":87.9,"iowait":0.0,"irq":0.0,"softirq":0.1,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":11.4,"nice":0.0,"system":2.3,"idle":80.3,"iowait":0.0,"irq":0.0,"softirq":6.1,"steal":0.0,"guest":0.0,"guest_nice":0.0}]},"time":1564581054.0358574}',
+        "item_hash": "84afd8484912d3fa11a402e480d17e949fbf600fcdedd69674253be0320fa62c",
+        "signature": "21027c108022f992f090bbe5c78ca8822f5b7adceb705ae2cd5318543d7bcdd2a74700473045022100b59f7df5333d57080a93be53b9af74e66a284170ec493455e675eb2539ac21db022077ffc66fe8dde7707038344496a85266bf42af1240017d4e1fa0d7068c588ca7",
+    }
+    message = parse_message(message_dict)
+    status, ops = await incoming(message)
     assert status == IncomingStatus.MESSAGE_HANDLED


### PR DESCRIPTION
Propagated the use of the `BasePendingMessage` subclasses in all
functions related to message processing.

Split the message validation function, check_message, in two parts:
* `parse_message` checks that the message is semantically valid,
  i.e. that all the required fields are present, are of the correct
  type and have sensible values.
* `verify_signature` checks the signature of the message using
  the public key of the sender.

We now call parse_message as early as possible in the process.
This allows to simplify hypotheses about the presence/absence
of specific fields and allows to simplify the codebase.

One of the current issues is that the content of the message
can only be loaded conditionally (if the message has inline content).
Otherwise, we must load the content from the network. As this
operation goes beyond simple validation, we perform it later
in the flow, leading to a situation where the content of a message
is not guaranteed to be available at a given point depending
on the `item_type` field of the message.

Modified tests to use the raw message classes. Removed a few tests
that tested corner cases linked to incomplete message dictionaries.