### PR TITLE
[Forget] Forget aggregates

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     aiohttp==3.8.1
     aioipfs@git+https://github.com/aleph-im/aioipfs.git@76d5624661e879a13b70f3ea87dc9c9604c7eda7
     aleph-client==0.4.6
-    aleph-message==0.1.18
+    aleph-message==0.1.19
     coincurve==15.0.1
     configmanager==1.35.1
     configparser==5.2.0


### PR DESCRIPTION
Added support for the new `aggregates` field in FORGET messages.
Using this field, users can now specify one or more aggregates
to forget. This will lead to the deletion of all the messages
linked to these aggregates.

For now, the implementation simply lists all the messages stored
on the node and deletes them.