### PR TITLE
Fix: slow response times on addresses/stats.json

### DIFF
--- a/deployment/migrations/versions/0010_8a5eaab15d40_address_stats_view.py
+++ b/deployment/migrations/versions/0010_8a5eaab15d40_address_stats_view.py
@@ -1,0 +1,31 @@
+"""address stats view
+
+Revision ID: 8a5eaab15d40
+Revises: 8edf69c47884
+Create Date: 2023-03-06 17:27:14.514803
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8a5eaab15d40'
+down_revision = '8edf69c47884'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        create materialized view address_stats_mat_view as 
+            select sender as address, type, count(*) as nb_messages
+                from messages
+                group by sender, type
+        """)
+    op.execute("create unique index ix_address_type on address_stats_mat_view(address, type)")
+
+
+def downgrade() -> None:
+    op.execute("drop materialized view address_stats_mat_view")

--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -34,6 +34,7 @@ from aleph.jobs import start_jobs
 from aleph.jobs.job_utils import prepare_loop
 from aleph.network import listener_tasks
 from aleph.services import p2p
+from aleph.services.cache.materialized_views import refresh_cache_materialized_views
 from aleph.services.ipfs import IpfsService
 from aleph.services.ipfs.common import make_ipfs_client
 from aleph.services.keys import generate_keypair, save_keys
@@ -287,6 +288,10 @@ async def main(args):
         )
         tasks.append(chain_service.chain_event_loop(config))
         LOGGER.debug("Initialized listeners")
+
+        LOGGER.debug("Initializing cache tasks")
+        tasks.append(refresh_cache_materialized_views(session_factory))
+        LOGGER.debug("Initialized cache tasks")
 
         # Need to be passed here otherwise it gets lost in the fork
         from aleph.services.p2p import manager as p2p_manager

--- a/src/aleph/services/cache/materialized_views.py
+++ b/src/aleph/services/cache/materialized_views.py
@@ -1,0 +1,29 @@
+import logging
+
+from aleph.db.accessors.messages import refresh_address_stats_mat_view
+from aleph.types.db_session import DbSessionFactory
+import asyncio
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def refresh_cache_materialized_views(session_factory: DbSessionFactory) -> None:
+    """
+    Refresh DB materialized views used as caches, periodically.
+
+    Materialized views are a simple solution to cache expensive DB queries, at the cost
+    of refreshing them manually once in a while. This background task does exactly that.
+    Note that materialized views used by the API should support concurrent refreshing
+    to reduce latency.
+    """
+
+    while True:
+        try:
+            with session_factory() as session:
+                refresh_address_stats_mat_view(session)
+                LOGGER.info("Refreshed address stats materialized view")
+
+        except Exception:
+            LOGGER.exception("Error refreshing cache materialized views")
+
+        await asyncio.sleep(10 * 60)

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -11,7 +11,7 @@ from aleph.db.accessors.files import (
     get_address_files_for_api,
     get_address_files_stats,
 )
