### PR TITLE
Fix: MongoDB _id was included in messages

### DIFF
--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -6,7 +6,7 @@ from aiohttp.web_exceptions import HTTPBadRequest
 import asyncio
 from pymongo.cursor import CursorType
 from bson.objectid import ObjectId
-from aleph.web.controllers.utils import Pagination, cond_output, prepare_date_filters
+from aleph.web.controllers.utils import Pagination, cond_output, prepare_date_filters, prune_mongo_id
 import logging
 
 LOGGER = logging.getLogger("MESSAGES")
@@ -126,7 +126,7 @@ async def view_messages_list(request):
         pagination_skip = 0
 
     messages = [
-        msg
+        prune_mongo_id(msg)
         async for msg in Message.collection.find(
             find_filters,
             limit=pagination_per_page,
@@ -206,7 +206,7 @@ async def messages_ws(request: web.Request):
                     item["_id"] = str(item["_id"])
 
                     last_id = item["_id"]
-                    await ws.send_json(item)
+                    await ws.send_json(prune_mongo_id(item))
 
                 await asyncio.sleep(1)
 

--- a/src/aleph/web/controllers/utils.py
+++ b/src/aleph/web/controllers/utils.py
@@ -125,3 +125,10 @@ def cond_output(request, context, template):
     response.enable_compression()
 
     return response
+
+
+def prune_mongo_id(data: Dict) -> Dict:
+    try:
+        del data["_id"]
+    except KeyError:
+        pass

--- a/tests/web/controllers/test_utils.py
+++ b/tests/web/controllers/test_utils.py
@@ -1,0 +1,18 @@
+from aleph.web.controllers.utils import prune_mongo_id
+
+
+def test_prune_mongo_id():
+    data = {
+        "_id": {
+            "$oid": "63174837a56357d39fcb2830",
+        },
+        "something": "cool",
+        "other_key": "other_value",
+    }
+
+    result = prune_mongo_id(data)
+    assert "_id" not in result
+    assert result == {
+        "something": "cool",
+        "other_key": "other_value",
+    }


### PR DESCRIPTION
On `/api/v0/messages.json` and `/api/ws0/messages`.

Solution: Prune the MongoDB _id field from messages before returning them to clients.