### PR TITLE
[Messages] Improve throughput of jobs

### DIFF
--- a/deployment/docker-build/pyaleph.dockerfile
+++ b/deployment/docker-build/pyaleph.dockerfile
@@ -84,6 +84,9 @@ RUN /opt/venv/bin/pip install --no-cache-dir "."
 # Save installed Python requirements for debugging
 RUN /opt/venv/bin/pip freeze > /opt/build-frozen-requirements.txt
 
+USER root
+RUN chown -R aleph:aleph /opt/pyaleph/
+
 USER aleph
 ENTRYPOINT ["bash", "deployment/scripts/run_aleph_ccn.sh"]
 

--- a/deployment/samples/docker-monitoring/grafana/dashboards/aleph/dashboard.json
+++ b/deployment/samples/docker-monitoring/grafana/dashboards/aleph/dashboard.json
@@ -8,28 +8,32 @@
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
       },
+      "description": "Pending message tasks by message type.",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -56,7 +60,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "8.4.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -66,18 +70,69 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pyaleph_processing_pending_messages_i_total",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "pyaleph_processing_pending_messages_aggregate_tasks",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "Aggregate",
           "queryType": "randomWalk",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "pyaleph_processing_pending_messages_forget_tasks",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Forget",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "pyaleph_processing_pending_messages_post_tasks",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Post",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "pyaleph_processing_pending_messages_program_tasks",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Program",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "pyaleph_processing_pending_messages_store_tasks",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Store",
+          "refId": "E"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
-      "title": "processing_pending_messages_i",
+      "title": "Tasks by message type",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -85,33 +140,26 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
+          "$$hashKey": "object:178",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
+          "$$hashKey": "object:179",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -119,12 +167,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -133,583 +178,6 @@
         "w": 12,
         "x": 12,
         "y": 0
-      },
-      "hiddenSeries": false,
-      "id": 20,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.4.5",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "pyaleph_processing_pending_messages_j_total",
-          "interval": "",
-          "legendFormat": "",
-          "queryType": "randomWalk",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "processing_pending_messages_j",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 8
-      },
-      "hiddenSeries": false,
-      "id": 16,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.4.5",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "pyaleph_processing_pending_messages_messages_actions_total",
-          "interval": "",
-          "legendFormat": "",
-          "queryType": "randomWalk",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "processing_pending_messages_messages_actions",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 8
-      },
-      "hiddenSeries": false,
-      "id": 14,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.4.5",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "pyaleph_processing_pending_messages_action_total",
-          "interval": "",
-          "legendFormat": "",
-          "queryType": "randomWalk",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "processing_pending_messages_action",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      },
-      "hiddenSeries": false,
-      "id": 12,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.4.5",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "pyaleph_processing_pending_messages_tasks_total",
-          "interval": "",
-          "legendFormat": "",
-          "queryType": "randomWalk",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "processing_pending_messages_tasks",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
-      },
-      "hiddenSeries": false,
-      "id": 10,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.4.5",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "pyaleph_processing_pending_messages_gtasks_total",
-          "interval": "",
-          "legendFormat": "",
-          "queryType": "randomWalk",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "processing_pending_messages_gtasks",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 24
-      },
-      "hiddenSeries": false,
-      "id": 8,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.4.5",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "pyaleph_processing_pending_messages_seen_ids_total",
-          "interval": "",
-          "legendFormat": "",
-          "queryType": "randomWalk",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "processing_pending_messages_seen_ids",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 24
       },
       "hiddenSeries": false,
       "id": 6,
@@ -729,7 +197,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "8.4.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -747,9 +215,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "ETH Sync",
       "tooltip": {
         "shared": true,
@@ -758,33 +224,24 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -792,23 +249,21 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
       },
+      "description": "",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 8
       },
       "hiddenSeries": false,
-      "id": 4,
+      "id": 12,
       "legend": {
         "avg": false,
         "current": false,
@@ -825,7 +280,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "8.4.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -835,18 +290,16 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pyaleph_status_sync_pending_messages_total",
-          "hide": false,
+          "expr": "pyaleph_processing_pending_messages_tasks_total",
           "interval": "",
           "legendFormat": "",
-          "refId": "B"
+          "queryType": "randomWalk",
+          "refId": "A"
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
-      "title": "Pending Messages",
+      "title": "processing_pending_messages_tasks",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -854,33 +307,24 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -888,12 +332,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -901,7 +342,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 8
       },
       "hiddenSeries": false,
       "id": 22,
