### PR TITLE
Feature: return errors for invalid message API queries

### DIFF
--- a/src/aleph/web/controllers/utils.py
+++ b/src/aleph/web/controllers/utils.py
@@ -19,7 +19,9 @@ class Pagination(object):
         with_pagination = pagination_param != 0
 
         if pagination_page < 1:
-            raise web.HTTPBadRequest(text=f"Query field 'page' must be ≥ 1, not {pagination_page}")
+            raise web.HTTPBadRequest(
+                text=f"Query field 'page' must be ≥ 1, not {pagination_page}"
+            )
 
         if not with_pagination:
             pagination_per_page = None
@@ -64,6 +66,21 @@ class Pagination(object):
                     yield None
                 yield num
                 last = num
+
+
+def make_date_filters(start: float, end: float, filter_key: str):
+    filters = []
+    if start:
+        filters.append({filter_key: {"$gte": start}})
+    if end:
+        filters.append({filter_key: {"$lt": end}})
+
+    if len(filters) > 1:
+        return {"$and": filters}
+    if filters:
+        return filters[0]
+
+    return None
 
 
 def prepare_date_filters(request, filter_key):

--- a/tests/api/test_messages.py
+++ b/tests/api/test_messages.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Dict, Iterable, List, Optional, Callable, Union
+from typing import Dict, Iterable, List, Optional, Union
 
 import aiohttp
 import pytest
@@ -8,12 +8,6 @@ from .utils import get_messages_by_keys
 
 MESSAGES_URI = "/api/v0/messages.json"
 MESSAGES_PAGE_URI = "/api/v0/messages/page/{page}.json"
-
-
-def get_messages_by_predicate(
-    messages: Iterable[Dict], predicate: Callable[[Dict], bool]
-) -> List[Dict]:
-    return [msg for msg in messages if predicate(msg)]
 
 
 def check_message_fields(messages: Iterable[Dict]):
@@ -183,8 +177,9 @@ async def test_time_filters(fixture_messages, ccn_api_client):
     )
     assert_messages_equal(
         messages=messages,
-        expected_messages=get_messages_by_predicate(
-            fixture_messages, lambda msg: start_time <= msg["time"] < end_time
+        expected_messages=filter(
+            lambda msg: start_time <= msg["time"] < end_time,
+            fixture_messages,
         ),
     )
 
@@ -194,8 +189,9 @@ async def test_time_filters(fixture_messages, ccn_api_client):
     )
     assert_messages_equal(
         messages=messages,
-        expected_messages=get_messages_by_predicate(
-            fixture_messages, lambda msg: msg["time"] >= start_time
+        expected_messages=filter(
+            lambda msg: msg["time"] >= start_time,
+            fixture_messages,
         ),
     )
 
@@ -205,8 +201,9 @@ async def test_time_filters(fixture_messages, ccn_api_client):
     )
     assert_messages_equal(
         messages=messages,
-        expected_messages=get_messages_by_predicate(
-            fixture_messages, lambda msg: msg["time"] < end_time
+        expected_messages=filter(
+            lambda msg: msg["time"] < end_time,
+            fixture_messages,
         ),
     )
 
@@ -216,8 +213,9 @@ async def test_time_filters(fixture_messages, ccn_api_client):
     )
     assert_messages_equal(
         messages=messages,
-        expected_messages=get_messages_by_predicate(
-            fixture_messages, lambda msg: start_time <= msg["time"] < end_time
+        expected_messages=filter(
+            lambda msg: start_time <= msg["time"] < end_time,
+            fixture_messages,
         ),
     )
 
@@ -306,7 +304,9 @@ async def test_pagination(fixture_messages, ccn_api_client):
     assert messages == []
 
     # With the /page/{page} endpoint
-    response = await ccn_api_client.get(MESSAGES_PAGE_URI.format(page=2), params={"pagination": 4})
+    response = await ccn_api_client.get(
+        MESSAGES_PAGE_URI.format(page=2), params={"pagination": 4}
+    )
     assert response.status == 200, await response.text()
     messages = (await response.json())["messages"]
     assert_messages_equal(messages, sorted_messages_by_time[-8:-4])

--- a/tests/api/utils/__init__.py
+++ b/tests/api/utils/__init__.py
@@ -22,6 +22,9 @@ def get_messages_by_keys(messages: Iterable[Dict], **keys) -> List[Dict]:
     >>> )
 
     """
-    return get_messages_by_predicate(
-        messages, lambda msg: all(msg[k] == v for k, v in keys.items())
+    return list(
+        filter(
+            lambda msg: all(msg[k] == v for k, v in keys.items()),
+            messages,
+        )
     )


### PR DESCRIPTION
Problem: the messages.json endpoint was too permissive, allowing users to specify invalid chains, message types, make incoherent pagination / time filtering, etc.

Solution: detect these cases and return a 422 error.

Replaced the custom validation code of the endpoint by a Pydantic model. Added tests for start/end date parameters and pagination.

Breaking changes:
* The "endDate" field is now considered as exclusive. Only messages with a time field strictly lower than the value will be returned, instead of a value lower or equal before.
* The endpoint now returns a 422 error instead of a 400 when incorrect parameters are passed.

Moreover, a 422 error code will now be returned in the following situations, where the previous implementation would simply return a 200:
* if an invalid/unknown chain appears in the "chains".
* if an invalid/unknown message type is specified in "msgType".
* if an invalid item hash (=not a hexadecimal sha256, CIDv0 or CIDv1) is specified in the "hashes" or "contentHashes" field.
* if the "endDate" field is lower than the "startDate" field.
* if "endDate" or "startDate" are negative.
* if pagination parameters ("page" and "pagination") are negative.