### PR TITLE
Internal: Persistent VM messages were rejected

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     aiohttp==3.8.1
     aioipfs@git+https://github.com/aleph-im/aioipfs.git@76d5624661e879a13b70f3ea87dc9c9604c7eda7
     aleph-client==0.4.6
-    aleph-message==0.1.20
+    aleph-message~=0.2.0
     aleph-pytezos@git+https://github.com/aleph-im/aleph-pytezos.git@97fe92ffa6e21ef5ec17ef4fa16c86022b30044c
     coincurve==15.0.1
     configmanager==1.35.1


### PR DESCRIPTION
The schema of Aleph messages is validated against aleph-message definitions since v0.3.3. The support for persistent VMs adds new fields that are not present in `aleph-message` version `0.1.20`, and an upgrade is necessary.