@@ -921,7 +362,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "8.4.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -939,9 +380,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "status_sync_messages",
       "tooltip": {
         "shared": true,
@@ -950,33 +389,24 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -984,12 +414,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
       },
       "fill": 1,
       "fillGradient": 0,
@@ -997,7 +424,171 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 40
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "pyaleph_processing_pending_messages_seen_ids_total",
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "processing_pending_messages_seen_ids",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.4.5",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "pyaleph_status_sync_pending_messages_total",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Pending Messages",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
       },
       "hiddenSeries": false,
       "id": 2,
@@ -1017,7 +608,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "8.4.5",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1035,9 +626,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Peers Total",
       "tooltip": {
         "shared": true,
@@ -1046,50 +635,42 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     }
   ],
-  "refresh": "10s",
-  "schemaVersion": 27,
+  "refresh": false,
+  "schemaVersion": 35,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": []
   },
   "time": {
-    "from": "now-6h",
-    "to": "now"
+    "from": "2022-05-19T15:07:23.553Z",
+    "to": "2022-05-19T16:09:31.568Z"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Aleph Node Metrics",
   "uid": "8qvKiYwMz",
-  "version": 1
+  "version": 1,
+  "weekStart": ""
 }

--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -14,6 +14,15 @@ def get_defaults():
             "host": "0.0.0.0",
             "port": 8000,
             "reference_node_url": None,
