### PR TITLE
Fix: Default peers of p2p-service did not work

### DIFF
--- a/deployment/samples/docker-compose/sample-config.yml
+++ b/deployment/samples/docker-compose/sample-config.yml
@@ -39,7 +39,11 @@ p2p:
   http_port: 4024
   port: 4025
   control_port: 4030
+  listen_port: 4031
   reconnect_delay: 60
+  peers:
+    - /dns/api1.aleph.im/tcp/4025/p2p/Qmaxufiqdyt5uVWcy1Xh2nh3Rs3382ArnSP2umjCiNG2Vs
+    - /dns/api2.aleph.im/tcp/4025/p2p/QmZkurbY2G2hWay59yiTgQNaQxHSNzKZFt2jbnwJhQcKgV
 
 rabbitmq:
   host: rabbitmq


### PR DESCRIPTION
The p2p service failed to connect to the rest of the network using the configured peers. The default configuration of pyaleph is in Python code and cannot be read from the p2p-service.

Solution: override the default peers in the default configuration file as well.

Related: Fix the default values in the configuration of p2p-service in https://github.com/aleph-im/p2p-service/pull/42