### PR TITLE
Fix: Dockerfile missed VOLUME field

### DIFF
--- a/deployment/docker-build/pyaleph.dockerfile
+++ b/deployment/docker-build/pyaleph.dockerfile
@@ -71,4 +71,5 @@ RUN chown -R aleph:aleph /var/lib/pyaleph
 ENV PATH="/opt/venv/bin:${PATH}"
 WORKDIR /opt/pyaleph
 USER aleph
+VOLUME "/var/lib/aleph"
 ENTRYPOINT ["bash", "deployment/scripts/run_aleph_ccn.sh"]


### PR DESCRIPTION
See https://docs.docker.com/engine/reference/builder/#volume

> The VOLUME instruction creates a mount point with the specified name and marks it as holding externally mounted volumes from native host or other containers