### PR TITLE
Internal: store P2P client in aiohttp app context

### DIFF
--- a/src/aleph/services/p2p/__init__.py
+++ b/src/aleph/services/p2p/__init__.py
@@ -19,9 +19,6 @@ def init_p2p_client(config: Config) -> P2PClient:
     listen_maddr = Multiaddr(f"/ip4/0.0.0.0/tcp/{listen_port}")
     p2p_client = P2PClient(control_maddr=control_maddr, listen_maddr=listen_maddr)
 
-    # This singleton will not be required anymore once the API is in its own separate program.
-    singleton.client = p2p_client
-
     return p2p_client
 
 

--- a/src/aleph/services/p2p/singleton.py
+++ b/src/aleph/services/p2p/singleton.py
@@ -3,7 +3,6 @@ from typing import List, Optional, TypeVar
 from p2pclient import Client as P2PClient
 from .protocol import AlephProtocol
 
-client: Optional[P2PClient] = None
 streamer: Optional[AlephProtocol] = None
 
 # TODO: this global variable is currently used to distribute the list of HTTP nodes
@@ -18,10 +17,6 @@ def _get_singleton(singleton: Optional[T], name: str) -> T:
     if singleton is None:
         raise ValueError(f"{name} is null!")
     return singleton
-
-
-def get_p2p_client() -> P2PClient:
-    return _get_singleton(client, "P2P client")
 
 
 def get_streamer() -> AlephProtocol:

--- a/src/aleph/web/controllers/p2p.py
+++ b/src/aleph/web/controllers/p2p.py
@@ -10,7 +10,6 @@ from aleph.exceptions import InvalidMessageError
 from aleph.schemas.pending_messages import parse_message
 from aleph.services.ipfs.pubsub import pub as pub_ipfs
 from aleph.services.p2p.pubsub import publish as pub_p2p
-from aleph.services.p2p.singleton import get_p2p_client
 from aleph.types import Protocol
 
 LOGGER = logging.getLogger("web.controllers.p2p")
@@ -52,7 +51,7 @@ async def pub_json(request: web.Request):
         failed_publications.append(Protocol.IPFS)
 
     try:
-        p2p_client = get_p2p_client()
+        p2p_client = request.app["p2p_client"]
         await asyncio.wait_for(pub_p2p(p2p_client, request_data.get("topic"), request_data.get("data")), 10)
     except Exception:
         LOGGER.exception("Can't publish on p2p")


### PR DESCRIPTION
Problem: the P2P client object was stored in a singleton for use within API endpoints. Singleton objects can be complex to handle and introduce subtle bugs.

Solution: store the P2P client within the aiohttp application context.