+            "jobs": {
+                "pending_messages": {
+                    "max_concurrency": 2000,
+                    "store": 100,
+                },
+                "pending_txs": {
+                    "max_concurrency": 20,
+                }
+            }
         },
         "p2p": {
             "http_port": 4024,

--- a/src/aleph/jobs/__init__.py
+++ b/src/aleph/jobs/__init__.py
@@ -35,8 +35,8 @@ def start_jobs(
         p1.start()
         p2.start()
     else:
-        tasks.append(retry_messages_task(shared_stats=shared_stats))
-        tasks.append(handle_txs_task())
+        tasks.append(retry_messages_task(config=config, shared_stats=shared_stats))
+        tasks.append(handle_txs_task(config))
 
     if config.ipfs.enabled.value:
         tasks.append(reconnect_ipfs_job(config))

--- a/src/aleph/jobs/job_utils.py
+++ b/src/aleph/jobs/job_utils.py
@@ -1,15 +1,17 @@
 import asyncio
+from itertools import groupby
+from typing import Callable, cast
 from typing import Dict
 from typing import Iterable, Tuple
 
+from configmanager import Config
+
 import aleph.config
 from aleph.model import init_db_globals
+from aleph.model.db_bulk_operation import DbBulkOperation
 from aleph.services.ipfs.common import init_ipfs_globals
 from aleph.services.p2p import init_p2p_client
-from configmanager import Config
-from typing import Awaitable, Callable, List
-from aleph.model.db_bulk_operation import DbBulkOperation
-from itertools import groupby
+from aleph.toolkit.split import split_iterable
 
 
 def prepare_loop(config_values: Dict) -> Tuple[asyncio.AbstractEventLoop, Config]:
@@ -45,32 +47,29 @@ async def perform_db_operations(db_operations: Iterable[DbBulkOperation]) -> Non
         await collection.collection.bulk_write(mongo_ops)
 
 
-async def gather_and_perform_db_operations(
-    tasks: List[Awaitable[List[DbBulkOperation]]],
+async def process_job_results(
+    tasks: Iterable[asyncio.Task],  # TODO: switch to a generic type when moving to 3.9+
     on_error: Callable[[BaseException], None],
-) -> None:
+):
     """
     Processes the result of the pending TX/message tasks.
 
-    Gathers the results of the tasks passed in input, handles exceptions
-    and performs DB operations.
+    Splits successful and failed jobs, handles exceptions and performs
+    DB operations.
 
-    :param tasks: Job tasks. Each of these tasks must return a list of
-                  DbBulkOperation objects.
+    :param tasks: Finished job tasks. Each of these tasks must return a list of
+                  DbBulkOperation objects. It is up to the caller to determine
+                  when tasks are done, for example by using asyncio.wait.
     :param on_error: Error callback function. This function will be called
                      on each error from one of the tasks.
     """
-    task_results = await asyncio.gather(*tasks, return_exceptions=True)
+    successes, errors = split_iterable(tasks, lambda t: t.exception() is None)
 
-    errors = [op for op in task_results if isinstance(op, BaseException)]
     for error in errors:
-        on_error(error)
+        # mypy sees Optional[BaseException] otherwise
+        exception = cast(BaseException, error.exception())
+        on_error(exception)
 
-    db_operations = (
-        op
-        for operations in task_results
-        if not isinstance(operations, BaseException)
-        for op in operations
-    )
+    db_operations = (op for success in successes for op in success.result())
 
     await perform_db_operations(db_operations)

--- a/src/aleph/toolkit/split.py
+++ b/src/aleph/toolkit/split.py
@@ -1,0 +1,17 @@
+from typing import Callable, Iterable, List, Tuple, TypeVar
+
+
+T = TypeVar("T")
+
+
+def split_iterable(iterable: Iterable[T], cond: Callable[[T], bool]) -> Tuple[List[T], List[T]]:
+    matches = []
+    others = []
+
+    for x in iterable:
+        if cond(x):
+            matches.append(x)
+        else:
+            others.append(x)
+
+    return matches, others

--- a/src/aleph/web/controllers/metrics.py
+++ b/src/aleph/web/controllers/metrics.py
@@ -7,13 +7,15 @@ from typing import Dict, Optional
 from urllib.parse import urljoin
 
 import aiohttp
-import aleph.model
 from aiocache import cached
-from aleph import __version__
-from aleph.config import get_config
+from aleph_message.models import MessageType
 from dataclasses_json import DataClassJsonMixin
 from requests import HTTPError
 from web3 import Web3
+
+import aleph.model
+from aleph import __version__
+from aleph.config import get_config
 
 LOGGER = getLogger("WEB.metrics")
 
@@ -74,12 +76,14 @@ class Metrics(DataClassJsonMixin):
     pyaleph_status_chain_eth_last_committed_height: Optional[int]
 
     pyaleph_processing_pending_messages_seen_ids_total: Optional[int] = None
-    pyaleph_processing_pending_messages_gtasks_total: Optional[int] = None
     pyaleph_processing_pending_messages_tasks_total: Optional[int] = None
+    pyaleph_processing_pending_messages_aggregate_tasks: int = 0
+    pyaleph_processing_pending_messages_forget_tasks: int = 0
+    pyaleph_processing_pending_messages_post_tasks: int = 0
+    pyaleph_processing_pending_messages_program_tasks: int = 0
+    pyaleph_processing_pending_messages_store_tasks: int = 0
+
     pyaleph_processing_pending_messages_action_total: Optional[int] = None
-    pyaleph_processing_pending_messages_messages_actions_total: Optional[int] = None
-    pyaleph_processing_pending_messages_i_total: Optional[int] = None
-    pyaleph_processing_pending_messages_j_total: Optional[int] = None
 
     pyaleph_status_sync_messages_reference_total: Optional[int] = None
     pyaleph_status_sync_messages_remaining_total: Optional[int] = None
@@ -177,24 +181,24 @@ async def get_metrics(shared_stats: dict) -> Metrics:
         pyaleph_processing_pending_messages_seen_ids_total=shared_stats.get(
             "retry_messages_job_seen_ids"
         ),
-        pyaleph_processing_pending_messages_gtasks_total=shared_stats.get(
-            "retry_messages_job_gtasks"
-        ),
         pyaleph_processing_pending_messages_tasks_total=shared_stats.get(
             "retry_messages_job_tasks"
         ),
-        pyaleph_processing_pending_messages_action_total=shared_stats.get(
-            "retry_messages_job_actions"
-        ),
-        pyaleph_processing_pending_messages_messages_actions_total=shared_stats.get(
-            "retry_messages_job_messages_actions"
-        ),
-        pyaleph_processing_pending_messages_i_total=shared_stats.get(
-            "retry_messages_job_i"
-        ),
-        pyaleph_processing_pending_messages_j_total=shared_stats.get(
-            "retry_messages_job_j"
-        ),
+        pyaleph_processing_pending_messages_aggregate_tasks=shared_stats[
+            "message_jobs"
+        ][MessageType.aggregate],
+        pyaleph_processing_pending_messages_forget_tasks=shared_stats["message_jobs"][
+            MessageType.forget
+        ],
+        pyaleph_processing_pending_messages_post_tasks=shared_stats["message_jobs"][
+            MessageType.post
+        ],
+        pyaleph_processing_pending_messages_program_tasks=shared_stats["message_jobs"][
+            MessageType.program
+        ],
+        pyaleph_processing_pending_messages_store_tasks=shared_stats["message_jobs"][
+            MessageType.store
+        ],
         pyaleph_status_sync_messages_total=sync_messages_total,
         pyaleph_status_sync_permanent_files_total=await aleph.model.db.filepins.estimated_document_count(),
         pyaleph_status_sync_messages_reference_total=sync_messages_reference_total,

--- a/tests/web/controllers/test_metrics.py
+++ b/tests/web/controllers/test_metrics.py
@@ -49,6 +49,11 @@ def test_metrics():
         pyaleph_status_sync_pending_messages_total=456,
         pyaleph_status_sync_pending_txs_total=0,
         pyaleph_status_chain_eth_last_committed_height=0,
+        pyaleph_processing_pending_messages_aggregate_tasks=0,
+        pyaleph_processing_pending_messages_forget_tasks=0,
+        pyaleph_processing_pending_messages_post_tasks=0,
+        pyaleph_processing_pending_messages_program_tasks=0,
+        pyaleph_processing_pending_messages_store_tasks=0,
     )
 
     assert format_dataclass_for_prometheus(
@@ -59,5 +64,10 @@ def test_metrics():
           'pyaleph_status_sync_permanent_files_total 1999\n'
           'pyaleph_status_sync_pending_messages_total 456\n'
           'pyaleph_status_sync_pending_txs_total 0\n'
-          'pyaleph_status_chain_eth_last_committed_height 0'
+          'pyaleph_status_chain_eth_last_committed_height 0\n'
+          'pyaleph_processing_pending_messages_aggregate_tasks 0\n'
+          'pyaleph_processing_pending_messages_forget_tasks 0\n'
+          'pyaleph_processing_pending_messages_post_tasks 0\n'
+          'pyaleph_processing_pending_messages_program_tasks 0\n'
+          'pyaleph_processing_pending_messages_store_tasks 0'
     )


### PR DESCRIPTION
Several improvements to the pending TX/message jobs.

* The jobs used to work by batch, meaning they started a series
  of N tasks and then waited for these tasks to finish before
  starting the next batch. This has the obvious disadvantage
  that the job ends up waiting on the slower tasks, while other
  tasks could have been started earlier. The jobs now have a
  max concurrency parameter that limits the total number of tasks.
  The job will automatically collect any finished task and spawn
  new ones up until the limit.

* Refactored the message processing job to get rid of the i/j
  logic that modified the batch size depending on whether the job
  was processing STORE messages. The job now uses a system of
  semaphores per message type that can limit the number of tasks
  running in parallel for a specific message type. This is still
  suboptimal as using semaphores per item type would make more
  (to limit the number of tasks fetching data from the network
  or ipfs), but this feature will be implemented later.

* Several job metrics were removed, as they lost meaning:
  - pyaleph_processing_pending_messages_gtasks_total
  - pyaleph_processing_pending_messages_i_total
  - pyaleph_processing_pending_messages_j_total

  These metrics were replaced by:
  - pyaleph_processing_pending_messages_aggregate_tasks
  - pyaleph_processing_pending_messages_forget_tasks
  - pyaleph_processing_pending_messages_post_tasks
  - pyaleph_processing_pending_messages_program_tasks
  - pyaleph_processing_pending_messages_store_tasks.

* The max concurrency parameter of each job and the limits per
  message type can now be configured from the config file.