### PR TITLE
fix: (minor) setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ cover/*
 MANIFEST
 
 # Per-project virtualenvs
-.venv*/
+venv*/
 
 # Secret files
 config.yml


### PR DESCRIPTION
Setup instructions boostraps virtualenv inside a `venv` directory while the `.gitignore` file ignores `.venv`