### PR TITLE
[Fix] Set default item_type in messages

### DIFF
--- a/src/aleph/network.py
+++ b/src/aleph/network.py
@@ -69,6 +69,10 @@ async def check_message(
 
     message = parse_message(message_dict)
 
+    # TODO: this is a temporary fix to set the item_type of the message to the correct
+    #       value. This should be replaced by a full use of Pydantic models.
+    message_dict["item_type"] = message.item_type.value
+
     if trusted:
         # only in the case of a message programmatically built here
         # from legacy native chain signing for example (signing offloaded)

--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -21,7 +21,7 @@ from aleph.services.ipfs.storage import get_ipfs_content
 from aleph.services.ipfs.storage import pin_add as ipfs_pin_add
 from aleph.services.p2p.http import request_hash as p2p_http_request_hash
 from aleph.services.p2p.singleton import get_streamer
-from aleph.utils import get_sha256, run_in_executor
+from aleph.utils import get_sha256, run_in_executor, item_type_from_hash
 
 LOGGER = logging.getLogger("STORAGE")
 
@@ -67,7 +67,7 @@ async def json_async_loads(s: AnyStr):
 
 
 async def get_message_content(message: Dict) -> MessageContent:
-    item_type: str = message.get("item_type", ItemType.ipfs)
+    item_type: str = message["item_type"]
     item_hash = message["item_hash"]
 
     if item_type in (ItemType.ipfs, ItemType.storage):


### PR DESCRIPTION
Fix for a regression in the message validation. If the user did
not specify the item type of the message, the default value was
not added to the message anymore, resulting in errors down
the line.