### PR TITLE
Fix: Validation errors did not return valid JSON on POST

### DIFF
--- a/src/aleph/network.py
+++ b/src/aleph/network.py
@@ -5,6 +5,7 @@ from typing import Coroutine, Dict, List
 from urllib.parse import unquote
 
 from p2pclient import Client as P2PClient
+from pydantic import ValidationError
 
 from aleph.exceptions import InvalidMessageError
 from aleph.register_chain import VERIFIER_REGISTER
@@ -67,7 +68,10 @@ async def check_message(
     TODO: Implement it fully! Dangerous!
     """
 
-    message = parse_message(message_dict)
+    try:
+        message = parse_message(message_dict)
+    except ValidationError as e:
+        raise InvalidMessageError(json.dumps(e.json())) from e
 
     if trusted:
         # only in the case of a message programmatically built here

--- a/src/aleph/schemas/pending_messages.py
+++ b/src/aleph/schemas/pending_messages.py
@@ -204,7 +204,4 @@ def parse_message(message_dict: Any) -> BasePendingMessage:
 
     msg_cls = MESSAGE_TYPE_TO_CLASS[message_type]
 
-    try:
-        return msg_cls(**message_dict)
-    except ValidationError as e:
-        raise InvalidMessageError(json.dumps(e.json())) from e
+    return msg_cls(**message_dict)

--- a/src/aleph/web/controllers/p2p.py
+++ b/src/aleph/web/controllers/p2p.py
@@ -5,6 +5,7 @@ from typing import Dict, cast
 
 from aiohttp import web
 from configmanager import Config
+from pydantic import ValidationError
 
 from aleph.exceptions import InvalidMessageError
 from aleph.schemas.pending_messages import parse_message
@@ -32,6 +33,8 @@ def validate_request_data(config: Config, request_data: Dict) -> None:
         message = json.loads(cast(str, request_data.get("data")))
         try:
             _ = parse_message(message)
+        except ValidationError as e:
+            raise web.HTTPUnprocessableEntity(json=e.json(indent=4)) from e
         except InvalidMessageError as e:
             raise web.HTTPUnprocessableEntity(body=str(e))
 


### PR DESCRIPTION
When posting an invalid message, PyDantic exposes the reason of the validation failure as JSON. This result was serialized in a string with the wrong headers (text/plain) instead of being returned as a proper JSON body.