### PR TITLE
[Doc] Fix upgrade guide for migrations

### DIFF
--- a/docs/guides/upgrade.rst
+++ b/docs/guides/upgrade.rst
@@ -46,7 +46,9 @@ Upgrade your node
     docker-compose [-f <docker-compose-file>] down
 
     docker-compose [-f <docker-compose-file>] \
-            run pyaleph /opt/pyaleph/migrations/config_updater.py \
+            run \
+            --entrypoint /opt/pyaleph/migrations/config_updater.py \
+            pyaleph \
             --key-dir /opt/pyaleph/keys \
             --key-file /opt/pyaleph/keys/node-secret.key \
             --config /opt/pyaleph/config.yml \


### PR DESCRIPTION
The new Dockerfile sets the entrypoint to the startup script.
This fix tells users how to override this entrypoint to run
migrations when upgrading a node.