### PR TITLE
Feature: Tezos message sync

### DIFF
--- a/src/aleph/chains/avalanche.py
+++ b/src/aleph/chains/avalanche.py
@@ -52,8 +52,13 @@ async def get_chain_info(address):
 
 
 async def verify_signature(message: BasePendingMessage):
+
     """Verifies a signature of a message, return True if verified, false if not"""
     try:
+        if message.signature is None:
+            LOGGER.warning("'%s': missing signature.", message.item_hash)
+            return False
+
         chain_id, hrp = await get_chain_info(message.sender)
     except Exception:
         LOGGER.exception("Avalanche sender address deserialization error")

--- a/src/aleph/chains/cosmos.py
+++ b/src/aleph/chains/cosmos.py
@@ -54,6 +54,10 @@ async def verify_signature(message: BasePendingMessage) -> bool:
     """Verifies a signature of a message, return True if verified, false if not"""
 
     try:
+        if message.signature is None:
+            LOGGER.warning("'%s': missing signature.", message.item_hash)
+            return False
+
         signature = json.loads(message.signature)
     except Exception:
         LOGGER.exception("Cosmos signature deserialization error")

--- a/src/aleph/chains/nuls.py
+++ b/src/aleph/chains/nuls.py
@@ -25,6 +25,11 @@ CHAIN_NAME = "NULS"
 
 async def verify_signature(message: BasePendingMessage) -> bool:
     """Verifies a signature of a message, return True if verified, false if not"""
+
+    if message.signature is None:
+        LOGGER.warning("'%s': missing signature.", message.item_hash)
+        return False
+
     sig_raw = bytes(bytearray.fromhex(message.signature))
     sig = NulsSignature(sig_raw)
 

--- a/src/aleph/chains/nuls2.py
+++ b/src/aleph/chains/nuls2.py
@@ -47,6 +47,11 @@ DECIMALS = None  # will get populated later... bad?
 
 async def verify_signature(message: BasePendingMessage) -> bool:
     """Verifies a signature of a message, return True if verified, false if not"""
+
+    if message.signature is None:
+        LOGGER.warning("'%s': missing signature.", message.item_hash)
+        return False
+
     sig_raw = base64.b64decode(message.signature)
 
     sender_hash = hash_from_address(message.sender)

--- a/src/aleph/chains/solana.py
+++ b/src/aleph/chains/solana.py
@@ -16,6 +16,10 @@ CHAIN_NAME = "SOL"
 async def verify_signature(message: BasePendingMessage) -> bool:
     """Verifies a signature of a message, return True if verified, false if not"""
 
+    if message.signature is None:
+        LOGGER.warning("'%s': missing signature.", message.item_hash)
+        return False
+
     try:
         signature = json.loads(message.signature)
         sigdata = base58.b58decode(signature["signature"])

--- a/src/aleph/chains/substrate.py
+++ b/src/aleph/chains/substrate.py
@@ -14,6 +14,10 @@ CHAIN_NAME = "DOT"
 async def verify_signature(message: BasePendingMessage) -> bool:
     """Verifies a signature of a message, return True if verified, false if not"""
 
+    if message.signature is None:
+        LOGGER.warning("'%s': missing signature.", message.item_hash)
+        return False
+
     try:
         signature = json.loads(message.signature)
     except Exception:

--- a/src/aleph/chains/tezos.py
+++ b/src/aleph/chains/tezos.py
@@ -86,7 +86,7 @@ def make_graphql_query(
     recentBlock
     status
   }
