### PR TITLE
Fix: use correct chain name in indexer messages

### DIFF
--- a/src/aleph/chains/indexer_reader.py
+++ b/src/aleph/chains/indexer_reader.py
@@ -258,7 +258,7 @@ def indexer_event_to_aleph_message(
     )
 
     tx_context = TxContext(
-        chain_name=Chain.TEZOS,
+        chain_name=chain,
         tx_hash=indexer_event.transaction,
         height=indexer_event.height,
         time=indexer_event.timestamp,


### PR DESCRIPTION
Problem: the chain name is hardcoded to Tezos.