### PR TITLE
[Fix] Set default item type early

### DIFF
--- a/src/aleph/network.py
+++ b/src/aleph/network.py
@@ -69,10 +69,6 @@ async def check_message(
 
     message = parse_message(message_dict)
 
-    # TODO: this is a temporary fix to set the item_type of the message to the correct
-    #       value. This should be replaced by a full use of Pydantic models.
-    message_dict["item_type"] = message.item_type.value
-
     if trusted:
         # only in the case of a message programmatically built here
         # from legacy native chain signing for example (signing offloaded)


### PR DESCRIPTION
Fix for the previous fix. Some messages end up with check_message
set to False, bypassing the validation in `incoming`. We now
set the default value of `item_type` as the first thing in
the function.

Note that this is a temporary fix that will disappear as soon
as we use Pydantic models everywhere.