### PR TITLE
Fix: reduce total log files size

### DIFF
--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -7,7 +7,7 @@ def get_defaults():
     return {
         "logging": {
             "level": logging.WARNING,
-            "max_log_file_size": 1_000_000_000,  # 1GB,
+            "max_log_file_size": 50_000_000,  # 50MB
         },
         "aleph": {
             "queue_topic": "ALEPH-TEST",


### PR DESCRIPTION
Problem: node operators complain that the log files for the different processes making up the node take up too much space.

Solution: reduce the maximum log file size to 50MB. As we rotate logs up to 6 times, this reduces the total maximum log size from 6GB to 300MB per process.