### PR TITLE
Chore: bump aleph-message for ItemHash type

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     aiohttp==3.8.1
     aioipfs@git+https://github.com/aleph-im/aioipfs.git@76d5624661e879a13b70f3ea87dc9c9604c7eda7
     aleph-client==0.4.6
-    aleph-message~=0.2.0
+    aleph-message~=0.2.1
     aleph-pytezos@git+https://github.com/aleph-im/aleph-pytezos.git@97fe92ffa6e21ef5ec17ef4fa16c86022b30044c
     coincurve==15.0.1
     configmanager==1.35.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     aiohttp==3.8.1
     aioipfs@git+https://github.com/aleph-im/aioipfs.git@76d5624661e879a13b70f3ea87dc9c9604c7eda7
     aleph-client==0.4.6
-    aleph-message~=0.2.1
+    aleph-message==0.2.1
     aleph-pytezos@git+https://github.com/aleph-im/aleph-pytezos.git@97fe92ffa6e21ef5ec17ef4fa16c86022b30044c
     coincurve==15.0.1
     configmanager==1.35.1

--- a/src/aleph/schemas/pending_messages.py
+++ b/src/aleph/schemas/pending_messages.py
@@ -31,7 +31,7 @@ from aleph_message.models import (
     ProgramContent,
     StoreContent,
 )
-from aleph_message.models import MessageType, ItemType
+from aleph_message.models import MessageType, ItemHash, ItemType
 from pydantic import BaseModel, ValidationError, root_validator, validator
 
 from aleph.exceptions import InvalidMessageError, UnknownHashError
@@ -51,7 +51,7 @@ class BasePendingMessage(BaseModel):
     type: MessageType
     item_content: Optional[str]
     item_type: ItemType
-    item_hash: str
+    item_hash: ItemHash
     time: float
     channel: Optional[str] = None
     content: Optional[BaseContent] = None

--- a/tests/storage/test_store_message.py
+++ b/tests/storage/test_store_message.py
@@ -62,7 +62,7 @@ async def test_handle_new_storage_invalid_content(
     result = await handle_new_storage(
         fixture_message_directory, missing_item_hash_content
     )
-    assert result == -1
+    assert not result
 
     missing_item_type_content = {
         "address": "0x2278d6A697B2Be8aE4Ddf090f918d1642Ee43c8C",
@@ -73,10 +73,10 @@ async def test_handle_new_storage_invalid_content(
     result = await handle_new_storage(
         fixture_message_directory, missing_item_type_content
     )
-    assert result == -1
+    assert not result
 
     result = await handle_new_storage(fixture_message_directory, content={})
-    assert result == -1
+    assert not result
 
 
 @pytest.mark.asyncio
@@ -149,5 +149,5 @@ async def test_handle_new_storage_invalid_hash(
     content = json.loads(fixture_message_file["item_content"])
     content["item_hash"] = "some-invalid-hash"
 
-    with pytest.raises(UnknownHashError):
-        _ = await handle_new_storage(fixture_message_file, content)
+    result = await handle_new_storage(fixture_message_file, content)
+    assert not result

--- a/tests/storage/test_store_message.py
+++ b/tests/storage/test_store_message.py
@@ -1,9 +1,9 @@
+import json
+
 import pytest
 
 from aleph.handlers.storage import handle_new_storage
 from aleph.storage import ContentSource, RawContent
-import json
-from aleph.exceptions import UnknownHashError
 
 
 @pytest.fixture
@@ -62,7 +62,7 @@ async def test_handle_new_storage_invalid_content(
     result = await handle_new_storage(
         fixture_message_directory, missing_item_hash_content
     )
-    assert not result
+    assert result is False
 
     missing_item_type_content = {
         "address": "0x2278d6A697B2Be8aE4Ddf090f918d1642Ee43c8C",
@@ -73,10 +73,10 @@ async def test_handle_new_storage_invalid_content(
     result = await handle_new_storage(
         fixture_message_directory, missing_item_type_content
     )
-    assert not result
+    assert result is False
 
     result = await handle_new_storage(fixture_message_directory, content={})
-    assert not result
+    assert result is False
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_handle_new_storage_directory(
     content = json.loads(fixture_message_directory["item_content"])
 
     result = await handle_new_storage(fixture_message_directory, content)
-    assert result and result != -1
+    assert result
 
     # Check the updates to the content dict
     assert content["engine_info"] == ipfs_stats
@@ -150,4 +150,4 @@ async def test_handle_new_storage_invalid_hash(
     content["item_hash"] = "some-invalid-hash"
 
     result = await handle_new_storage(fixture_message_file, content)
-    assert not result
+    assert result is False


### PR DESCRIPTION
Fixed a test case related to item hash validation. Fixed an error where some invalid STORE messages could still be stored in the database.