### PR TITLE
[Messages] Use Pydantic message models everywhere

### DIFF
--- a/src/aleph/handlers/forget.py
+++ b/src/aleph/handlers/forget.py
@@ -6,13 +6,12 @@ from typing import Dict, Optional, List
 
 from aioipfs.api import RepoAPI
 from aioipfs.exceptions import NotPinnedError
-from aleph_message.models import ForgetMessage, MessageType
-from aleph_message.models import ItemType
-from pydantic import ValidationError
+from aleph_message.models import ItemType, MessageType
 
 from aleph.model.filepin import PermanentPin
 from aleph.model.hashes import delete_value
 from aleph.model.messages import Message
+from aleph.schemas.validated_message import ValidatedForgetMessage
 from aleph.services.ipfs.common import get_ipfs_api
 from aleph.utils import item_type_from_hash
 
@@ -118,7 +117,7 @@ async def garbage_collect(storage_hash: str, storage_type: ItemType):
 
 
 async def is_allowed_to_forget(
-    target_info: TargetMessageInfo, by: ForgetMessage
+    target_info: TargetMessageInfo, by: ValidatedForgetMessage
 ) -> bool:
     """Check if a forget message is allowed to 'forget' the target message given its hash."""
     # Both senders are identical:
@@ -136,7 +135,7 @@ async def is_allowed_to_forget(
 
 
 async def forget_if_allowed(
-    target_info: TargetMessageInfo, forget_message: ForgetMessage
+    target_info: TargetMessageInfo, forget_message: ValidatedForgetMessage
 ) -> None:
     """Forget a message.
 
@@ -210,17 +209,8 @@ async def get_target_message_info(target_hash: str) -> Optional[TargetMessageInf
     return TargetMessageInfo.from_db_object(message_dict)
 
 
-async def handle_forget_message(message: Dict, content: Dict) -> bool:
+async def handle_forget_message(forget_message: ValidatedForgetMessage) -> bool:
     # Parsing and validation
-    # TODO: this is a temporary fix to release faster, finish od-message-models-in-pipeline
-    message["content"] = content
-
-    try:
-        forget_message = ForgetMessage(**message)
-    except ValidationError as e:
-        logger.error("Invalid forget message: %s", e)
-        return False
-
     logger.debug(f"Handling forget message {forget_message.item_hash}")
     hashes_to_forget = forget_message.content.hashes
 

--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -19,6 +19,7 @@ from aleph.model.db_bulk_operation import DbBulkOperation
 from aleph.model.pending import PendingMessage
 from aleph.services.p2p import singleton
 from .job_utils import prepare_loop, process_job_results
+from ..schemas.pending_messages import parse_message
 
 LOGGER = getLogger("jobs.pending_messages")
 
@@ -48,9 +49,11 @@ async def handle_pending_message(
     seen_ids: Dict[Tuple, int],
 ) -> List[DbBulkOperation]:
 
+    message = parse_message(pending["message"])
+
     async with sem:
         status, operations = await incoming(
-            pending["message"],
+            pending_message=message,
             chain_name=pending["source"].get("chain_name"),
             tx_hash=pending["source"].get("tx_hash"),
             height=pending["source"].get("height"),

--- a/src/aleph/schemas/base_messages.py
+++ b/src/aleph/schemas/base_messages.py
@@ -1,0 +1,93 @@
+"""
+Base (abstract) class for messages.
+"""
+
+from hashlib import sha256
+from typing import Optional, Generic, TypeVar
+
+from aleph_message.models import (
+    BaseContent,
+    Chain,
+)
+from aleph_message.models import MessageType, ItemType
+from pydantic import root_validator, validator
+from pydantic.generics import GenericModel
+
+from aleph.utils import item_type_from_hash
+
+MType = TypeVar("MType", bound=MessageType)
+ContentType = TypeVar("ContentType", bound=BaseContent)
+
+
+class AlephBaseMessage(GenericModel, Generic[MType, ContentType]):
+    """
+    The base structure of an Aleph message.
+    All the fields of this class appear in all the representations
+    of messages on the Aleph network.
+    """
+
+    sender: str
+    chain: Chain
+    signature: str
+    type: MType
+    item_content: Optional[str]
+    item_type: ItemType
+    item_hash: str
+    time: float
+    channel: Optional[str] = None
+    content: Optional[ContentType] = None
+
+    @root_validator()
+    def check_item_type(cls, values):
+        """
+        Checks that the item hash of the message matches the one inferred from the hash.
+        Only applicable to storage/ipfs item types.
+        """
+        item_type_value = values.get("item_type")
+        if item_type_value is None:
+            raise ValueError("Could not determine item type")
+
+        item_type = ItemType(item_type_value)
+        if item_type == ItemType.inline:
+            return values
+
+        item_hash = values.get("item_hash")
+        if item_hash is None:
+            raise ValueError("Could not determine item hash")
+
+        expected_item_type = item_type_from_hash(item_hash)
+        if item_type != expected_item_type:
+            raise ValueError(
+                f"Expected {expected_item_type} based on hash but item type is {item_type}."
+            )
+        return values
+
+    @validator("item_hash")
+    def check_item_hash(cls, v, values):
+        """
+        For inline item types, check that the item hash is equal to
+        the hash of the item content.
+        """
+
+        item_type = values.get("item_type")
+        if item_type is None:
+            raise ValueError("Could not determine item type")
+
+        if item_type == ItemType.inline:
+            item_content: str = values.get("item_content")
+            if item_content is None:
+                raise ValueError("Could not find inline item content")
+
+            computed_hash: str = sha256(item_content.encode()).hexdigest()
+            if v != computed_hash:
+                raise ValueError(
+                    "'item_hash' does not match 'sha256(item_content)'"
+                    f", expecting {computed_hash}"
+                )
+        elif item_type == ItemType.ipfs:
+            # TODO: CHeck that the hash looks like an IPFS multihash
+            pass
+        else:
+            if item_type != ItemType.storage:
+                raise ValueError(f"Unknown item type: '{item_type}'")
+        return v

--- a/src/aleph/schemas/message_content.py
+++ b/src/aleph/schemas/message_content.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional, Union
+
+
+class ContentSource(str, Enum):
+    """
+    Defines the source of the content of a message.
+
+    Message content can be fetched from different sources depending on the procedure followed by the user sending
+    a particular message. This enum determines where the node found the content.
+    """
+
+    DB = "DB"
+    P2P = "P2P"
+    IPFS = "IPFS"
+    INLINE = "inline"
+
+
+@dataclass
+class StoredContent:
+    hash: str
+    source: Optional[ContentSource]
+
+
+@dataclass
+class RawContent(StoredContent):
+    value: bytes
+
+    def __len__(self):
+        return len(self.value)
+
+
+@dataclass
+class MessageContent(StoredContent):
+    value: Any
+    raw_value: Union[bytes, str]

--- a/src/aleph/schemas/validated_message.py
+++ b/src/aleph/schemas/validated_message.py
@@ -1,0 +1,169 @@
+"""
+Schemas for validated messages, as stored in the messages collection.
+Validated messages are fully loaded, i.e. their content field is
+always present, unlike pending messages.
+"""
+
+from typing import List, Literal, Optional, Generic, Dict, Type, Any
+
+from aleph_message.models import (
+    MessageConfirmation,
+    AggregateContent,
+    ForgetContent,
+    MessageType,
+    PostContent,
+    ProgramContent,
+    StoreContent,
+)
+from pydantic import BaseModel, Field
+
+from aleph.schemas.base_messages import AlephBaseMessage, ContentType, MType
+from aleph.schemas.pending_messages import (
+    BasePendingMessage,
+    PendingAggregateMessage,
+    PendingForgetMessage,
+    PendingPostMessage,
+    PendingProgramMessage,
+    PendingStoreMessage,
+)
+from .message_content import MessageContent
+
+
+class EngineInfo(BaseModel):
+    hash: str = Field(alias="Hash")
+    size: int = Field(alias="Size")
+    cumulative_size: int = Field(alias="CumulativeSize")
+    blocks: int = Field(alias="Blocks")
+    type: str = Field(alias="Type")
+
+
+class StoreContentWithMetadata(StoreContent):
+    content_type: Literal["directory", "file"]
+    size: int
+    engine_info: Optional[EngineInfo] = None
+
+    @classmethod
+    def from_content(cls, store_content: StoreContent):
+        return cls(
+            address=store_content.address,
+            time=store_content.time,
+            item_type=store_content.item_type,
+            item_hash=store_content.item_hash,
+            content_type="file",
+            size=0,
+            engine_info=None,
+        )
+
+
+class BaseValidatedMessage(AlephBaseMessage, Generic[MType, ContentType]):
+    confirmed: bool
+    size: int
+    content: ContentType
+    confirmations: List[MessageConfirmation] = Field(default_factory=list)
+    forgotten_by: List[str] = Field(default_factory=list)
+
+
+class ValidatedAggregateMessage(
+    BaseValidatedMessage[Literal[MessageType.aggregate], AggregateContent]  # type: ignore
+):
+    pass
+
+
+class ValidatedForgetMessage(
+    BaseValidatedMessage[Literal[MessageType.forget], ForgetContent]  # type: ignore
+):
+    pass
+
+
+class ValidatedPostMessage(
+    BaseValidatedMessage[Literal[MessageType.post], PostContent]  # type: ignore
+):
+    pass
+
+
+class ValidatedProgramMessage(
+    BaseValidatedMessage[Literal[MessageType.program], ProgramContent]  # type: ignore
+):
+    pass
+
+
+class ValidatedStoreMessage(
+    BaseValidatedMessage[Literal[MessageType.store], StoreContent]  # type: ignore
+):
+    pass
+
+
+def validate_pending_message(
+    pending_message: BasePendingMessage[MType, ContentType],
+    content: MessageContent,
+    confirmations: List[MessageConfirmation],
+) -> BaseValidatedMessage[MType, ContentType]:
+
+    type_map: Dict[Type[BasePendingMessage], Type[BaseValidatedMessage]] = {
+        PendingAggregateMessage: ValidatedAggregateMessage,
+        PendingForgetMessage: ValidatedForgetMessage,
+        PendingPostMessage: ValidatedPostMessage,
+        PendingProgramMessage: ValidatedProgramMessage,
+        PendingStoreMessage: ValidatedStoreMessage,
+    }
+
+    # Some values may be missing in the content, adjust them
+    json_content = content.value
+    if json_content.get("address", None) is None:
+        json_content["address"] = pending_message.sender
+
+    if json_content.get("time", None) is None:
+        json_content["time"] = pending_message.time
+
+    # Note: we could use the construct method of Pydantic to bypass validation
+    # and speed up the conversion process. However, this means giving up on validation.
+    # At the time of writing, correctness seems more important than performance.
+    return type_map[type(pending_message)](
+        **pending_message.dict(exclude={"content"}),
+        content=content.value,
+        confirmed=bool(confirmations),
+        confirmations=confirmations,
+        size=len(content.raw_value),
+    )
+
+
+def make_confirmation_update_query(confirmations: List[MessageConfirmation]) -> Dict:
+    """
+    Creates a MongoDB update query that confirms an existing message.
+    """
+
+    # We use addToSet as multiple confirmations may be treated in //
+    if not confirmations:
+        return {"$max": {"confirmed": False}}
+
+    return {
+        "$max": {"confirmed": True},
+        "$addToSet": {
+            "confirmations": {
+                "$each": [confirmation.dict() for confirmation in confirmations]
+            }
+        },
+    }
+
+
+def make_message_upsert_query(message: BaseValidatedMessage[Any, Any]) -> Dict:
+    """
+    Creates a MongoDB upsert query to insert the message in the DB.
+    """
+
+    updates = {
+        "$set": {
+            "content": message.content.dict(exclude_none=True),
+            "size": message.size,
+            "item_content": message.item_content,
+            "item_type": message.item_type.value,
+            "channel": message.channel,
+            "signature": message.signature,
+        },
+        "$min": {"time": message.time},
+    }
+
+    # Add fields related to confirmations
+    updates.update(make_confirmation_update_query(message.confirmations))
+
+    return updates

--- a/src/aleph/services/ipfs/pubsub.py
+++ b/src/aleph/services/ipfs/pubsub.py
@@ -41,14 +41,14 @@ async def pub(topic: str, message: Union[str, bytes]):
 
 
 async def incoming_channel(topic) -> None:
-    from aleph.network import incoming_check
+    from aleph.network import get_pubsub_message
     from aleph.chains.common import process_one_message
 
     while True:
         try:
             async for mvalue in sub(topic):
                 try:
-                    message = await incoming_check(mvalue)
+                    message = await get_pubsub_message(mvalue)
                     LOGGER.debug("New message %r" % message)
                     asyncio.create_task(process_one_message(message))
                 except InvalidMessageError:

--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -14,7 +14,7 @@ from p2pclient.libp2p_stubs.peer.id import ID
 
 from aleph import __version__
 from aleph.exceptions import AlephStorageException, InvalidMessageError
-from aleph.network import incoming_check
+from aleph.network import get_pubsub_message
 from aleph.services.utils import pubsub_msg_to_dict
 from .pubsub import receive_pubsub_messages, subscribe
 
@@ -191,7 +191,7 @@ async def incoming_channel(p2p_client: P2PClient, topic: str) -> None:
                     # we should check the sender here to avoid spam
                     # and such things...
                     try:
-                        message = await incoming_check(msg_dict)
+                        message = await get_pubsub_message(msg_dict)
                     except InvalidMessageError:
                         continue
 

--- a/tests/chains/test_common.py
+++ b/tests/chains/test_common.py
@@ -9,7 +9,7 @@ from aleph.chains.common import (
 )
 from unittest.mock import MagicMock
 
-from aleph.schemas.pending_messages import BasePendingMessage
+from aleph.schemas.pending_messages import BasePendingMessage, parse_message
 
 
 @pytest.mark.asyncio
@@ -55,7 +55,7 @@ async def test_incoming_inline(mocker):
 
     mocker.patch("aleph.model.db")
 
-    msg = {
+    message_dict = {
         "chain": "NULS",
         "channel": "SYSINFO",
         "sender": "TTapAav8g3fFjxQQCjwPd4ERPnai9oya",
@@ -65,6 +65,8 @@ async def test_incoming_inline(mocker):
         "item_hash": "84afd8484912d3fa11a402e480d17e949fbf600fcdedd69674253be0320fa62c",
         "signature": "21027c108022f992f090bbe5c78ca8822f5b7adceb705ae2cd5318543d7bcdd2a74700473045022100b59f7df5333d57080a93be53b9af74e66a284170ec493455e675eb2539ac21db022077ffc66fe8dde7707038344496a85266bf42af1240017d4e1fa0d7068c588ca7",
     }
-    msg["item_type"] = "inline"
-    status, ops = await incoming(msg, check_message=True)
+    message_dict["item_type"] = "inline"
+
+    message = parse_message(message_dict)
+    status, ops = await incoming(message, check_message=True)
     assert status == IncomingStatus.MESSAGE_HANDLED

--- a/tests/chains/test_tezos.py
+++ b/tests/chains/test_tezos.py
@@ -1,9 +1,7 @@
 import pytest
 
-from aleph.chains import (
-    tezos,
-)  # TODO: this import is currently necessary because of circular dependencies
-from aleph.network import check_message
+from aleph.network import verify_signature
+from aleph.schemas.pending_messages import parse_message
 
 
 @pytest.mark.asyncio
@@ -25,7 +23,8 @@ async def test_tezos_verify_signature():
         },
     }
 
-    _ = await check_message(message_dict)
+    message = parse_message(message_dict)
+    await verify_signature(message)
 
 
 @pytest.mark.asyncio
@@ -42,4 +41,5 @@ async def test_tezos_verify_signature_ed25519():
         "item_hash": "41de1a7766c7e5fad54772470eefde63b6bef8683c4159d9179d74955009deb4",
     }
 
-    _ = await check_message(message_dict)
+    message = parse_message(message_dict)
+    await verify_signature(message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import sys
 
 import pymongo
 import pytest
@@ -11,6 +13,12 @@ from aleph.model import init_db
 from aleph.web import create_app
 
 TEST_DB = "ccn_automated_tests"
+
+
+# Add the helpers to the PYTHONPATH.
+# Note: mark the "helpers" directory as a source directory to tell PyCharm
+# about this trick and avoid IDE errors.
+sys.path.append(os.path.join(os.path.dirname(__file__), 'helpers'))
 
 
 def drop_db(db_name: str, config: Config):

--- a/tests/helpers/message_test_helpers.py
+++ b/tests/helpers/message_test_helpers.py
@@ -1,0 +1,49 @@
+import json
+from typing import Dict, List, Optional, Union
+
+from aleph_message.models import ItemType, MessageConfirmation
+
+from aleph.schemas.message_content import MessageContent, ContentSource
+from aleph.schemas.pending_messages import parse_message
+from aleph.schemas.validated_message import validate_pending_message
+
+
+def make_validated_message_from_dict(
+    message_dict: Dict,
+    raw_content: Optional[Union[str, bytes]] = None,
+    confirmations: Optional[List[MessageConfirmation]] = None,
+):
+    """
+    Creates a validated message instance from a raw message dictionary.
+    This is helpful to easily import fixtures from an API or the DB and transform
+    them into a valid object.
+
+    :param message_dict: The raw message dictionary.
+    :param raw_content: The raw content of the message, as a string or bytes.
+    :param confirmations: List of confirmations, if any.
+    """
+
+    pending_message = parse_message(message_dict)
+
+    if raw_content is None:
+        assert message_dict["item_type"] == ItemType.inline
+        raw_content = message_dict["item_content"]
+
+    content_source = (
+        ContentSource.INLINE
+        if pending_message.item_type == ItemType.inline
+        else ContentSource.P2P
+    )
+
+    message_content = MessageContent(
+        hash=pending_message.item_hash,
+        source=content_source,
+        value=json.loads(raw_content),
+        raw_value=raw_content,
+    )
+
+    return validate_pending_message(
+        pending_message=pending_message,
+        content=message_content,
+        confirmations=confirmations or [],
+    )

--- a/tests/message_processing/load_fixtures.py
+++ b/tests/message_processing/load_fixtures.py
@@ -1,7 +1,6 @@
 import json
-import os
-from typing import Dict, List
 from pathlib import Path
+from typing import Dict, List
 
 
 def load_fixture_messages(fixture: str) -> List[Dict]:

--- a/tests/message_processing/test_perform_db_operations.py
+++ b/tests/message_processing/test_perform_db_operations.py
@@ -1,6 +1,5 @@
 import pytest
-from pymongo import DeleteOne
-from pymongo import InsertOne
+from pymongo import DeleteOne, InsertOne
 
 from aleph.jobs.job_utils import perform_db_operations
 from aleph.model.db_bulk_operation import DbBulkOperation

--- a/tests/message_processing/test_process_pending_txs.py
+++ b/tests/message_processing/test_process_pending_txs.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from collections import defaultdict
 from typing import Dict, List
 
 import pytest

--- a/tests/permissions/test_check_sender_authorization.py
+++ b/tests/permissions/test_check_sender_authorization.py
@@ -1,34 +1,27 @@
-from aleph.permissions import check_sender_authorization
 import pytest
+
 from aleph.model.messages import Message
+from aleph.permissions import check_sender_authorization
+from message_test_helpers import make_validated_message_from_dict
 
 
 @pytest.mark.asyncio
 async def test_owner_is_sender():
-    message = {
-        "_id": {"$oid": "6278d1f451c0b9a4fb11c8a9"},
+    message_dict = {
         "chain": "ETH",
         "item_hash": "2a5aaf71c8767bda8eb235223a3387b310af117f42fac08f02461e90aee073b0",
         "sender": "0xdeF61fAadE93a8aaE303D083Ead5BF7a25E55a23",
         "type": "STORE",
         "channel": "TEST",
-        "confirmed": False,
-        "content": {
-            "address": "0xdeF61fAadE93a8aaE303D083Ead5BF7a25E55a23",
-            "item_type": "storage",
-            "item_hash": "e916165d63c9b1d455dc415859ec3e1da5a3c6c86cc743cbedf2203fd92a2b1b",
-            "time": 1652085236.777,
-            "size": 2780,
-            "content_type": "file",
-        },
         "item_content": '{"address":"0xdeF61fAadE93a8aaE303D083Ead5BF7a25E55a23","item_type":"storage","item_hash":"e916165d63c9b1d455dc415859ec3e1da5a3c6c86cc743cbedf2203fd92a2b1b","time":1652085236.777}',
         "item_type": "inline",
         "signature": "0x51383ef8823665bd8ea1150175be0c3745a36ea1f0d503ceb51e0d7ff1fd88a5290665564bf9c2315d97884e7448efdb8d4b4f8293b47a641c2ff43f21b6c5b61c",
-        "size": 179,
         "time": 1652085236.777,
     }
 
-    is_authorized = await check_sender_authorization(message, message["content"])
+    message = make_validated_message_from_dict(message_dict, message_dict["item_content"])
+
+    is_authorized = await check_sender_authorization(message)
     assert is_authorized
 
 
@@ -36,7 +29,7 @@ async def test_owner_is_sender():
 async def test_store_unauthorized(mocker):
     mocker.patch("aleph.permissions.get_computed_address_aggregates", return_value={})
 
-    message = {
+    message_dict = {
         "chain": "ETH",
         "channel": "TEST",
         "item_content": '{"address":"VM on executor","time":1651050219.3481126,"content":{"date":"2022-04-27T09:03:38.361081","test":true,"answer":42,"something":"interesting"},"type":"test"}',
@@ -48,19 +41,9 @@ async def test_store_unauthorized(mocker):
         "type": "POST",
     }
 
-    content = {
-        "address": "VM on executor",
-        "content": {
-            "answer": 42,
-            "date": "2022-04-27T09:03:38.361081",
-            "something": "interesting",
-            "test": True,
-        },
-        "time": 1651050219.3481126,
-        "type": "test",
-    }
+    message = make_validated_message_from_dict(message_dict, message_dict["item_content"])
 
-    is_authorized = await check_sender_authorization(message, content)
+    is_authorized = await check_sender_authorization(message)
     assert not is_authorized
 
 
@@ -68,20 +51,12 @@ AUTHORIZED_MESSAGE = {
     "chain": "ETH",
     "channel": "TEST",
     "item_content": '{"address":"0xA3c613b12e862EB6e0C9897E03F1deEb207b5B58","time":1651050219.3481126,"content":{"date":"2022-04-27T09:03:38.361081","test":true,"answer":42,"something":"interesting"},"type":"test"}',
-    "content": {
-        "address": "0xA3c613b12e862EB6e0C9897E03F1deEb207b5B58",
-        "content": {
-            "answer": 42,
-            "date": "2022-04-27T09:03:38.361081",
-            "something": "interesting",
-            "test": True,
-        },
-    },
-    "item_hash": "498a10255877a74609654b673af4f8f29eb8ef1aa5d6265d9a6bf9e342d352db",
+    "item_hash": "1d8c28dac67725dd9d0ed218127d5ef7870443c803cd35598bb6cbb03ec76383",
     "item_type": "inline",
     "sender": "0x86F39e17910E3E6d9F38412EB7F24Bf0Ba31eb2E",
     "time": 1651050219.3488848,
     "type": "POST",
+    "signature": "fake signature, not checked here<",
 }
 
 
@@ -100,9 +75,9 @@ async def test_authorized(mocker):
         },
     )
 
-    is_authorized = await check_sender_authorization(
-        AUTHORIZED_MESSAGE, AUTHORIZED_MESSAGE["content"]
-    )
+    message = make_validated_message_from_dict(AUTHORIZED_MESSAGE, AUTHORIZED_MESSAGE["item_content"])
+
+    is_authorized = await check_sender_authorization(message)
     assert is_authorized
 
 
@@ -141,7 +116,7 @@ async def test_authorized_with_db(test_db):
 
     await Message.collection.insert_one(security_message)
 
-    is_authorized = await check_sender_authorization(
-        AUTHORIZED_MESSAGE, AUTHORIZED_MESSAGE["content"]
-    )
+    message = make_validated_message_from_dict(AUTHORIZED_MESSAGE, AUTHORIZED_MESSAGE["item_content"])
+
+    is_authorized = await check_sender_authorization(message)
     assert is_authorized

--- a/tests/schemas/test_pending_messages.py
+++ b/tests/schemas/test_pending_messages.py
@@ -187,7 +187,7 @@ def test_default_item_type_inline():
 
 
 def test_default_item_type_ipfs():
-    # Note: we reuse the fixture of test_parse_program_message here
+    # Note: we reuse the fixture of test_parse_post_message_storage_content here
     message_dict = {
         "chain": "ETH",
         "item_hash": "QmcS6md3AHR62rbmrnjy6SzJkunTsqtc6XhAuzYkYV66m4",

--- a/tests/schemas/test_validated_messages.py
+++ b/tests/schemas/test_validated_messages.py
@@ -1,0 +1,154 @@
+"""
+Tests for the validated message schemas. These tests use the same fixtures
+as the tests for the pending message schemas and check additional features.
+"""
+
+import json
+from typing import Dict
+
+from aleph_message.models import MessageConfirmation
+
+from aleph.schemas.message_content import MessageContent, ContentSource
+from aleph.schemas.pending_messages import (
+    PendingAggregateMessage,
+    PendingPostMessage,
+    PendingStoreMessage,
+    parse_message,
+)
+from aleph.schemas.validated_message import (
+    validate_pending_message,
+    BaseValidatedMessage,
+    ValidatedAggregateMessage,
+    ValidatedStoreMessage,
+)
+
+
+def check_basic_message_fields(message: BaseValidatedMessage, message_dict: Dict):
+    assert message.chain == message_dict["chain"]
+    assert message.item_hash == message_dict["item_hash"]
+    assert message.sender == message_dict["sender"]
+    assert message.type == message_dict["type"]
+    assert message.channel == message_dict["channel"]
+    assert message.signature == message_dict["signature"]
+    assert message.channel == message_dict["channel"]
+
+
+def test_parse_aggregate_inline_message():
+    message_dict = {
+        "chain": "ETH",
+        "item_hash": "6127637a9415444e62843f62c81a9dda708363b3bb830a5b10fcc212cd586fa9",
+        "sender": "0x51A58800b26AA1451aaA803d1746687cB88E0501",
+        "type": "AGGREGATE",
+        "channel": "UNSLASHED",
+        "item_content": '{"address":"0x51A58800b26AA1451aaA803d1746687cB88E0501","key":"0x93463a4f3af42de28f6840e59de6111b4192cf8bbinance","content":{"1652716953956":{"version":"x25519-xsalsa20-poly1305","nonce":"eohzj0i+fiaduqOcRnKyHVoTN19Gdv1N","ephemPublicKey":"eAWtQ7A0qA1b/VpnuexR098LFzQhw4/wbneri+XuBgA=","ciphertext":"qsWudj1UrcC5qbdZgzks3h8OF+kOD/CpB5og7zZXNj3zDYoXA+0CLYErX8gsN7yuJQNd+MciEHoxfQZWKtulR9+RMxQrD7DnNUE4y0ick3aFKjXAcJLcbCKOXllo5p9hxq1o/VONJor4uiHc97UhRTK1RXQUNdKz+V+RknAPrlamDcv3LJopm9zdMoxw5hRYIpF3fKH5natLkvc7EzmeQ3Bvo3mUtcyHWZZqmWpmtjVNFf1I+OHgFz4SK4O8nLq2fDPW8EtJBwTTfKeUIhj9B34V4+gl4O+822e4Tnbi4sTFGREc2lSqwDME4u4qyYMaM7omFYcfVvLwBHtIOoSl21xtaPh7g5q8z9lqlWJQTE9ZE2z0kKUuDLPCcrLMm1ooc69pSKPn2W87ycAWyN1v88i5KIU8vIBraWlFY76ROlHScw1L05PKI+1S03demsgNaT+hNTxGwSBOuEq7P25aJjiL3eKXZZ+lZONtSbegxTfFBg==","sha256":"99b9660c915e6ba26fb52cc7ae2735e73b1aeebd167db762e6e4b3d6ec85235f"}},"time":1652716955.776}',
+        "item_type": "inline",
+        "signature": "0xb0b97e102f7f75091306ec3ac39639a9560783a1652ed9f1c79138cafc77b9a1519a5cccabf7eb64a8cf4de11394757d95f9d7218833f85010ee847b77716c201c",
+        "time": 1652716955.776,
+    }
+
+    item_content = message_dict["item_content"]
+    content = json.loads(item_content)
+
+    pending_message = parse_message(message_dict)
+    assert isinstance(pending_message, PendingAggregateMessage)
+
+    message_content = MessageContent(
+        pending_message.item_hash, ContentSource.INLINE, content, item_content
+    )
+    confirmations = []
+    validated_message = validate_pending_message(
+        pending_message=pending_message,
+        content=message_content,
+        confirmations=confirmations,
+    )
+    assert isinstance(validated_message, ValidatedAggregateMessage)
+
+    check_basic_message_fields(validated_message, message_dict)
+
+    assert validated_message.content.address == content["address"]
+    assert validated_message.content.time == content["time"]
+    assert validated_message.content.key == content["key"]
+    assert validated_message.content.content == content["content"]
+
+    assert validated_message.confirmations == confirmations
+    assert not validated_message.confirmed
+
+
+def test_parse_post_message_storage_content():
+    message_dict = {
+        "chain": "ETH",
+        "item_hash": "QmWx3j1gSQUrBkYnA8wiuhmE5wGuVNKv5wW6L7RHgLi4H4",
+        "sender": "0x06DE0C46884EbFF46558Cd1a9e7DA6B1c3E9D0a8",
+        "type": "POST",
+        "channel": None,
+        "item_content": None,
+        "item_type": "ipfs",
+        "signature": "0xa1d9fadcf5e6613f6929aa18720c216763a4c04d1462c6e10b81b37d8b2b7fd42618f7889fd2b29d4940d5cb68b6eb24243b51fa932dec6d96de9bbb7e64f91d1c",
+        "time": 1608297192.085,
+    }
+
+    content = {
+        "address": "0x06DE0C46884EbFF46558Cd1a9e7DA6B1c3E9D0a8",
+        "content": {"banner": None, "body": "d", "subtitle": "", "tags": []},
+        "time": 1556200724.599,
+        "type": "blog_pers",
+    }
+
+    pending_message = parse_message(message_dict)
+    assert isinstance(pending_message, PendingPostMessage)
+
+    message_content = MessageContent(
+        pending_message.item_hash, ContentSource.INLINE, content, json.dumps(content)
+    )
+
+    confirmations = []
+    validated_message = validate_pending_message(
+        pending_message=pending_message,
+        content=message_content,
+        confirmations=confirmations,
+    )
+
+    check_basic_message_fields(validated_message, message_dict)
+    assert not validated_message.confirmed
+    assert validated_message.confirmations == []
+
+
+def test_parse_store_message_inline_content():
+    message_dict = {
+        "chain": "NULS2",
+        "item_hash": "4bbcfe7c4775492c2e602d322d68f558891468927b5e0d6cb89ff880134f323e",
+        "sender": "NULSd6Hgbhr42Dm5nEgf6foEUT5bgwHesZQJB",
+        "type": "STORE",
+        "channel": "MYALEPH",
+        "item_content": '{"address":"NULSd6Hgbhr42Dm5nEgf6foEUT5bgwHesZQJB","item_type":"ipfs","item_hash":"QmUDS8mpQmpPyptyUEedHxHMkxo7ueRRiAvrpgvJMpjXwW","time":1577325086.513}',
+        "item_type": "inline",
+        "signature": "G7/xlWoMjjOr1NBN4SiZ8USYYVM9Q3JHXChR9hPw9/YSItfAplshWysqYDkvmBZiwbICG0IVB3ilMPJ/ZVgPNlk=",
+        "time": 1608297193.717,
+    }
+
+    item_content = message_dict["item_content"]
+    content = json.loads(item_content)
+
+    pending_message = parse_message(message_dict)
+    assert isinstance(pending_message, PendingStoreMessage)
+
+    confirmations = [MessageConfirmation(chain="ETH", height=1234, hash="abcd")]
+    message_content = MessageContent(
+        pending_message.item_hash, ContentSource.INLINE, content, item_content
+    )
+    validated_message = validate_pending_message(
+        pending_message=pending_message,
+        content=message_content,
+        confirmations=confirmations,
+    )
+    assert isinstance(validated_message, ValidatedStoreMessage)
+
+    check_basic_message_fields(validated_message, message_dict)
+
+    assert validated_message.content.address == content["address"]
+    assert validated_message.content.time == content["time"]
+    assert validated_message.content.item_hash == content["item_hash"]
+    assert validated_message.content.item_type == content["item_type"]
+
+    assert validated_message.confirmed
+    assert validated_message.confirmations == confirmations

--- a/tests/storage/forget/test_forget_message.py
+++ b/tests/storage/forget/test_forget_message.py
@@ -2,6 +2,8 @@ import pytest
 from aleph_message.models import ForgetMessage
 from aleph.handlers.forget import forget_if_allowed, TargetMessageInfo
 
+from message_test_helpers import make_validated_message_from_dict
+
 
 @pytest.mark.asyncio
 async def test_forget_inline_message(mocker):
@@ -41,7 +43,7 @@ async def test_forget_inline_message(mocker):
         },
     }
 
-    forget_message = ForgetMessage(**forget_message)
+    forget_message = make_validated_message_from_dict(forget_message)
     garbage_collect_mock = mocker.patch("aleph.handlers.forget.garbage_collect")
     message_mock = mocker.patch("aleph.handlers.forget.Message")
     message_mock.collection.update_many = mocker.AsyncMock()
@@ -93,16 +95,9 @@ async def test_forget_store_message(mocker):
         "item_content": '{"address":"0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106","time":1652794384.3101473,"hashes":["f6fc4884e3ec3624bd3f60a3c37abf83a130777086061b1a373e659f2bab4d06"]}',
         "item_hash": "5e40c8e2197e0678b5fba9cb1679e3a80fa6aeaa1a440d94f059525295fa32d3",
         "signature": "0xc342e671be10894bf707b86c3f7538cdb7e4bb5760e234f8d07f8b3dfde015492337bd8756f169e37ac691b74c765415e96b6e1813238912e10ea54cc003887d1b",
-        "content": {
-            "address": "0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106",
-            "time": 1652794384.3101473,
-            "hashes": [
-                "f6fc4884e3ec3624bd3f60a3c37abf83a130777086061b1a373e659f2bab4d06"
-            ],
-        },
     }
 
-    forget_message = ForgetMessage(**forget_message)
+    forget_message = make_validated_message_from_dict(forget_message)
     garbage_collect_mock = mocker.patch("aleph.handlers.forget.garbage_collect")
     message_mock = mocker.patch("aleph.handlers.forget.Message")
     message_mock.collection.update_many = mocker.AsyncMock()
@@ -168,7 +163,7 @@ async def test_forget_forget_message(mocker):
         "time": 1639058312.376,
     }
 
-    forget_message = ForgetMessage(**forget_message)
+    forget_message = make_validated_message_from_dict(forget_message)
     garbage_collect_mock = mocker.patch("aleph.handlers.forget.garbage_collect")
     message_mock = mocker.patch("aleph.handlers.forget.Message")
     message_mock.collection.update_many = mocker.AsyncMock()

--- a/tests/storage/forget/test_forget_multi_users.py
+++ b/tests/storage/forget/test_forget_multi_users.py
@@ -12,6 +12,7 @@ from aleph.model.hashes import (
     set_value as store_gridfs_file,
 )
 from aleph.model.messages import Message
+from aleph.schemas.pending_messages import parse_message
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -25,41 +26,38 @@ async def test_forget_multiusers_storage(mocker, test_db):
 
     file_hash = "05a123fe17aa6addeef5a97d1665878d10f076d84309d5ae674d4bb292b484c3"
 
-    message_user1 = {
+    message_user1_dict = {
         "chain": "ETH",
         "sender": "0x971300C78A38e0F85E60A3b04ae3fA70b4276B64",
         "type": "STORE",
         "channel": "TESTS_FORGET",
         "confirmed": False,
         "item_type": "inline",
-        "size": 202,
         "time": 1646123806,
         "item_content": '{"address": "0x971300C78A38e0F85E60A3b04ae3fA70b4276B64", "time": 1651757380.8522494, "item_type": "storage", "item_hash": "05a123fe17aa6addeef5a97d1665878d10f076d84309d5ae674d4bb292b484c3", "size": 220916, "content_type": "file"}',
         "item_hash": "50635384e43c7af6b3297f6571644c30f3f07ac681bfd14b9c556c63e661a69e",
         "signature": "0x71263de6b8d1ea4c0b028f5892287505f6ee73dfa165d1455ca665ffdf5318955345c193a5df2f5c4eb2185947689d7bf5be36155b00711572fec5f27764625c1b",
     }
 
-    message_user2 = {
+    message_user2_dict = {
         "chain": "ETH",
         "sender": "0xaC033C1cA5C49Eff98A1D9a56BeDBC4840010BA4",
         "type": "STORE",
         "channel": "TESTS_FORGET",
         "confirmed": False,
         "item_type": "inline",
-        "size": 202,
         "time": 1646123806,
         "item_content": '{"address": "0xaC033C1cA5C49Eff98A1D9a56BeDBC4840010BA4", "time": 1651757416.2203836, "item_type": "storage", "item_hash": "05a123fe17aa6addeef5a97d1665878d10f076d84309d5ae674d4bb292b484c3", "size": 220916, "content_type": "file"}',
         "item_hash": "dbe8199004b052108ec19618f43af1d2baf5c04974d0aec1c4de2d02c44a2483",
         "signature": "0x4c9ef501e1e4f4b0a05c1eebfa1063837a82788f80deeb59808d25ff481c855157dd65102eaa365e33c7572a78d551cf25075f49d00ebb60c8506c0a6647ab761b",
     }
 
-    forget_message_user1 = {
+    forget_message_user1_dict = {
         "chain": "ETH",
         "sender": "0x971300C78A38e0F85E60A3b04ae3fA70b4276B64",
         "type": "FORGET",
         "channel": "TESTS_FORGET",
         "item_type": "inline",
-        "size": 202,
         "time": 1651757583.497435,
         "item_content": '{"address": "0x971300C78A38e0F85E60A3b04ae3fA70b4276B64", "time": 1651757583.4974332, "hashes": ["50635384e43c7af6b3297f6571644c30f3f07ac681bfd14b9c556c63e661a69e"], "reason": "I do not like this file"}',
         "item_hash": "0223e74dbae53b45da6a443fa18fd2a25f88677c82ed2de93f17ab24f78f58cf",
@@ -71,35 +69,38 @@ async def test_forget_multiusers_storage(mocker, test_db):
         file_content = f.read()
     await store_gridfs_file(key=file_hash, value=file_content)
 
+    message_user1 = parse_message(message_user1_dict)
     await process_one_message(message_user1)
 
     message1_db = await Message.collection.find_one(
-        {"item_hash": message_user1["item_hash"]}
+        {"item_hash": message_user1.item_hash}
     )
     assert message1_db is not None
 
+    message_user2 = parse_message(message_user2_dict)
     await process_one_message(message_user2)
 
     # Sanity check: check that the file exists
     db_file_data = await read_gridfs_file(file_hash)
     assert db_file_data == file_content
 
+    forget_message_user1 = parse_message(forget_message_user1_dict)
     await process_one_message(forget_message_user1)
 
     # Check that the message was properly forgotten
     forgotten_message = await Message.collection.find_one(
-        {"item_hash": message_user1["item_hash"]}
+        {"item_hash": message_user1.item_hash}
     )
     assert forgotten_message is not None
-    assert forgotten_message["forgotten_by"] == [forget_message_user1["item_hash"]]
+    assert forgotten_message["forgotten_by"] == [forget_message_user1.item_hash]
 
     # Check that the message from user 2 is not affected
     message_user2_db = await Message.collection.find_one(
-        {"item_hash": message_user2["item_hash"]}
+        {"item_hash": message_user2.item_hash}
     )
     assert message_user2_db is not None
     assert "forgotten_by" not in message_user2_db
-    assert message_user2_db["item_content"] == message_user2["item_content"]
+    assert message_user2_db["item_content"] == message_user2.item_content
 
     # Check that the file still exists
     db_file_data = await read_gridfs_file(file_hash)

--- a/tests/storage/test_store_message.py
+++ b/tests/storage/test_store_message.py
@@ -1,87 +1,68 @@
 import json
 
 import pytest
+from aleph_message.models import MessageConfirmation
 
 from aleph.handlers.storage import handle_new_storage
-from aleph.storage import ContentSource, RawContent
+from aleph.schemas.message_content import ContentSource, RawContent
+from aleph.schemas.validated_message import (
+    ValidatedStoreMessage,
+    StoreContentWithMetadata,
+)
+from message_test_helpers import make_validated_message_from_dict
 
 
 @pytest.fixture
 def fixture_message_file():
-    return {
-        "_id": {"$oid": "621908cb378bcd3ef596fa50"},
+    message_dict = {
         "chain": "ETH",
         "item_hash": "7e4f914865028356704919810073ec5690ecc4bb0ee3bd6bdb24829fd532398f",
         "sender": "0x1772213F07b98eBf3e85CCf88Ac29482ff97d9B1",
         "type": "STORE",
         "channel": "TEST",
-        "confirmed": True,
         "item_content": '{"address":"0x1772213F07b98eBf3e85CCf88Ac29482ff97d9B1","item_type":"ipfs","item_hash":"QmWxcFfKfmDddodV2iUKvkhGQ931AyakgkZRUNVPUq9E6G","time":1645807812.6829665,"id":1301,"name":"Amphibian Outlaws #1301","description":"Amphibian Outlaws is a collection of 7777 NFTs living together in Hyfall City. Each NFT is either a member of a mob family or a street gang. Visit https://www.amphibianoutlaws.com/ for more info.","attributes":[{"trait_type":"Type","value":"Typical"},{"trait_type":"Color","value":"Charcoal"},{"trait_type":"Eye Color","value":"Orange"},{"trait_type":"Hat","value":"Fedora"},{"trait_type":"Hat Color","value":"White & Blue"},{"trait_type":"Background","value":"Purple Fog"},{"trait_type":"Shades","value":"Black"},{"trait_type":"Cigar","value":"Red"}],"ref":"0xd55316fc244c7f5b44DC246e725c1C6c3E0cB8C2"}',
         "item_type": "inline",
         "signature": "0xc4d2660f8cd40f93dbfe153c67ebbdc86113811bf04fb1ce903a3da5da9017f011001587eee18837d2089a84589ae8be7df428d4b72f0a62e956868aef5938c61b",
-        "size": 823,
         "time": 1645807812.6829786,
-        "confirmations": [
-            {
-                "chain": "ETH",
-                "height": 14276536,
-                "hash": "0x28fd852984b1f2222ca1870a97f44cc34b535a49d2618f5689a10a67985935d5",
-            }
-        ],
     }
+    return make_validated_message_from_dict(
+        message_dict,
+        raw_content=message_dict["item_content"],
+        confirmations=[
+            MessageConfirmation(
+                chain="ETH",
+                hash="0x28fd852984b1f2222ca1870a97f44cc34b535a49d2618f5689a10a67985935d5",
+                height=14276536,
+            )
+        ],
+    )
 
 
 @pytest.fixture
 def fixture_message_directory():
-    return {
-        "_id": {"$oid": "1234"},
+    message_dict = {
         "chain": "ETH",
         "item_hash": "b3d17833bcefb7a6eb2d9fa7c77cca3eed3a3fa901a904d35c529a71be25fc6d",
         "sender": "0xdeadbeef",
         "type": "STORE",
         "channel": "PINNING",
-        "confirmed": False,
         "item_content": '{"address":"0x2278d6A697B2Be8aE4Ddf090f918d1642Ee43c8C","item_type":"ipfs","item_hash":"QmPZrod87ceK4yVvXQzRexDcuDgmLxBiNJ1ajLjLoMx9sU","time":1644409598.782}',
         "item_type": "inline",
         "signature": "0x755cce871af0ba577a940c2515f361b52726fb9c9c5a4c4a8323b9e773ca3008527f4ca7a73e3ea12c7df05b22b3e5c4fb27cfc9220b0cfcf2620c0f4d22c51d1c",
-        "size": 158,
         "time": 1644409598.782,
     }
 
+    return make_validated_message_from_dict(
+        message_dict, raw_content=message_dict["item_content"]
+    )
+
 
 @pytest.mark.asyncio
-async def test_handle_new_storage_invalid_content(
-    mock_config, fixture_message_directory
+async def test_handle_new_storage_file(
+    mocker, mock_config, fixture_message_file: ValidatedStoreMessage
 ):
-    missing_item_hash_content = {
-        "address": "0x2278d6A697B2Be8aE4Ddf090f918d1642Ee43c8C",
-        "item_type": "ipfs",
-        "time": 1644409598.782,
-    }
-
-    result = await handle_new_storage(
-        fixture_message_directory, missing_item_hash_content
-    )
-    assert result is False
-
-    missing_item_type_content = {
-        "address": "0x2278d6A697B2Be8aE4Ddf090f918d1642Ee43c8C",
-        "item_hash": "QmPZrod87ceK4yVvXQzRexDcuDgmLxBiNJ1ajLjLoMx9sU",
-        "time": 1644409598.782,
-    }
-
-    result = await handle_new_storage(
-        fixture_message_directory, missing_item_type_content
-    )
-    assert result is False
-
-    result = await handle_new_storage(fixture_message_directory, content={})
-    assert result is False
-
-
-@pytest.mark.asyncio
-async def test_handle_new_storage_file(mocker, mock_config, fixture_message_file):
-    content = json.loads(fixture_message_file["item_content"])
+    assert fixture_message_file.item_content is not None  # for mypy
+    content = json.loads(fixture_message_file.item_content)
 
     raw_content = RawContent(
         hash=content["item_hash"],
@@ -102,20 +83,22 @@ async def test_handle_new_storage_file(mocker, mock_config, fixture_message_file
     mock_ipfs_api.files.stat = mocker.AsyncMock(return_value=ipfs_stats)
     mocker.patch("aleph.handlers.storage.get_ipfs_api", return_value=mock_ipfs_api)
 
-    result = await handle_new_storage(fixture_message_file, content)
-    assert result and result != -1
+    message = fixture_message_file
+    result = await handle_new_storage(message)
+    assert result
 
     # The IPFS stats are not added for files
-    assert "engine_info" not in content
-    assert content["size"] == len(raw_content)
-    assert content["content_type"] == "file"
+    assert isinstance(message.content, StoreContentWithMetadata)
+    assert message.content.engine_info is None
+    assert message.content.size == len(raw_content)
+    assert message.content.content_type == "file"
 
     assert get_hash_content_mock.called_once
 
 
 @pytest.mark.asyncio
 async def test_handle_new_storage_directory(
-    mocker, mock_config, fixture_message_directory
+    mocker, mock_config, fixture_message_directory: ValidatedStoreMessage
 ):
     get_hash_content_mock = mocker.patch("aleph.handlers.storage.get_hash_content")
     mock_ipfs_api = mocker.MagicMock()
@@ -129,25 +112,21 @@ async def test_handle_new_storage_directory(
     mock_ipfs_api.files.stat = mocker.AsyncMock(return_value=ipfs_stats)
     mocker.patch("aleph.handlers.storage.get_ipfs_api", return_value=mock_ipfs_api)
 
-    content = json.loads(fixture_message_directory["item_content"])
-
-    result = await handle_new_storage(fixture_message_directory, content)
+    message = fixture_message_directory
+    result = await handle_new_storage(message)
     assert result
 
-    # Check the updates to the content dict
-    assert content["engine_info"] == ipfs_stats
-    assert content["size"] == ipfs_stats["CumulativeSize"]
-    assert content["content_type"] == "directory"
+    # Check the updates to the message content
+    assert isinstance(message.content, StoreContentWithMetadata)
+    assert message.content.engine_info is not None
+
+    assert message.content.engine_info.hash == ipfs_stats["Hash"]
+    assert message.content.engine_info.size == ipfs_stats["Size"]
+    assert message.content.engine_info.cumulative_size == ipfs_stats["CumulativeSize"]
+    assert message.content.engine_info.blocks == ipfs_stats["Blocks"]
+    assert message.content.engine_info.type == ipfs_stats["Type"]
+
+    assert message.content.size == ipfs_stats["CumulativeSize"]
+    assert message.content.content_type == "directory"
 
     assert not get_hash_content_mock.called
-
-
-@pytest.mark.asyncio
-async def test_handle_new_storage_invalid_hash(
-    mocker, mock_config, fixture_message_file
-):
-    content = json.loads(fixture_message_file["item_content"])
-    content["item_hash"] = "some-invalid-hash"
-
-    result = await handle_new_storage(fixture_message_file, content)
-    assert result is False

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -4,7 +4,8 @@ import pytest
 import aleph.chains
 from aleph.exceptions import InvalidMessageError
 from aleph.chains.common import IncomingStatus
-from aleph.network import check_message
+from aleph.network import verify_signature
+from aleph.schemas.pending_messages import parse_message
 
 __author__ = "Moshe Malawach"
 __copyright__ = "Moshe Malawach"
@@ -20,25 +21,28 @@ __license__ = "mit"
 #     assert msg['item_type'] == 'ipfs', "ipfs should be the default"
 #     assert msg is passed_msg, "same object should be returned"
 
+
 @pytest.mark.skip("TODO: NULS signature verification does not work with the fixture.")
 @pytest.mark.asyncio
 async def test_valid_message():
-    sample_message = {
+    sample_message_dict = {
         "item_hash": "QmfDkHXdGND7e8uwJr4yvXSAvbPc8rothM6UN5ABQPsLkF",
+        "item_type": "ipfs",
         "chain": "NULS",
         "channel": "SYSINFO",
         "sender": "TTanii7eCT93f45g2UpKH81mxpVNcCYw",
         "type": "AGGREGATE",
         "time": 1563279102.3155158,
-        "signature": "2103041b0b357446927d2c8c62fdddd27910d82f665f16a4907a2be927b5901f5e6c004730450221009a54ecaff6869664e94ad68554520c79c21d4f63822864bd910f9916c32c1b5602201576053180d225ec173fb0b6e4af5efb2dc474ce6aa77a3bdd67fd14e1d806b4"
+        "signature": "2103041b0b357446927d2c8c62fdddd27910d82f665f16a4907a2be927b5901f5e6c004730450221009a54ecaff6869664e94ad68554520c79c21d4f63822864bd910f9916c32c1b5602201576053180d225ec173fb0b6e4af5efb2dc474ce6aa77a3bdd67fd14e1d806b4",
     }
-    message = await check_message(sample_message)
-    assert message is not None
+
+    sample_message = parse_message(sample_message_dict)
+    await verify_signature(sample_message)
 
 
 @pytest.mark.asyncio
 async def test_invalid_chain_message():
-    sample_message = {
+    sample_message_dict = {
         "item_hash": "QmfDkHXdGND7e8uwJr4yvXSAvbPc8rothM6UN5ABQPsLkF",
         "item_type": "ipfs",
         "chain": "BAR",
@@ -46,15 +50,16 @@ async def test_invalid_chain_message():
         "sender": "TTanii7eCT93f45g2UpKH81mxpVNcCYw",
         "type": "AGGREGATE",
         "time": 1563279102.3155158,
-        "signature": "2103041b0b357446927d2c8c62fdddd27910d82f665f16a4907a2be927b5901f5e6c004730450221009a54ecaff6869664e94ad68554520c79c21d4f63822864bd910f9916c32c1b5602201576053180d225ec173fb0b6e4af5efb2dc474ce6aa77a3bdd67fd14e1d806b4"
+        "signature": "2103041b0b357446927d2c8c62fdddd27910d82f665f16a4907a2be927b5901f5e6c004730450221009a54ecaff6869664e94ad68554520c79c21d4f63822864bd910f9916c32c1b5602201576053180d225ec173fb0b6e4af5efb2dc474ce6aa77a3bdd67fd14e1d806b4",
     }
+
     with pytest.raises(InvalidMessageError):
-        _ = await check_message(sample_message)
+        _ = parse_message(sample_message_dict)
 
 
 @pytest.mark.asyncio
 async def test_invalid_signature_message():
-    sample_message = {
+    sample_message_dict = {
         "item_hash": "QmfDkHXdGND7e8uwJr4yvXSAvbPc8rothM6UN5ABQPsLkF",
         "item_type": "ipfs",
         "chain": "NULS",
@@ -62,86 +67,55 @@ async def test_invalid_signature_message():
         "sender": "TTanii7eCT93f45g2UpKH81mxpVNcCYw",
         "type": "AGGREGATE",
         "time": 1563279102.3155158,
-        "signature": "BAR"
+        "signature": "BAR",
     }
+
+    sample_message = parse_message(sample_message_dict)
     with pytest.raises(InvalidMessageError):
-        _ = await check_message(sample_message)
+        _ = await verify_signature(sample_message)
 
 
-@pytest.mark.skip("TODO: NULS signature verification does not fail as expected with this fixture.")
 @pytest.mark.asyncio
 async def test_invalid_signature_message_2():
-    sample_message = {
+    sample_message_dict = {
         "item_hash": "QmfDkHXdGND7e8uwJr4yvXSAvbPc8rothM6UN5ABQPsLkF",
+        "item_type": "ipfs",
         "chain": "NULS",
         "channel": "SYSINFO",
         "sender": "TTanii7eCT93f45g2UpKH81mxpVNcCYw",
         "type": "AGGREGATE",
         "time": 1563279102.3155158,
-        "signature": "2153041b0b357446927d2c8c62fdddd27910d82f665f16a4907a2be927b5901f5e6c004730450221009a54ecaff6869664e94ad68554525c79c21d4f63822864bd910f9916c32c1b5602201576053180d225ec173fb0b6e4af5efb2dc474ce6aa77a3bdd67fd14e1d806b4"
+        "signature": "2153041b0b357446927d2c8c62fdddd27910d82f665f16a4907a2be927b5901f5e6c004730450221009a54ecaff6869664e94ad68554525c79c21d4f63822864bd910f9916c32c1b5602201576053180d225ec173fb0b6e4af5efb2dc474ce6aa77a3bdd67fd14e1d806b4",
     }
-    # with pytest.raises(InvalidMessageError):
-    x = await check_message(sample_message)
-    print(x)
+
+    sample_message = parse_message(sample_message_dict)
+    with pytest.raises(InvalidMessageError):
+        _ = await verify_signature(sample_message)
 
 
-@pytest.mark.skip("TODO: NULS signature verification does not work with the fixture.")
-@pytest.mark.asyncio
-async def test_extraneous_fields():
-    sample_message = {
-        "item_hash": "QmfDkHXdGND7e8uwJr4yvXSAvbPc8rothM6UN5ABQPsLkF",
-        "chain": "NULS",
-        "channel": "SYSINFO",
-        "sender": "TTanii7eCT93f45g2UpKH81mxpVNcCYw",
-        "type": "AGGREGATE",
-        "foo": "bar",
-        "time": 1563279102.3155158,
-        "signature": "2103041b0b357446927d2c8c62fdddd27910d82f665f16a4907a2be927b5901f5e6c004730450221009a54ecaff6869664e94ad68554520c79c21d4f63822864bd910f9916c32c1b5602201576053180d225ec173fb0b6e4af5efb2dc474ce6aa77a3bdd67fd14e1d806b4"
-    }
-    message = await check_message(sample_message)
-    # assert "type" not in message
-    assert "foo" not in message
-
-# @pytest.mark.asyncio
-# async def test_inline_content():
-#     content = json.dumps({'foo': 'bar'})
-#     h = hashlib.sha256()
-#     h.update(content.encode('utf-8'))
-#     sample_message = {
-#         "item_hash": h.hexdigest(),
-#         "item_content": content,
-#         "chain": "NULS"
-#     }
-#     message = await check_message(sample_message, trusted=True)
-#     assert message is not None
-#     assert message['item_hash'] == h.hexdigest()
-#     assert message['item_content'] == content
-#     assert message['item_type'] == 'inline'
-
-
-@pytest.mark.skip("TODO: NULS signature verification does not work with the fixtures.")
 @pytest.mark.asyncio
 async def test_incoming_inline_content(mocker):
     from aleph.chains.common import incoming
     from unittest.mock import MagicMock
-    
+
     async def async_magic():
         pass
 
     MagicMock.__await__ = lambda x: async_magic().__await__()
-    
-    mocker.patch('aleph.model.db')
 
-    msg = {'chain': 'NULS',
-           'channel': 'SYSINFO',
-           'sender': 'TTapAav8g3fFjxQQCjwPd4ERPnai9oya',
-           'type': 'AGGREGATE',
-           'time': 1564581054.0532622,
-           'item_content': '{"key":"metrics","address":"TTapAav8g3fFjxQQCjwPd4ERPnai9oya","content":{"memory":{"total":12578275328,"available":5726081024,"percent":54.5,"used":6503415808,"free":238661632,"active":8694841344,"inactive":2322239488,"buffers":846553088,"cached":4989644800,"shared":172527616,"slab":948609024},"swap":{"total":7787769856,"free":7787495424,"used":274432,"percent":0.0,"swapped_in":0,"swapped_out":16384},"cpu":{"user":9.0,"nice":0.0,"system":3.1,"idle":85.4,"iowait":0.0,"irq":0.0,"softirq":2.5,"steal":0.0,"guest":0.0,"guest_nice":0.0},"cpu_cores":[{"user":8.9,"nice":0.0,"system":2.4,"idle":82.2,"iowait":0.0,"irq":0.0,"softirq":6.4,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":9.6,"nice":0.0,"system":2.9,"idle":84.6,"iowait":0.0,"irq":0.0,"softirq":2.9,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":7.2,"nice":0.0,"system":3.0,"idle":86.8,"iowait":0.0,"irq":0.0,"softirq":3.0,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":11.4,"nice":0.0,"system":3.0,"idle":84.8,"iowait":0.1,"irq":0.0,"softirq":0.7,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":9.3,"nice":0.0,"system":3.3,"idle":87.0,"iowait":0.1,"irq":0.0,"softirq":0.3,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":5.5,"nice":0.0,"system":4.4,"idle":89.9,"iowait":0.0,"irq":0.0,"softirq":0.1,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":8.7,"nice":0.0,"system":3.3,"idle":87.9,"iowait":0.0,"irq":0.0,"softirq":0.1,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":11.4,"nice":0.0,"system":2.3,"idle":80.3,"iowait":0.0,"irq":0.0,"softirq":6.1,"steal":0.0,"guest":0.0,"guest_nice":0.0}]},"time":1564581054.0358574}',
-           'item_hash': '84afd8484912d3fa11a402e480d17e949fbf600fcdedd69674253be0320fa62c',
-           'signature': '21027c108022f992f090bbe5c78ca8822f5b7adceb705ae2cd5318543d7bcdd2a74700473045022100b59f7df5333d57080a93be53b9af74e66a284170ec493455e675eb2539ac21db022077ffc66fe8dde7707038344496a85266bf42af1240017d4e1fa0d7068c588ca7'
-           }
-    # msg['item_type'] = 'inline'
-    msg = await check_message(msg)
-    status, ops = await incoming(msg)
+    mocker.patch("aleph.model.db")
+
+    message_dict = {
+        "chain": "NULS",
+        "channel": "SYSINFO",
+        "sender": "TTapAav8g3fFjxQQCjwPd4ERPnai9oya",
+        "type": "AGGREGATE",
+        "time": 1564581054.0532622,
+        "item_type": "inline",
+        "item_content": '{"key":"metrics","address":"TTapAav8g3fFjxQQCjwPd4ERPnai9oya","content":{"memory":{"total":12578275328,"available":5726081024,"percent":54.5,"used":6503415808,"free":238661632,"active":8694841344,"inactive":2322239488,"buffers":846553088,"cached":4989644800,"shared":172527616,"slab":948609024},"swap":{"total":7787769856,"free":7787495424,"used":274432,"percent":0.0,"swapped_in":0,"swapped_out":16384},"cpu":{"user":9.0,"nice":0.0,"system":3.1,"idle":85.4,"iowait":0.0,"irq":0.0,"softirq":2.5,"steal":0.0,"guest":0.0,"guest_nice":0.0},"cpu_cores":[{"user":8.9,"nice":0.0,"system":2.4,"idle":82.2,"iowait":0.0,"irq":0.0,"softirq":6.4,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":9.6,"nice":0.0,"system":2.9,"idle":84.6,"iowait":0.0,"irq":0.0,"softirq":2.9,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":7.2,"nice":0.0,"system":3.0,"idle":86.8,"iowait":0.0,"irq":0.0,"softirq":3.0,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":11.4,"nice":0.0,"system":3.0,"idle":84.8,"iowait":0.1,"irq":0.0,"softirq":0.7,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":9.3,"nice":0.0,"system":3.3,"idle":87.0,"iowait":0.1,"irq":0.0,"softirq":0.3,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":5.5,"nice":0.0,"system":4.4,"idle":89.9,"iowait":0.0,"irq":0.0,"softirq":0.1,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":8.7,"nice":0.0,"system":3.3,"idle":87.9,"iowait":0.0,"irq":0.0,"softirq":0.1,"steal":0.0,"guest":0.0,"guest_nice":0.0},{"user":11.4,"nice":0.0,"system":2.3,"idle":80.3,"iowait":0.0,"irq":0.0,"softirq":6.1,"steal":0.0,"guest":0.0,"guest_nice":0.0}]},"time":1564581054.0358574}',
+        "item_hash": "84afd8484912d3fa11a402e480d17e949fbf600fcdedd69674253be0320fa62c",
+        "signature": "21027c108022f992f090bbe5c78ca8822f5b7adceb705ae2cd5318543d7bcdd2a74700473045022100b59f7df5333d57080a93be53b9af74e66a284170ec493455e675eb2539ac21db022077ffc66fe8dde7707038344496a85266bf42af1240017d4e1fa0d7068c588ca7",
+    }
+    message = parse_message(message_dict)
+    status, ops = await incoming(message)
     assert status == IncomingStatus.MESSAGE_HANDLED


### PR DESCRIPTION
Propagated the use of Pydantic message models to all the functions
related to message processing.

Extended the Pydantic message models by introducing a new
message class, `ValidatedBaseMessage`. This schema represents
fully-loaded messages, including their content field.

Split the message validation function, check_message, in two parts:
* `parse_message` checks that the message is semantically valid,
  i.e. that all the required fields are present, are of the correct
  type and have sensible values.
* `verify_signature` checks the signature of the message using
  the public key of the sender.

We now call parse_message as early as possible in the process.
This allows to simplify hypotheses about the presence/absence
of specific fields and allows to simplify the codebase.

Improved the typing of the message models by using generics
to represent the message and item type fields.

Split the message validation function, check_message, in two parts:
* `parse_message` checks that the message is semantically valid,
  i.e. that all the required fields are present, are of the correct
  type and have sensible values.
* `verify_signature` checks the signature of the message using
  the public key of the sender.

We now call parse_message as early as possible in the process.
This allows to simplify hypotheses about the presence/absence
of specific fields and allows to simplify the codebase.

Modified tests to use the message classes. Removed a few tests
that tested corner cases linked to incomplete message dictionaries.