### PR TITLE
Fix: reactivate message API time filters

### DIFF
--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -14,6 +14,7 @@ from aleph.web.controllers.utils import (
     LIST_FIELD_SEPARATOR,
     Pagination,
     cond_output,
+    make_date_filters,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -174,6 +175,15 @@ class MessageQueryParams(BaseMessageQueryParams):
         description="End date timestamp. If specified, only messages with "
         "a time field lower than this value will be returned.",
     )
+
+    def to_filter_list(self) -> List[Mapping[str, Any]]:
+        filters = super().to_filter_list()
+        date_filters = make_date_filters(
+            start=self.start_date, end=self.end_date, filter_key="time"
+        )
+        if date_filters:
+            filters.append(date_filters)
+        return filters
 
 
 class WsMessageQueryParams(BaseMessageQueryParams):

--- a/tests/api/test_messages.py
+++ b/tests/api/test_messages.py
@@ -171,7 +171,7 @@ async def fetch_messages_filter_time_expect_success(
 @pytest.mark.asyncio
 async def test_time_filters(fixture_messages, ccn_api_client):
     # Start and end time specified, should return all messages
-    start_time, end_time = 164821580, 1648215820
+    start_time, end_time = 1648215900, 1652126600
     messages = await fetch_messages_filter_time_expect_success(
         ccn_api_client, start=start_time, end=end_time
     )


### PR DESCRIPTION
Problem: the time filters are ignored in the messages.json endpoint since #337.

Solution: reactivate the filtering.