### PR TITLE
[Doc] Update doc to generate node keys

### DIFF
--- a/deployment/docker-build/README.md
+++ b/deployment/docker-build/README.md
@@ -30,7 +30,7 @@ An Aleph node needs an asymmetric key pair to communicate with other nodes on th
 
 You can generate this key using the following commands after building the Docker image:
 ```shell script
-docker run --rm -ti --user root -v $(pwd)/node-secret.key:/opt/pyaleph/node-secret.key alephim/pyaleph-node:latest pyaleph --gen-keys
+docker run --rm --user root --entrypoint "" -v $(pwd)/node-secret.key:/opt/pyaleph/node-secret.key alephim/pyaleph-node:latest pyaleph --gen-keys
 ```
 
 ## Start the dev environment

--- a/docs/guides/install.rst
+++ b/docs/guides/install.rst
@@ -116,8 +116,8 @@ We strongly advise to back up your keys once generated.
 .. parsed-literal::
 
     mkdir keys
-    docker run --rm -ti --user root -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:|pyaleph_version| chown aleph:aleph /opt/pyaleph/keys
-    docker run --rm -ti -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:|pyaleph_version| pyaleph --gen-keys --key-dir /opt/pyaleph/keys
+    docker run --rm --user root --entrypoint "" -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:|pyaleph_version| chown aleph:aleph /opt/pyaleph/keys
+    docker run --rm --entrypoint "" -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:|pyaleph_version| pyaleph --gen-keys --key-dir /opt/pyaleph/keys
 
 To check that the generation of the keys succeeded, print your private key:
 

--- a/docs/guides/upgrade.rst
+++ b/docs/guides/upgrade.rst
@@ -22,7 +22,7 @@ and adjust the ownership of the folder:
 
     mkdir keys
     cp node-secret.key keys/
-    docker run --rm -ti --user root -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:|pyaleph_version| chown -R aleph:aleph /opt/pyaleph/keys
+    docker run --rm --user root --entrypoint "" -v $(pwd)/keys:/opt/pyaleph/keys alephim/pyaleph-node:|pyaleph_version| chown -R aleph:aleph /opt/pyaleph/keys
 
 Download the latest image
 -------------------------


### PR DESCRIPTION
Fixed a regression in the doc. The docker commands were not taking
the Docker entrypoint into account. We now reset the entrypoint
to the default value to launch specific commands with the Docker
image.