### PR TITLE
[Fix] type error in storage/forget handlers

### DIFF
--- a/src/aleph/handlers/forget.py
+++ b/src/aleph/handlers/forget.py
@@ -212,7 +212,10 @@ async def get_target_message_info(target_hash: str) -> Optional[TargetMessageInf
 
 async def handle_forget_message(message: Dict, content: Dict):
     # Parsing and validation
-    forget_message = ForgetMessage(**message, content=content)
+    # TODO: this is a temporary fix to release faster, finish od-message-models-in-pipeline
+    message["content"] = content
+
+    forget_message = ForgetMessage(**message)
     logger.debug(f"Handling forget message {forget_message.item_hash}")
 
     for target_hash in forget_message.content.hashes:

--- a/src/aleph/handlers/storage.py
+++ b/src/aleph/handlers/storage.py
@@ -31,10 +31,13 @@ async def handle_new_storage(message: Dict, content: Dict):
     if not config.storage.store_files.value:
         return True  # Ignore
 
+    # TODO: this is a temporary fix to release faster, finish od-message-models-in-pipeline
+    message["content"] = content
+
     # TODO: ideally the content should be transformed earlier, but this requires more clean up
     #       (ex: no more in place modification of content, simplification of the flow)
     try:
-        store_message = StoreMessage(**message, content=content)
+        store_message = StoreMessage(**message)
     except ValidationError as e:
         print(e)
         return -1  # Invalid store message, discard


### PR DESCRIPTION
Implemented a temporary fix to resolve a TypeError that sometimes
occurs in the forget/storage handler. When building Aleph message
content models, the content would sometimes be passed twice to
the constructor, once in the message itself and a second time
explicitly with the `content` key.

We fix this by setting the `content` key directly in the message.
This is a temporary fix until Pydantic models are used everywhere
in the pipeline.