### PR TITLE
Fix: Support Ed25519 Tezos keys

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     aioipfs@git+https://github.com/aleph-im/aioipfs.git@76d5624661e879a13b70f3ea87dc9c9604c7eda7
     aleph-client==0.4.6
     aleph-message==0.1.20
-    aleph-pytezos@git+https://github.com/aleph-im/aleph-pytezos.git@e584ede63c4302c6c22ac1777fda6676655d664a
+    aleph-pytezos@git+https://github.com/aleph-im/aleph-pytezos.git@9392c655f1e089bea0fb154def3d416f2d70f336
     coincurve==15.0.1
     configmanager==1.35.1
     configparser==5.2.0

--- a/tests/chains/test_tezos.py
+++ b/tests/chains/test_tezos.py
@@ -1,6 +1,8 @@
 import pytest
 
-from aleph.chains import tezos  # TODO: this import is currently necessary because of circular dependencies
+from aleph.chains import (
+    tezos,
+)  # TODO: this import is currently necessary because of circular dependencies
 from aleph.network import check_message
 
 
@@ -21,6 +23,23 @@ async def test_tezos_verify_signature():
             "content": {"status": "testing"},
             "type": "test",
         },
+    }
+
+    _ = await check_message(message_dict)
+
+
+@pytest.mark.asyncio
+async def test_tezos_verify_signature_ed25519():
+    message_dict = {
+        "chain": "TEZOS",
+        "sender": "tz1SmGHzna3YhKropa3WudVq72jhTPDBn4r5",
+        "type": "POST",
+        "channel": "ALEPH-TEST",
+        "signature": '{"signature":"siggLSTX5i9ZZJHb6vUoi5gNxWEjEcBD62Jjs8JdFgDND3uc9xb5YC9bUFLpBAoudhdTRNfmV7GTnJzoWUm9y1cDh7T6KX59","publicKey":"edpkvUuhtQDPA9KfC3BY7ydh89hT34KTANMfX7L22BUrA9aGWg6QxF"}',
+        "time": 1661451074.86,
+        "item_type": "inline",
+        "item_content": '{"type":"custom_type","address":"tz1SmGHzna3YhKropa3WudVq72jhTPDBn4r5","content":{"body":"Hello World TEZOS"},"time":1661451074.86}',
+        "item_hash": "41de1a7766c7e5fad54772470eefde63b6bef8683c4159d9179d74955009deb4",
     }
 
     _ = await check_message(message_dict)


### PR DESCRIPTION
Bumped pytezos to a version that supports verifying signatures
generated by Ed25519 keys. Added a test to avoid regressions.