### PR TITLE
Feature: support all message types in trusted messages

### DIFF
--- a/src/aleph/schemas/pending_messages.py
+++ b/src/aleph/schemas/pending_messages.py
@@ -26,7 +26,7 @@ from aleph_message.models import (
     ForgetContent,
     PostContent,
     ProgramContent,
-    StoreContent,
+    StoreContent, BaseContent,
 )
 from aleph_message.models import ItemType, MessageType
 from pydantic import ValidationError

--- a/tests/chains/test_tezos.py
+++ b/tests/chains/test_tezos.py
@@ -1,7 +1,15 @@
 import pytest
-from aleph_message.models import Chain, MessageType, ItemType, StoreContent
+from aleph_message.models import (
+    Chain,
+    MessageType,
+    ItemType,
+    StoreContent,
+    PostContent,
+    AggregateContent,
+)
 
 from aleph.chains.tezos import indexer_event_to_aleph_message
+from aleph.exceptions import InvalidMessageError
 from aleph.network import verify_signature
 from aleph.schemas.chains.tezos_indexer_response import (
     IndexerMessageEvent,
@@ -51,7 +59,7 @@ async def test_tezos_verify_signature_ed25519():
     await verify_signature(message)
 
 
-def test_indexer_event_to_aleph_message():
+def test_indexer_event_to_aleph_message_store_ipfs():
     indexer_event = IndexerMessageEvent(
         source="KT1BfL57oZfptdtMFZ9LNakEPvuPPA2urdSW",
         timestamp="2022-11-16T00:00:00Z",
@@ -90,3 +98,139 @@ def test_indexer_event_to_aleph_message():
     assert tx_context.publisher == indexer_event.source
     assert tx_context.tx_hash == indexer_event.block_hash
     assert tx_context.height == indexer_event.block_level
+
+
+def test_indexer_event_to_aleph_message_post():
+    content = PostContent(
+        content={"body": "My first post on Tezos"},
+        ref=None,
+        type="my-type",
+        address="KT1VBeLD7hzKpj17aRJ3Kc6QQFeikCEXi7W6",
+        time=1000,
+    )
+
+    indexer_event = IndexerMessageEvent(
+        source="KT1BfL57oZfptdtMFZ9LNakEPvuPPA2urdSW",
+        timestamp="2022-11-16T00:00:00Z",
+        type="MessageEvent",
+        blockHash="BMaSNJJCebD52e37nNEmSntx9UraJo2js5QT9siXA34E7a8gzRc",
+        blockLevel=584664,
+        payload=MessageEventPayload(
+            timestamp=1668611900,
+            addr="KT1VBeLD7hzKpj17aRJ3Kc6QQFeikCEXi7W6",
+            msgtype="POST",
+            msgcontent=content.json(),
+        ),
+    )
+
+    pending_message, tx_context = indexer_event_to_aleph_message(indexer_event)
+
+    assert (
+        pending_message.item_hash
+        == "cbe9c48c7290d6e243c80247444c6d28c36a475c99286b6e921b5223dc2cba39"
+    )
+    assert pending_message.sender == indexer_event.payload.addr
+    assert pending_message.chain == Chain.TEZOS
+    assert pending_message.signature is None
+    assert pending_message.type == MessageType.post
+    assert pending_message.item_type == ItemType.inline
+    assert pending_message.channel is None
+
+    message_content = PostContent.parse_raw(pending_message.item_content)
+    assert message_content.address == content.address
+    assert message_content.time == content.time
+    assert message_content.ref == content.ref
+    assert message_content.type == content.type
+    assert message_content.content == content.content
+
+    assert tx_context.chain_name == Chain.TEZOS
+    assert tx_context.time == indexer_event.timestamp.timestamp()
+    assert tx_context.publisher == indexer_event.source
+    assert tx_context.tx_hash == indexer_event.block_hash
+    assert tx_context.height == indexer_event.block_level
+
+
+def test_indexer_event_to_aleph_message_aggregate():
+    content = AggregateContent(
+        key="my-aggregate",
+        content={"body": "My first post on Tezos"},
+        address="KT1VBeLD7hzKpj17aRJ3Kc6QQFeikCEXi7W6",
+        time=1000,
+    )
+
+    indexer_event = IndexerMessageEvent(
+        source="KT1BfL57oZfptdtMFZ9LNakEPvuPPA2urdSW",
+        timestamp="2022-11-16T00:00:00Z",
+        type="MessageEvent",
+        blockHash="BMaSNJJCebD52e37nNEmSntx9UraJo2js5QT9siXA34E7a8gzRc",
+        blockLevel=584664,
+        payload=MessageEventPayload(
+            timestamp=1668611900,
+            addr="KT1VBeLD7hzKpj17aRJ3Kc6QQFeikCEXi7W6",
+            msgtype="AGGREGATE",
+            msgcontent=content.json(),
+        ),
+    )
+
+    pending_message, tx_context = indexer_event_to_aleph_message(indexer_event)
+
+    assert (
+        pending_message.item_hash
+        == "8771f3be34fdb380f98bb9e4e6b37658c68581317e3d5efed966e53caa060a5b"
+    )
+    assert pending_message.sender == indexer_event.payload.addr
+    assert pending_message.chain == Chain.TEZOS
+    assert pending_message.signature is None
+    assert pending_message.type == MessageType.aggregate
+    assert pending_message.item_type == ItemType.inline
+    assert pending_message.channel is None
+
+    message_content = AggregateContent.parse_raw(pending_message.item_content)
+    assert message_content.address == content.address
+    assert message_content.time == content.time
+    assert message_content.key == content.key
+    assert message_content.content == content.content
+
+    assert tx_context.chain_name == Chain.TEZOS
+    assert tx_context.time == indexer_event.timestamp.timestamp()
+    assert tx_context.publisher == indexer_event.source
+    assert tx_context.tx_hash == indexer_event.block_hash
+    assert tx_context.height == indexer_event.block_level
+
+
+def test_indexer_event_to_aleph_message_invalid_payload():
+    indexer_event = IndexerMessageEvent(
+        source="KT1BfL57oZfptdtMFZ9LNakEPvuPPA2urdSW",
+        timestamp="2022-11-16T00:00:00Z",
+        type="MessageEvent",
+        blockHash="BMaSNJJCebD52e37nNEmSntx9UraJo2js5QT9siXA34E7a8gzRc",
+        blockLevel=584664,
+        payload=MessageEventPayload(
+            timestamp=1668611900,
+            addr="KT1VBeLD7hzKpj17aRJ3Kc6QQFeikCEXi7W6",
+            msgtype="POST",
+            msgcontent="",
+        ),
+    )
+
+    # Invalid JSON (empty message content)
+    with pytest.raises(InvalidMessageError):
+        _ = indexer_event_to_aleph_message(indexer_event)
+
+    # Wrong content type, aggregate for a post
+    invalid_content = AggregateContent(
+        key="my-aggregate",
+        content={"body": "My first post on Tezos"},
+        address="KT1VBeLD7hzKpj17aRJ3Kc6QQFeikCEXi7W6",
+        time=1000,
+    )
+    indexer_event.payload.message_content = invalid_content.json()
+
+    with pytest.raises(InvalidMessageError):
+        _ = indexer_event_to_aleph_message(indexer_event)
+
+    # Invalid message type
+    indexer_event.payload.message_type = "NOPE"
+
+    with pytest.raises(InvalidMessageError):
+        _ = indexer_event_to_aleph_message(indexer_event)


### PR DESCRIPTION
Problem: we only support `STORE_IPFS` messages as trusted messages coming from the Tezos indexer.

Solution: support all the other message types by deserializing the JSON message content from the `msgcontent` field.