### PR TITLE
Internal: improve validation of the aggregates endpoint

### DIFF
--- a/src/aleph/web/controllers/utils.py
+++ b/src/aleph/web/controllers/utils.py
@@ -7,6 +7,7 @@ from bson import json_util
 
 PER_PAGE = 20
 PER_PAGE_SUMMARY = 50
+LIST_FIELD_SEPARATOR = ","
 
 
 class Pagination(object):


### PR DESCRIPTION
Use a Pydantic model instead of manual validation.