-  stats {
+  stats(address: "%s") {
     totalEvents
   }
   events(limit: %d, skip: %d, source: "%s", type: "%s") {
@@ -99,6 +99,7 @@ def make_graphql_query(
   }
 }
 """ % (
+        sync_contract_address,
         limit,
         skip,
         sync_contract_address,

--- a/src/aleph/chains/tezos.py
+++ b/src/aleph/chains/tezos.py
@@ -1,11 +1,25 @@
+import asyncio
 import json
 import logging
+from typing import List, Sequence, Tuple
 
+import aiohttp
+from aleph_message.models import Chain, MessageType, StoreContent, ItemType
 from aleph_pytezos.crypto.key import Key
+from configmanager import Config
 
 from aleph.chains.common import get_verification_buffer
-from aleph.register_chain import register_verifier
-from aleph.schemas.pending_messages import BasePendingMessage
+from aleph.chains.tx_context import TxContext
+from aleph.model.chains import Chain as ChainDb
+from aleph.model.pending import PendingMessage
+from aleph.register_chain import register_verifier, register_incoming_worker
+from aleph.schemas.chains.tezos_indexer_response import (
+    IndexerResponse,
+    SyncStatus,
+    IndexerMessageEvent,
+)
+from aleph.schemas.pending_messages import BasePendingMessage, PendingStoreMessage
+from aleph.utils import get_sha256
 
 LOGGER = logging.getLogger(__name__)
 CHAIN_NAME = "TEZOS"
@@ -15,6 +29,10 @@ async def verify_signature(message: BasePendingMessage) -> bool:
     """
     Verifies the cryptographic signature of a message signed with a Tezos key.
     """
+
+    if message.signature is None:
+        LOGGER.warning("'%s': missing signature.", message.item_hash)
+        return False
 
     verification_buffer = get_verification_buffer(message)
     try:
@@ -27,7 +45,7 @@ async def verify_signature(message: BasePendingMessage) -> bool:
         signature = signature_dict["signature"]
         public_key = signature_dict["publicKey"]
     except KeyError as e:
-        LOGGER.exception("'%s' key missing from Tezos signature dictionary.", e.args[0])
+        LOGGER.warning("'%s' key missing from Tezos signature dictionary.", e.args[0])
         return False
 
     key = Key.from_encoded_key(public_key)
@@ -52,3 +70,198 @@ async def verify_signature(message: BasePendingMessage) -> bool:
 
 
 register_verifier(CHAIN_NAME, verify_signature)
+
+
+def make_graphql_status_query():
+    return "{indexStatus {status}}"
+
+
+def make_graphql_query(
+    sync_contract_address: str, event_type: str, limit: int, skip: int
+):
+    return """
+{
+  indexStatus {
+    oldestBlock
+    recentBlock
+    status
+  }
+  stats {
+    totalEvents
+  }
+  events(limit: %d, skip: %d, source: "%s", type: "%s") {
+    source
+    timestamp
+    blockHash
+    blockLevel
+    type
+    payload
+  }
+}
+""" % (
+        limit,
+        skip,
+        sync_contract_address,
+        event_type,
+    )
+
+
+async def get_indexer_status(http_session: aiohttp.ClientSession) -> SyncStatus:
+    response = await http_session.post("/", json={"query": make_graphql_status_query()})
+    response.raise_for_status()
+    response_json = await response.json()
+
+    return SyncStatus(response_json["data"]["indexStatus"]["status"])
+
+
+async def fetch_messages(
+    http_session: aiohttp.ClientSession,
+    sync_contract_address: str,
+    event_type: str,
+    limit: int,
+    skip: int,
+) -> IndexerResponse[IndexerMessageEvent]:
+
+    query = make_graphql_query(
+        limit=limit,
+        skip=skip,
+        sync_contract_address=sync_contract_address,
+        event_type=event_type,
+    )
+
+    response = await http_session.post("/", json={"query": query})
+    response.raise_for_status()
+    response_json = await response.json()
+
+    return IndexerResponse[IndexerMessageEvent].parse_obj(response_json)
+
+
+def indexer_event_to_aleph_message(
+    indexer_event: IndexerMessageEvent,
+) -> Tuple[BasePendingMessage, TxContext]:
+
+    if message_type := indexer_event.payload.message_type != "STORE_IPFS":
+        raise ValueError(f"Unexpected message type: {message_type}")
+
+    content = StoreContent(
+        address=indexer_event.payload.addr,
+        time=indexer_event.payload.timestamp,
+        item_type=ItemType.ipfs,
+        item_hash=indexer_event.payload.message_content,
+    )
+    item_content = content.json()
+    item_hash = get_sha256(item_content)
+
+    pending_message = PendingStoreMessage(
+        item_hash=item_hash,
+        sender=indexer_event.payload.addr,
+        chain=Chain.TEZOS,
+        signature=None,
+        type=MessageType.store,
+        item_content=StoreContent(
+            address=indexer_event.payload.addr,
+            time=indexer_event.payload.timestamp,
+            item_type=ItemType.ipfs,
+            item_hash=indexer_event.payload.message_content,
+        ).json(),
+        content=content,
+        item_type=ItemType.inline,
+        time=indexer_event.timestamp.timestamp(),
+        channel=None,
+    )
+
+    tx_context = TxContext(
+        chain_name=Chain.TEZOS,
+        tx_hash=indexer_event.block_hash,
+        height=indexer_event.block_level,
+        time=indexer_event.timestamp.timestamp(),
+        publisher=indexer_event.source,
+    )
+
+    return pending_message, tx_context
+
+
+async def extract_aleph_messages_from_indexer_response(
+    indexer_response: IndexerResponse[IndexerMessageEvent],
+) -> List[Tuple[BasePendingMessage, TxContext]]:
+
+    events = indexer_response.data.events
+    return [indexer_event_to_aleph_message(event) for event in events]
+
+
+async def insert_pending_messages(
+    pending_messages: Sequence[Tuple[BasePendingMessage, TxContext]]
+):
+    for pending_message, tx_context in pending_messages:
+        await PendingMessage.collection.insert_one(
+            {
+                "message": pending_message.dict(exclude={"content"}),
+                "source": dict(
+                    chain_name=tx_context.chain_name,
+                    tx_hash=tx_context.tx_hash,
+                    height=tx_context.height,
+                    check_message=False,
+                ),
+            }
+        )
+
+
+async def fetch_incoming_messages(config: Config):
+
+    indexer_url = config.tezos.indexer_url.value
+
+    async with aiohttp.ClientSession(indexer_url) as http_session:
+        status = await get_indexer_status(http_session)
+
+        if status != SyncStatus.SYNCED:
+            LOGGER.warning("Tezos indexer is not yet synced, waiting until it is")
+            return
+
+        last_committed_height = (await ChainDb.get_last_height(Chain.TEZOS)) or 0
+        limit = 100
+
+        try:
+            while True:
+                indexer_response_data = await fetch_messages(
+                    http_session,
+                    sync_contract_address=config.tezos.sync_contract.value,
+                    event_type="MessageEvent",
+                    limit=limit,
+                    skip=last_committed_height,
+                )
+                pending_messages = await extract_aleph_messages_from_indexer_response(
+                    indexer_response_data
+                )
+                await insert_pending_messages(pending_messages)
+
+                last_committed_height += limit
+                if (
+                    last_committed_height
+                    >= indexer_response_data.data.stats.total_events
+                ):
+                    last_committed_height = (
+                        indexer_response_data.data.stats.total_events
+                    )
+                    break
+
+        finally:
+            await ChainDb.set_last_height(
+                chain=Chain.TEZOS, height=last_committed_height
+            )
+
+
+async def tezos_sync_worker(config):
+    if config.tezos.enabled.value:
+        while True:
+            try:
+                await fetch_incoming_messages(config)
+
+            except Exception:
+                LOGGER.exception(
+                    "An unexpected exception occurred, "
+                    "relaunching Tezos message sync in 10 seconds"
+                )
+            await asyncio.sleep(10)
+
+
+register_incoming_worker(CHAIN_NAME, tezos_sync_worker)

--- a/src/aleph/chains/tx_context.py
+++ b/src/aleph/chains/tx_context.py
@@ -7,5 +7,5 @@ class TxContext:
     tx_hash: str
     height: int
     # Transaction timestamp, in Unix time (number of seconds since epoch).
-    time: int
+    time: float
     publisher: str

--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -41,11 +41,10 @@ def get_defaults():
         },
         "storage": {"folder": "./data/", "store_files": False, "engine": "mongodb"},
         "tezos": {
-            "enabled": False,
-            "indexer_url": "https://tezosdevnet.api.aleph.cloud",
+            "enabled": True,
+            "indexer_url": "https://tezos-mainnet.api.aleph.cloud",
             "chain_id": "main",
-            "sync_contract": "KT1BfL57oZfptdtMFZ9LNakEPvuPPA2urdSW",
-            "authorized_emitters": ["0x23eC28598DCeB2f7082Cc3a9D670592DfEd6e0dC"],
+            "sync_contract": "KT1FfEoaNvooDfYrP61Ykct6L8z7w7e2pgnT",
         },
         "nuls": {
             "chain_id": 8964,

--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -40,6 +40,13 @@ def get_defaults():
             "topics": ["ALIVE", "ALEPH-TEST"],
         },
         "storage": {"folder": "./data/", "store_files": False, "engine": "mongodb"},
+        "tezos": {
+            "enabled": False,
+            "indexer_url": "https://tezosdevnet.api.aleph.cloud",
+            "chain_id": "main",
+            "sync_contract": "KT1BfL57oZfptdtMFZ9LNakEPvuPPA2urdSW",
+            "authorized_emitters": ["0x23eC28598DCeB2f7082Cc3a9D670592DfEd6e0dC"],
+        },
         "nuls": {
             "chain_id": 8964,
             "enabled": False,

--- a/src/aleph/schemas/base_messages.py
+++ b/src/aleph/schemas/base_messages.py
@@ -28,7 +28,7 @@ class AlephBaseMessage(GenericModel, Generic[MType, ContentType]):
 
     sender: str
     chain: Chain
-    signature: str
+    signature: Optional[str]
     type: MType
     item_content: Optional[str]
     item_type: ItemType

--- a/src/aleph/schemas/chains/tezos_indexer_response.py
+++ b/src/aleph/schemas/chains/tezos_indexer_response.py
@@ -1,0 +1,57 @@
+import datetime as dt
+from typing import Any, List, Generic, TypeVar
+
+from pydantic import BaseModel, Field
+from enum import Enum
+
+from pydantic.generics import GenericModel
+
+
+PayloadType = TypeVar("PayloadType")
+
+
+class SyncStatus(str, Enum):
+    SYNCED = "synced"
+    IN_PROGRESS = "in_progress"
+
+
+class IndexerStatus(BaseModel):
+    oldest_block: str = Field(alias="oldestBlock")
+    recent_block: str = Field(alias="recentBlock")
+    status: SyncStatus
+
+
+class IndexerStats(BaseModel):
+    total_events: int = Field(alias="totalEvents")
+
+
+class IndexerEvent(GenericModel, Generic[PayloadType]):
+    source: str
+    timestamp: dt.datetime
+    block_hash: str = Field(alias="blockHash")
+    block_level: int = Field(alias="blockLevel")
+    type: str
+    payload: PayloadType
+
+
+class MessageEventPayload(BaseModel):
+    timestamp: float
+    addr: str
+    message_type: str = Field(alias="msgtype")
+    message_content: str = Field(alias="msgcontent")
+
+
+IndexerMessageEvent = IndexerEvent[MessageEventPayload]
+
+
+IndexerEventType = TypeVar("IndexerEventType", bound=IndexerEvent)
+
+
+class IndexerResponseData(GenericModel, Generic[IndexerEventType]):
+    index_status: IndexerStatus = Field(alias="indexStatus")
+    stats: IndexerStats
+    events: List[IndexerEventType]
+
+
+class IndexerResponse(GenericModel, Generic[IndexerEventType]):
+    data: IndexerResponseData[IndexerEventType]

--- a/tests/chains/test_cosmos.py
+++ b/tests/chains/test_cosmos.py
@@ -12,7 +12,7 @@ TEST_MESSAGE = '{"chain": "CSDK", "channel": "TEST", "sender": "cosmos1rq3rcux05
 async def test_verify_signature_real():
     message = json.loads(TEST_MESSAGE)
     result = await verify_signature(message)
-    assert result == True
+    assert result is True
     
 @pytest.mark.asyncio
 async def test_verify_signature_nonexistent():
@@ -22,7 +22,7 @@ async def test_verify_signature_nonexistent():
         'type': 'TYPE',
         'item_hash': 'ITEM_HASH'
     })
-    assert result == False
+    assert result is False
     
 @pytest.mark.asyncio
 async def test_verify_signature_bad_json():
@@ -33,7 +33,7 @@ async def test_verify_signature_bad_json():
         'item_hash': 'ITEM_HASH',
         'signature': 'baba'
     })
-    assert result == False
+    assert result is False
     
 @pytest.mark.asyncio
 async def test_verify_signature_no_data():

--- a/tests/chains/test_register.py
+++ b/tests/chains/test_register.py
@@ -6,7 +6,7 @@ from aleph.register_chain import (VERIFIER_REGISTER, INCOMING_WORKERS,
                                   register_verifier,
                                   register_incoming_worker,
                                   register_outgoing_worker)
-from aleph.chains import ethereum, nuls, nuls2, substrate, cosmos, avalanche
+from aleph.chains import ethereum, nuls, nuls2, substrate, cosmos, avalanche, tezos
 
 @pytest.mark.asyncio
 async def test_register_verifier(monkeypatch):
@@ -82,8 +82,10 @@ async def test_register_incoming_worker(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_incoming():
-    assert len(INCOMING_WORKERS) == 2  # 2 verifiers are included by default
+    assert len(INCOMING_WORKERS) == 3  # 3 verifiers are included by default
     assert "ETH" in INCOMING_WORKERS.keys()
     assert INCOMING_WORKERS["ETH"] is ethereum.ethereum_incoming_worker
     assert "NULS2" in INCOMING_WORKERS.keys()
     assert INCOMING_WORKERS["NULS2"] is nuls2.nuls_incoming_worker
+    assert "TEZOS" in INCOMING_WORKERS.keys()
+    assert INCOMING_WORKERS["TEZOS"] is tezos.tezos_sync_worker


### PR DESCRIPTION
Problem: Users need a solution to pin content on Aleph automatically when minting NFTs on Tezos.

Solution: Add a sync worker to fetch messages from the Aleph sync smart contract on Tezos and transform them into valid Aleph messages.

Replaces #355 since that branch is on a fork.