### PR TITLE
[API] Add chain query parameter for messages

### DIFF
--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -18,6 +18,7 @@ KNOWN_QUERY_FIELDS = {
     "refs",
     "contentKeys",
     "contentTypes",
+    "chains",
     "channels",
     "tags",
     "hashes",
@@ -48,6 +49,7 @@ async def get_filters(request: web.Request):
     addresses = get_query_list_field("addresses")
     refs = get_query_list_field("refs")
     content_types = get_query_list_field("contentTypes")
+    chains = get_query_list_field("chains")
     channels = get_query_list_field("channels")
     tags = get_query_list_field("tags")
     hashes = get_query_list_field("hashes")
@@ -79,6 +81,9 @@ async def get_filters(request: web.Request):
 
     if tags is not None:
         filters.append({"content.content.tags": {"$elemMatch": {"$in": tags}}})
+
+    if chains is not None:
+        filters.append({"chain": {"$in": chains}})
 
     if channels is not None:
         filters.append({"channel": {"$in": channels}})

--- a/tests/api/test_messages.py
+++ b/tests/api/test_messages.py
@@ -12,8 +12,8 @@ from aleph.web import create_app
 MESSAGES_URI = "/api/v0/messages.json"
 
 
-def get_messages_by_channel(messages: Iterable[Dict], channel: str) -> List[Dict]:
-    return [msg for msg in messages if msg["channel"] == channel]
+def get_messages_by_keys(messages: Iterable[Dict], **keys) -> List[Dict]:
+    return [msg for msg in messages if all(msg[k] == v for k, v in keys.items())]
 
 
 def assert_messages_equal(messages: Iterable[Dict], expected_messages: Iterable[Dict]):
@@ -22,8 +22,10 @@ def assert_messages_equal(messages: Iterable[Dict], expected_messages: Iterable[
     for expected_message in expected_messages:
         message = messages_by_hash[expected_message["item_hash"]]
 
+        assert message["chain"] == expected_message["chain"]
         assert message["channel"] == expected_message["channel"]
         assert message["content"] == expected_message["content"]
+        assert message["item_content"] == expected_message["item_content"]
         assert message["sender"] == expected_message["sender"]
         assert message["signature"] == expected_message["signature"]
 
@@ -71,7 +73,7 @@ async def test_get_messages_filter_by_channel(fixture_messages, aiohttp_client):
     data = await fetch_messages_by_channel("unit-tests")
     messages = data["messages"]
 
-    unit_test_messages = get_messages_by_channel(fixture_messages, "unit-tests")
+    unit_test_messages = get_messages_by_keys(fixture_messages, channel="unit-tests")
 
     assert len(messages) == len(unit_test_messages)
     assert_messages_equal(messages, unit_test_messages)
@@ -79,15 +81,40 @@ async def test_get_messages_filter_by_channel(fixture_messages, aiohttp_client):
     data = await fetch_messages_by_channel("aggregates-tests")
     messages = data["messages"]
 
-    aggregates_test_messages = get_messages_by_channel(fixture_messages, "aggregates-tests")
+    aggregates_test_messages = get_messages_by_keys(
+        fixture_messages, channel="aggregates-tests"
+    )
     assert_messages_equal(messages, aggregates_test_messages)
 
     # Multiple channels
     data = await fetch_messages_by_channel("aggregates-tests,unit-tests")
     messages = data["messages"]
 
-    assert_messages_equal(messages, itertools.chain(unit_test_messages, aggregates_test_messages))
+    assert_messages_equal(
+        messages, itertools.chain(unit_test_messages, aggregates_test_messages)
+    )
 
     # Nonexistent channel
     data = await fetch_messages_by_channel("none-pizza-with-left-beef")
     assert data["messages"] == []
+
+
+@pytest.mark.asyncio
+async def test_get_messages_filter_by_chain(fixture_messages, aiohttp_client):
+    app = create_app()
+    client = await aiohttp_client(app)
+
+    async def fetch_messages_by_chain(chain: str) -> Dict:
+        response = await client.get(MESSAGES_URI, params={"chains": chain})
+        assert response.status == 200, await response.text()
+        return await response.json()
+
+    eth_data = await fetch_messages_by_chain("ETH")
+    eth_messages = eth_data["messages"]
+    assert_messages_equal(
+        eth_messages, get_messages_by_keys(fixture_messages, chain="ETH")
+    )
+
+    fake_chain_data = await fetch_messages_by_chain("2CHAINZ")
+    fake_chain_messages = fake_chain_data["messages"]
+    assert fake_chain_messages == []


### PR DESCRIPTION
Users can now specify one or more chains to filter messages
in the messages API.