-from aleph.db.accessors.messages import get_message_stats_by_sender
+from aleph.db.accessors.messages import get_message_stats_by_address
 from aleph.schemas.api.accounts import (
     GetAccountBalanceResponse,
     GetAccountFilesResponse,
@@ -24,10 +24,10 @@ from aleph.web.controllers.app_state_getters import get_session_factory_from_req
 def make_stats_dict(stats) -> Dict[str, Any]:
     stats_dict = {}
 
-    sorted_stats = sorted(stats, key=lambda s: s.sender)
-    for sender, sender_stats in groupby(sorted_stats, key=lambda s: s.sender):
-        nb_messages_by_type = {s.type: s.nb_messages for s in sender_stats}
-        stats_dict[sender] = {
+    sorted_stats = sorted(stats, key=lambda s: s.address)
+    for address, address_stats in groupby(sorted_stats, key=lambda s: s.address):
+        nb_messages_by_type = {s.type: s.nb_messages for s in address_stats}
+        stats_dict[address] = {
             "messages": sum(val for val in nb_messages_by_type.values()),
             "aggregates": nb_messages_by_type.get(MessageType.aggregate, 0),
             "posts": nb_messages_by_type.get(MessageType.post, 0),
@@ -45,7 +45,7 @@ async def addresses_stats_view(request: web.Request):
     session_factory: DbSessionFactory = request.app["session_factory"]
 
     with session_factory() as session:
-        stats = get_message_stats_by_sender(session=session, addresses=addresses)
+        stats = get_message_stats_by_address(session=session, addresses=addresses)
 
     stats_dict = make_stats_dict(stats)
 

--- a/tests/db/test_accounts.py
+++ b/tests/db/test_accounts.py
@@ -1,0 +1,102 @@
+import datetime as dt
+from typing import List
+
+import pytest
+import pytz
+from aleph_message.models import Chain, ItemType, MessageType
+from sqlalchemy import select
+
+from aleph.db.accessors.messages import (
+    get_message_stats_by_address,
+    refresh_address_stats_mat_view,
+)
+from aleph.db.models import MessageDb
+from aleph.toolkit.timestamp import timestamp_to_datetime
+from aleph.types.channel import Channel
+from aleph.types.db_session import DbSessionFactory
+
+from aleph.db.accessors.chains import upsert_chain_sync_status, get_last_height
+from aleph.db.models.chains import ChainSyncStatusDb
+
+
+@pytest.fixture
+def fixture_messages():
+    return [
+        MessageDb(
+            item_hash="e3b24727335e34016247c0d37e2b0203bb8c2d76deddafc1700b4cf0e13845c5",
+            chain=Chain.ETH,
+            sender="0xB68B9D4f3771c246233823ed1D3Add451055F9Ef",
+            signature="0xabfa661aab1a9f58955940ea213387de4773f8b1f244c2236cd4ac5ba7bf2ba902e17074bc4b289ba200807bb40951f4249668b055dc15af145b8842ecfad0601c",
+            item_type=ItemType.storage,
+            type=MessageType.forget,
+            item_content=None,
+            content={
+                "address": "0xB68B9D4f3771c246233823ed1D3Add451055F9Ef",
+                "time": 1645794065.439,
+                "aggregates": [],
+                "hashes": ["QmTQPocJ8n3r7jhwYxmCDR5bJ4SNsEhdVm8WwkNbGctgJF"],
+                "reason": "None",
+            },
+            size=154,
+            time=timestamp_to_datetime(1645794065.439),
+            channel=Channel("TEST"),
+        ),
+        MessageDb(
+            item_hash="aea68aac5f4dc6e6b813fc5de9e6c17d3ef1b03e77eace15398405260baf3ce4",
+            chain=Chain.ETH,
+            sender="0x1234",
+            signature="0x705ca1365a0b794cbfcf89ce13239376d0aab0674d8e7f39965590a46e5206a664bc4b313f3351f313564e033c9fe44fd258492dfbd6c36b089677d73224da0a1c",
+            type=MessageType.aggregate,
+            item_content='{"address": "0x51A58800b26AA1451aaA803d1746687cB88E0500", "key": "my-aggregate", "time": 1664999873, "content": {"easy": "as", "a-b": "c"}}',
+            content={
+                "address": "0x1234",
+                "key": "my-aggregate",
+                "time": 1664999873,
+                "content": {"easy": "as", "a-b": "c"},
+            },
+            item_type=ItemType.inline,
+            size=2000,
+            time=pytz.utc.localize(dt.datetime.utcfromtimestamp(1664999872)),
+            channel=Channel("CHANEL-N5"),
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_message_stats_by_address(
+    session_factory: DbSessionFactory, fixture_messages: List[MessageDb]
+):
+    # No data test
+    with session_factory() as session:
+        stats_no_data = get_message_stats_by_address(session)
+        assert stats_no_data == []
+
+        # Refresh the materialized view
+        session.add_all(fixture_messages)
+        session.commit()
+
+        refresh_address_stats_mat_view(session)
+        session.commit()
+
+        stats = get_message_stats_by_address(session)
+        assert len(stats) == 2
+
+        stats_by_address = {row.address: row for row in stats}
+        assert (
+            stats_by_address["0xB68B9D4f3771c246233823ed1D3Add451055F9Ef"].type
+            == MessageType.forget
+        )
+        assert (
+            stats_by_address["0xB68B9D4f3771c246233823ed1D3Add451055F9Ef"].nb_messages
+            == 1
+        )
+        assert stats_by_address["0x1234"].type == MessageType.aggregate
+        assert stats_by_address["0x1234"].nb_messages == 1
+
+        # Filter by address
+        stats = get_message_stats_by_address(session, addresses=("0x1234",))
+        assert len(stats) == 1
+        row = stats[0]
+        assert row.address == "0x1234"
+        assert row.type == MessageType.aggregate
+        assert row.nb_messages == 1


### PR DESCRIPTION
Problem: the response time of the stats endpoint is too slow because we perform a group by query on the whole message table every time.

Solution: go back to caching. We use a postgres materialized view to this purpose to make this cache available to other endpoints.