### PR TITLE
[Dependencies] Add dependency to aleph-message

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     aiohttp==3.8.1
     aioipfs@git+https://github.com/aleph-im/aioipfs.git@76d5624661e879a13b70f3ea87dc9c9604c7eda7
     aleph-client==0.4.6
+    aleph-message==0.1.18
     coincurve==15.0.1
     configmanager==1.35.1
     configparser==5.2.0


### PR DESCRIPTION
The dependency to determine the version of aleph-message was
missing and only relied on the dependency through aleph-client.