### PR TITLE
Fix: commit hash for pytezos

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     aioipfs@git+https://github.com/aleph-im/aioipfs.git@76d5624661e879a13b70f3ea87dc9c9604c7eda7
     aleph-client==0.4.6
     aleph-message==0.1.20
-    aleph-pytezos@git+https://github.com/aleph-im/aleph-pytezos.git@9392c655f1e089bea0fb154def3d416f2d70f336
+    aleph-pytezos@git+https://github.com/aleph-im/aleph-pytezos.git@97fe92ffa6e21ef5ec17ef4fa16c86022b30044c
     coincurve==15.0.1
     configmanager==1.35.1
     configparser==5.2.0


### PR DESCRIPTION
Use the hash on aleph-pytezos:master instead of the PR branch
for Ed25519 support.