### PR TITLE
Fix: support disabling IPFS

### DIFF
--- a/deployment/scripts/run_aleph_ccn.sh
+++ b/deployment/scripts/run_aleph_ccn.sh
@@ -45,7 +45,10 @@ RABBITMQ_HOST=$(get_config rabbitmq.host)
 RABBITMQ_PORT=$(get_config rabbitmq.port)
 
 wait_for_it "${DB_URI}"
-wait_for_it -h "${IPFS_HOST}" -p "${IPFS_PORT}"
+
+if [ "$(get_config ipfs.enabled)" = "True" ]; then
+  wait_for_it -h "${IPFS_HOST}" -p "${IPFS_PORT}"
+fi
 wait_for_it -h "${RABBITMQ_HOST}" -p "${RABBITMQ_PORT}"
 
 exec pyaleph "${PYALEPH_ARGS[@]}"


### PR DESCRIPTION
Problem: the CCN startup script calls wait-for-it on the IPFS daemon even if `ipfs.enabled` is set to false.

Solution: check `ipfs.enabled` and skip the check accordingly.