### PR TITLE
[Messages] Fix validation of P2P messages

### DIFF
--- a/src/aleph/web/controllers/p2p.py
+++ b/src/aleph/web/controllers/p2p.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import logging
-from typing import Dict
+from typing import Dict, cast
 
 from aiohttp import web
 from configmanager import Config
@@ -30,7 +30,7 @@ def validate_request_data(config: Config, request_data: Dict) -> None:
     # Currently, we only check validate messages
     message_topic = config.aleph.queue_topic.value
     if topic == message_topic:
-        message = json.loads(request_data.get("data"))
+        message = json.loads(cast(str, request_data.get("data")))
         try:
             _ = parse_message(message)
         except InvalidMessageError as e:

--- a/src/aleph/web/controllers/p2p.py
+++ b/src/aleph/web/controllers/p2p.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 from typing import Dict
 
@@ -7,10 +8,9 @@ from configmanager import Config
 
 from aleph.exceptions import InvalidMessageError
 from aleph.schemas.pending_messages import parse_message
-from aleph.services.p2p.singleton import get_p2p_client
-
 from aleph.services.ipfs.pubsub import pub as pub_ipfs
 from aleph.services.p2p.pubsub import publish as pub_p2p
+from aleph.services.p2p.singleton import get_p2p_client
 from aleph.types import Protocol
 
 LOGGER = logging.getLogger("web.controllers.p2p")
@@ -26,13 +26,13 @@ def validate_request_data(config: Config, request_data: Dict) -> None:
     """
 
     topic = request_data.get("topic")
-    data = request_data.get("data")
 
     # Currently, we only check validate messages
     message_topic = config.aleph.queue_topic.value
     if topic == message_topic:
+        message = json.loads(request_data.get("data"))
         try:
-            _ = parse_message(data)
+            _ = parse_message(message)
         except InvalidMessageError as e:
             raise web.HTTPUnprocessableEntity(body=str(e))
 

--- a/tests/web/controllers/test_pub_json.py
+++ b/tests/web/controllers/test_pub_json.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 
@@ -22,7 +24,7 @@ async def test_pub_valid_aleph_message(mock_config, ccn_api_client, mocker):
 
     response = await ccn_api_client.post(
         "/api/v0/ipfs/pubsub/pub",
-        json={"topic": message_topic, "data": message},
+        json={"topic": message_topic, "data": json.dumps(message)},
     )
     assert response.status == 200, await response.text()
 
@@ -38,7 +40,9 @@ async def test_pub_invalid_aleph_message(mock_config, ccn_api_client, mocker):
         "/api/v0/ipfs/pubsub/pub",
         json={
             "topic": message_topic,
-            "data": {"header": "this is not an Aleph message at all", "type": "STORE"},
+            "data": json.dumps(
+                {"header": "this is not an Aleph message at all", "type": "STORE"}
+            ),
         },
     )
     assert response.status == 422, await response.text()


### PR DESCRIPTION
Fixed an issue where the validation of messages performed
in the P2P endpoints would not deserialize the message beforehand.
This led to all messages being rejected.