### PR TITLE
Fix: process messages received from the REST API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     aioipfs@git+https://github.com/aleph-im/aioipfs.git@76d5624661e879a13b70f3ea87dc9c9604c7eda7
     aleph-client==0.4.6
     aleph-message==0.2.2
-    aleph-p2p-client@git+https://github.com/aleph-im/p2p-service-client-python@f9fc6057be5bf1712180129c831116a740441434
+    aleph-p2p-client@git+https://github.com/aleph-im/p2p-service-client-python@2c04af39c566217f629fd89505ffc3270fba8676
     aleph-pytezos@git+https://github.com/aleph-im/aleph-pytezos.git@97fe92ffa6e21ef5ec17ef4fa16c86022b30044c
     coincurve==15.0.1
     configmanager==1.35.1

--- a/src/aleph/services/p2p/pubsub.py
+++ b/src/aleph/services/p2p/pubsub.py
@@ -6,13 +6,19 @@ from aleph_p2p_client import AlephP2PServiceClient
 LOGGER = logging.getLogger("P2P.pubsub")
 
 
-async def publish(p2p_client: AlephP2PServiceClient, topic: str, message: Union[bytes, str]) -> None:
+async def publish(
+    p2p_client: AlephP2PServiceClient,
+    topic: str,
+    message: Union[bytes, str],
+    loopback: bool = False,
+) -> None:
     """
     Publishes a message on the specified topic.
     :param p2p_client: P2P daemon client.
     :param topic: Topic on which to send the message.
     :param message: The message itself. Can be provided as bytes or as a string.
+    :param loopback: Whether the message should also be forwarded/processed on this node.
     """
 
     data = message if isinstance(message, bytes) else message.encode("UTF-8")
-    await p2p_client.publish(data=data, topic=topic)
+    await p2p_client.publish(data=data, topic=topic, loopback=loopback)

--- a/src/aleph/web/controllers/p2p.py
+++ b/src/aleph/web/controllers/p2p.py
@@ -46,14 +46,24 @@ async def pub_json(request: web.Request):
 
     try:
         if request.app["config"].ipfs.enabled.value:
-            await asyncio.wait_for(pub_ipfs(request_data.get("topic"), request_data.get("data")), 1)
+            await asyncio.wait_for(
+                pub_ipfs(request_data.get("topic"), request_data.get("data")), 1
+            )
     except Exception:
         LOGGER.exception("Can't publish on ipfs")
         failed_publications.append(Protocol.IPFS)
 
     try:
         p2p_client: AlephP2PServiceClient = request.app["p2p_client"]
-        await asyncio.wait_for(pub_p2p(p2p_client, request_data.get("topic"), request_data.get("data")), 10)
+        await asyncio.wait_for(
+            pub_p2p(
+                p2p_client,
+                request_data.get("topic"),
+                request_data.get("data"),
+                loopback=True,
+            ),
+            10,
+        )
     except Exception:
         LOGGER.exception("Can't publish on p2p")
         failed_publications.append(Protocol.P2P)


### PR DESCRIPTION
Problem: the messages sent to the `pub_json` endpoint are forwarded to the network using P2P/IPFS pubsubs but are not actually processed on the node.

Solution: use the latest version of the P2P service client and use the new loopback feature.