### PR TITLE
[Fix] Avoid key errors in Pydantic validators

### DIFF
--- a/src/aleph/schemas/pending_messages.py
+++ b/src/aleph/schemas/pending_messages.py
@@ -33,7 +33,8 @@ from aleph_message.models import (
 )
 from aleph_message.models import MessageType, ItemType
 from pydantic import BaseModel, root_validator, validator
-from aleph.exceptions import InvalidMessageError
+
+from aleph.exceptions import InvalidMessageError, UnknownHashError
 from aleph.utils import item_type_from_hash
 
 MAX_INLINE_SIZE = 200000  # 200kb max inline content size.
@@ -64,12 +65,19 @@ class BasePendingMessage(BaseModel):
         Sets the default value for item_type, if required.
         """
 
+        item_hash = values.get("item_hash")
+        if item_hash is None:
+            raise ValueError("Could not determine item hash")
         item_content = values.get("item_content")
-        default_item_type = (
-            item_type_from_hash(values["item_hash"])
-            if item_content is None
-            else ItemType.inline
-        )
+
+        try:
+            default_item_type = (
+                item_type_from_hash(item_hash)
+                if item_content is None
+                else ItemType.inline
+            )
+        except UnknownHashError:
+            raise ValueError(f"Unexpected hash type: '{item_hash}'")
 
         input_item_type = values.get("item_type")
         item_type = input_item_type or default_item_type
@@ -100,11 +108,19 @@ class BasePendingMessage(BaseModel):
         Checks that the item hash of the message matches the one inferred from the hash.
         Only applicable to storage/ipfs item types.
         """
-        item_type = ItemType(values["item_type"])
+        item_type_value = values.get("item_type")
+        if item_type_value is None:
+            raise ValueError("Could not determine item type")
+
+        item_type = ItemType(item_type_value)
         if item_type == ItemType.inline:
             return values
 
-        expected_item_type = item_type_from_hash(values["item_hash"])
+        item_hash = values.get("item_hash")
+        if item_hash is None:
+            raise ValueError("Could not determine item hash")
+
+        expected_item_type = item_type_from_hash(item_hash)
         if item_type != expected_item_type:
             raise ValueError(
                 f"Expected {expected_item_type} based on hash but item type is {item_type}."
@@ -118,21 +134,27 @@ class BasePendingMessage(BaseModel):
         the hash of the item content.
         """
 
-        item_type = values["item_type"]
+        item_type = values.get("item_type")
+        if item_type is None:
+            raise ValueError("Could not determine item type")
+
         if item_type == ItemType.inline:
-            item_content: str = values["item_content"]
+            item_content: str = values.get("item_content")
+            if item_content is None:
+                raise ValueError("Could not find inline item content")
 
             computed_hash: str = sha256(item_content.encode()).hexdigest()
             if v != computed_hash:
                 raise ValueError(
-                    "'item_hash' do not match 'sha256(item_content)'"
+                    "'item_hash' does not match 'sha256(item_content)'"
                     f", expecting {computed_hash}"
                 )
         elif item_type == ItemType.ipfs:
             # TODO: CHeck that the hash looks like an IPFS multihash
             pass
         else:
-            assert item_type == ItemType.storage
+            if item_type != ItemType.storage:
+                raise ValueError(f"Unknown item type: '{item_type}'")
         return v
 
 

--- a/tests/schemas/test_pending_messages.py
+++ b/tests/schemas/test_pending_messages.py
@@ -203,6 +203,72 @@ def test_default_item_type_ipfs():
     assert message.item_type == ItemType.ipfs
 
 
+def test_invalid_item_type():
+    """
+    Tests a message with an uppercase item type instead of lower case.
+    """
+
+    message_dict = {
+        "_id": None,
+        "chain": "ETH",
+        "channel": "ANIMA_MAINNET",
+        "confirmed": False,
+        "item_hash": "c6c9df8d5b5dcd5cf74562c9d383308c354a5238d3b0d9db10d931b250490600",
+        "item_type": "STORAGE",
+        "sender": "0x989Cfa25243C07b90Bedc673Fe6Df69B5B0D675C",
+        "signature": "0x63e9dd351ff6735bb41c2658d95828bd0dbc14fc64eee119114fd7e84fa737f157c3b38ae7c5ca30a73c03e3794f35c94282b5fc9379d31b43f913d1c18300ca01",
+        "time": 1653989834,
+        "type": "AGGREGATE",
+    }
+
+    with pytest.raises(InvalidMessageError):
+        _ = parse_message(message_dict)
+
+
+def test_invalid_chain():
+    """
+    Tests a message sent on a chain that does not exist.
+    """
+
+    message_dict = {
+        "_id": None,
+        "chain": "MEGA_CHAIN",
+        "channel": "ANIMA_MAINNET",
+        "confirmed": False,
+        "item_hash": "c6c9df8d5b5dcd5cf74562c9d383308c354a5238d3b0d9db10d931b250490600",
+        "item_type": "storage",
+        "sender": "0x989Cfa25243C07b90Bedc673Fe6Df69B5B0D675C",
+        "signature": "0x63e9dd351ff6735bb41c2658d95828bd0dbc14fc64eee119114fd7e84fa737f157c3b38ae7c5ca30a73c03e3794f35c94282b5fc9379d31b43f913d1c18300ca01",
+        "time": 1653989834,
+        "type": "AGGREGATE",
+    }
+
+    with pytest.raises(InvalidMessageError):
+        _ = parse_message(message_dict)
+
+
+def test_invalid_hash():
+    """
+    Tests a message sent on a chain that does not exist.
+    """
+
+    message_dict = {
+        "_id": None,
+        "chain": "ETH",
+        "channel": "ANIMA_MAINNET",
+        "confirmed": False,
+        "item_hash": "deadbeef",
+        "item_type": "storage",
+        "sender": "0x989Cfa25243C07b90Bedc673Fe6Df69B5B0D675C",
+        "signature": "0x63e9dd351ff6735bb41c2658d95828bd0dbc14fc64eee119114fd7e84fa737f157c3b38ae7c5ca30a73c03e3794f35c94282b5fc9379d31b43f913d1c18300ca01",
+        "time": 1653989834,
+        "type": "AGGREGATE",
+    }
+
+    with pytest.raises(InvalidMessageError):
+        _ = parse_message(message_dict)
+
+
 def test_parse_none():
     with pytest.raises(InvalidMessageError):
         _ = parse_message(None)


### PR DESCRIPTION
Fixed an issue where the validators would fail when trying to
access the value of another field for which an error was already
raised. Pydantic validators are all run, even if errors occur in
previous validators.