### PR TITLE
[API] Add content hash query parameter for messages

### DIFF
--- a/src/aleph/model/messages.py
+++ b/src/aleph/model/messages.py
@@ -40,6 +40,7 @@ class Message(BaseClass):
         IndexModel([("sender", ASCENDING)]),
         IndexModel([("channel", ASCENDING)]),
         IndexModel([("content.address", ASCENDING)]),
+        IndexModel([("content.item_hash", ASCENDING)]),
         IndexModel([("content.key", ASCENDING)]),
         IndexModel([("content.ref", ASCENDING)]),
         IndexModel([("content.type", ASCENDING)]),

--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -16,6 +16,7 @@ KNOWN_QUERY_FIELDS = {
     "msgType",
     "addresses",
     "refs",
+    "contentHashes",
     "contentKeys",
     "contentTypes",
     "chains",
@@ -48,12 +49,13 @@ async def get_filters(request: web.Request):
     filters: List[Dict[str, Any]] = []
     addresses = get_query_list_field("addresses")
     refs = get_query_list_field("refs")
+    content_keys = get_query_list_field("contentKeys")
+    content_hashes = get_query_list_field("contentHashes")
     content_types = get_query_list_field("contentTypes")
     chains = get_query_list_field("chains")
     channels = get_query_list_field("channels")
     tags = get_query_list_field("tags")
     hashes = get_query_list_field("hashes")
-    content_keys = get_query_list_field("contentKeys")
 
     date_filters = prepare_date_filters(request, "time")
 
@@ -69,6 +71,9 @@ async def get_filters(request: web.Request):
                 ]
             }
         )
+
+    if content_hashes is not None:
+        filters.append({"content.item_hash": {"$in": content_hashes}})
 
     if content_keys is not None:
         filters.append({"content.key": {"$in": content_keys}})

--- a/tests/api/test_messages.py
+++ b/tests/api/test_messages.py
@@ -118,3 +118,25 @@ async def test_get_messages_filter_by_chain(fixture_messages, aiohttp_client):
     fake_chain_data = await fetch_messages_by_chain("2CHAINZ")
     fake_chain_messages = fake_chain_data["messages"]
     assert fake_chain_messages == []
+
+
+@pytest.mark.asyncio
+async def test_get_messages_filter_by_content_hash(fixture_messages, aiohttp_client):
+    app = create_app()
+    client = await aiohttp_client(app)
+
+    async def fetch_messages_by_content_hash(item_hash: str) -> Dict:
+        response = await client.get(MESSAGES_URI, params={"contentHashes": item_hash})
+        assert response.status == 200, await response.text()
+        return await response.json()
+
+    content_hash = "5ccdd7bccfbc5955e2e40166dd0cdea0b093154fd87bc2bea57e7c768cde2f21"
+    data = await fetch_messages_by_content_hash(content_hash)
+    messages = data["messages"]
+    assert_messages_equal(
+        messages, get_messages_by_keys(fixture_messages, item_hash="2953f0b52beb79fc0ed1bc455346fdcb530611605e16c636778a0d673d7184af")
+    )
+
+    fake_hash_data = await fetch_messages_by_content_hash("1234")
+    fake_hash_messages = fake_hash_data["messages"]
+    assert fake_hash_messages == []


### PR DESCRIPTION
Users can now specify one or more content hashes to filter
messages in the message API with the new `contentHashes`
query parameter. This new parameter filters messages
on their `content.item_hash` field.