### PR TITLE
Internal: replace Python shared memory by Redis

### DIFF
--- a/.github/workflows/pyaleph-ci.yml
+++ b/.github/workflows/pyaleph-ci.yml
@@ -26,6 +26,10 @@ jobs:
           POSTGRES_USER: aleph
           POSTGRES_PASSWORD: decentralize-everything
           POSTGRES_DATABASE: aleph
+      redis:
+        image: redis:7.0.10
+        ports:
+          - 127.0.0.1:6379:6379
 
     steps:
     - uses: actions/checkout@v2

--- a/deployment/docker-build/docker-compose.yml
+++ b/deployment/docker-build/docker-compose.yml
@@ -72,5 +72,13 @@ services:
     networks:
       - pyaleph
 
+  redis:
+    restart: always
+    image: redis:7.0.10
+    ports:
+      - "127.0.0.1:6380:6379"
+    networks:
+      - pyaleph
+
 networks:
   pyaleph:

--- a/deployment/samples/docker-compose/docker-compose.yml
+++ b/deployment/samples/docker-compose/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - postgres
       - ipfs
       - p2p-service
+      - redis
     networks:
       - pyaleph
     logging:
@@ -74,6 +75,12 @@ services:
     ports:
       - "127.0.0.1:5672:5672"
       - "127.0.0.1:15672:15672"
+
+  redis:
+    restart: always
+    image: redis:7.0.10
+    networks:
+      - pyaleph
 
   ipfs:
     restart: always

--- a/deployment/samples/docker-monitoring/docker-compose.yml
+++ b/deployment/samples/docker-monitoring/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - postgres
       - ipfs
       - p2p-service
+      - redis
     networks:
       - pyaleph
     logging:
@@ -75,6 +76,12 @@ services:
     ports:
       - "127.0.0.1:5672:5672"
       - "127.0.0.1:15672:15672"
+
+  redis:
+    restart: always
+    image: redis:7.0.10
+    networks:
+      - pyaleph
 
   ipfs:
     restart: always

--- a/deployment/scripts/run_aleph_ccn.sh
+++ b/deployment/scripts/run_aleph_ccn.sh
@@ -44,6 +44,8 @@ IPFS_HOST=$(get_config ipfs.host)
 IPFS_PORT=$(get_config ipfs.port)
 RABBITMQ_HOST=$(get_config rabbitmq.host)
 RABBITMQ_PORT=$(get_config rabbitmq.port)
+REDIS_HOST=$(get_config redis.host)
+REDIS_PORT=$(get_config redis.port)
 P2P_SERVICE_HOST=$(get_config p2p.daemon_host)
 P2P_SERVICE_CONTROL_PORT=$(get_config p2p.control_port)
 
@@ -53,6 +55,7 @@ fi
 
 wait_for_it -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}"
 wait_for_it -h "${RABBITMQ_HOST}" -p "${RABBITMQ_PORT}"
+wait_for_it -h "${REDIS_HOST}" -p "${REDIS_PORT}"
 wait_for_it -h "${P2P_SERVICE_HOST}" -p "${P2P_SERVICE_CONTROL_PORT}"
 
 exec pyaleph "${PYALEPH_ARGS[@]}"

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,7 @@ install_requires =
     python-dateutil==2.8.2
     pytz==2021.3
     pyyaml==6.0
+    redis[hiredis]==4.5.4
     requests==2.28.1
     secp256k1==0.14.0
     sentry-sdk==1.16.0
@@ -103,6 +104,7 @@ testing =
     pytest-asyncio
     pytest-mock
     types-pytz
+    types-redis
     types-requests
     types-setuptools
 nuls2 =

--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -126,6 +126,10 @@ def get_defaults():
             "sub_exchange": "p2p-subscribe",
             "message_exchange": "aleph-messages",
         },
+        "redis": {
+            "host": "127.0.0.1",
+            "port": 6379,
+        },
         "sentry": {
             "dsn": None,
             "traces_sample_rate": None,

--- a/src/aleph/jobs/__init__.py
+++ b/src/aleph/jobs/__init__.py
@@ -18,9 +18,7 @@ LOGGER = logging.getLogger("jobs")
 def start_jobs(
     config,
     session_factory: DbSessionFactory,
-    shared_stats: Dict,
     ipfs_service: IpfsService,
-    api_servers: List[str],
     use_processes=True,
 ) -> List[Coroutine]:
     LOGGER.info("starting jobs")
@@ -30,30 +28,22 @@ def start_jobs(
         config_values = config.dump_values()
         p1 = Process(
             target=fetch_pending_messages_subprocess,
-            args=(
-                config_values,
-                shared_stats,
-                api_servers,
-            ),
+            args=(config_values,),
         )
         p2 = Process(
             target=pending_messages_subprocess,
-            args=(
-                config_values,
-                shared_stats,
-                api_servers,
-            ),
+            args=(config_values,),
         )
         p3 = Process(
             target=pending_txs_subprocess,
-            args=(config_values, api_servers),
+            args=(config_values,),
         )
         p1.start()
         p2.start()
         p3.start()
     else:
         tasks.append(
-            fetch_and_process_messages_task(config=config, shared_stats=shared_stats)
+            fetch_and_process_messages_task(config=config)
         )
         tasks.append(handle_txs_task(config))
 

--- a/src/aleph/jobs/fetch_pending_messages.py
+++ b/src/aleph/jobs/fetch_pending_messages.py
@@ -26,7 +26,6 @@ from aleph.db.models import PendingMessageDb, MessageDb
 from aleph.handlers.message_handler import MessageHandler
 from aleph.services.ipfs import IpfsService
 from aleph.services.ipfs.common import make_ipfs_client
-from aleph.services.p2p import singleton
 from aleph.services.storage.fileystem_engine import FileSystemStorageEngine
 from aleph.storage import StorageService
 from aleph.toolkit.logging import setup_logging
@@ -34,6 +33,7 @@ from aleph.toolkit.monitoring import setup_sentry
 from aleph.toolkit.timestamp import utc_now
 from aleph.types.db_session import DbSessionFactory
 from .job_utils import prepare_loop, MessageJob
+from ..services.cache.node_cache import NodeCache
 
 LOGGER = getLogger(__name__)
 
@@ -78,12 +78,13 @@ class PendingMessageFetcher(MessageJob):
                 session.commit()
 
     async def fetch_pending_messages(
-        self, config: Config, shared_stats: Dict, loop: bool = True
+        self, config: Config, node_cache: NodeCache, loop: bool = True
     ) -> AsyncIterator[Sequence[MessageDb]]:
         LOGGER.info("starting fetch job")
 
         # Reset stats to avoid nonsensical values if the job restarts
-        shared_stats["retry_messages_job_tasks"] = 0
+        retry_messages_cache_key = "retry_messages_job_tasks"
+        await node_cache.set(retry_messages_cache_key, 0)
         max_concurrent_tasks = config.aleph.jobs.pending_messages.max_concurrency.value
         fetch_tasks: Set[asyncio.Task] = set()
         task_message_dict: Dict[asyncio.Task, PendingMessageDb] = {}
@@ -99,7 +100,7 @@ class PendingMessageFetcher(MessageJob):
                     for finished_task in finished_tasks:
                         pending_message = task_message_dict.pop(finished_task)
                         messages_being_fetched.remove(pending_message.item_hash)
-                        shared_stats["retry_messages_job_tasks"] -= 1
+                        await node_cache.decr(retry_messages_cache_key)
 
                 if len(fetch_tasks) < max_concurrent_tasks:
                     pending_messages = get_next_pending_messages(
@@ -119,7 +120,7 @@ class PendingMessageFetcher(MessageJob):
                         # Check if the message is already processing
                         messages_being_fetched.add(pending_message.item_hash)
 
-                        shared_stats["retry_messages_job_tasks"] += 1
+                        await node_cache.incr(retry_messages_cache_key)
 
                         message_task = asyncio.create_task(
                             self.fetch_pending_message(
@@ -145,27 +146,31 @@ class PendingMessageFetcher(MessageJob):
     def make_pipeline(
         self,
         config: Config,
-        shared_stats: Dict,
+        node_cache: NodeCache,
         loop: bool = True,
     ) -> AsyncIterator[Sequence[MessageDb]]:
         fetch_iterator = self.fetch_pending_messages(
-            config=config, shared_stats=shared_stats, loop=loop
+            config=config, node_cache=node_cache, loop=loop
         )
         return fetch_iterator
 
 
-async def fetch_messages_task(config: Config, shared_stats: Dict):
+async def fetch_messages_task(config: Config):
     # TODO: this sleep can probably be removed
     await asyncio.sleep(4)
 
     engine = make_engine(config=config, application_name="aleph-fetch")
     session_factory = make_session_factory(engine)
 
+    node_cache = NodeCache(
+        redis_host=config.redis.host.value, redis_port=config.redis.port.value
+    )
     ipfs_client = make_ipfs_client(config)
     ipfs_service = IpfsService(ipfs_client=ipfs_client)
     storage_service = StorageService(
         storage_engine=FileSystemStorageEngine(folder=config.storage.folder.value),
         ipfs_service=ipfs_service,
+        node_cache=node_cache,
     )
     chain_service = ChainService(
         session_factory=session_factory, storage_service=storage_service
@@ -186,7 +191,7 @@ async def fetch_messages_task(config: Config, shared_stats: Dict):
         with session_factory() as session:
             try:
                 fetch_pipeline = fetcher.make_pipeline(
-                    config=config, shared_stats=shared_stats
+                    config=config, node_cache=node_cache
                 )
                 async for fetched_messages in fetch_pipeline:
                     for fetched_message in fetched_messages:
@@ -202,9 +207,7 @@ async def fetch_messages_task(config: Config, shared_stats: Dict):
         await asyncio.sleep(1)
 
 
-def fetch_pending_messages_subprocess(
-    config_values: Dict, shared_stats: Dict, api_servers: List
-):
+def fetch_pending_messages_subprocess(config_values: Dict):
     """
     Background process that fetches all the messages received by the node.
 
@@ -214,11 +217,6 @@ def fetch_pending_messages_subprocess(
     (ex: a message to forget, a post to amend, etc).
 
     :param config_values: Application configuration, as a dictionary.
-    :param shared_stats: Dictionary of application metrics. This dictionary is updated by othe
-                         processes and must be allocated from shared memory.
-    :param api_servers: List of Core Channel Nodes with an HTTP interface found on the network.
-                        This list is updated by other processes and must be allocated from
-                        shared memory by the caller.
     """
 
     setproctitle("aleph.jobs.fetch_messages")
@@ -230,6 +228,5 @@ def fetch_pending_messages_subprocess(
         filename="/tmp/fetch_messages.log",
         max_log_file_size=config.logging.max_log_file_size.value,
     )
-    singleton.api_servers = api_servers
 
-    asyncio.run(fetch_messages_task(config=config, shared_stats=shared_stats))
+    asyncio.run(fetch_messages_task(config=config))

--- a/src/aleph/network.py
+++ b/src/aleph/network.py
@@ -7,6 +7,7 @@ from aleph_p2p_client import AlephP2PServiceClient
 import aleph.toolkit.json as aleph_json
 from aleph.chains.chain_service import ChainService
 from aleph.handlers.message_handler import MessageHandler
+from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
 from aleph.services.ipfs.common import make_ipfs_client
 from aleph.services.ipfs.pubsub import incoming_channel as incoming_ipfs_channel
@@ -36,7 +37,10 @@ async def decode_pubsub_message(message_data: bytes) -> Dict[str, Any]:
 
 
 def listener_tasks(
-    config, session_factory: DbSessionFactory, p2p_client: AlephP2PServiceClient
+    config,
+    session_factory: DbSessionFactory,
+    node_cache: NodeCache,
+    p2p_client: AlephP2PServiceClient,
 ) -> List[Coroutine]:
     from aleph.services.p2p.protocol import incoming_channel as incoming_p2p_channel
 
@@ -46,6 +50,7 @@ def listener_tasks(
     storage_service = StorageService(
         storage_engine=FileSystemStorageEngine(folder=config.storage.folder.value),
         ipfs_service=ipfs_service,
+        node_cache=node_cache,
     )
     chain_service = ChainService(
         session_factory=session_factory, storage_service=storage_service

--- a/src/aleph/services/cache/node_cache.py
+++ b/src/aleph/services/cache/node_cache.py
@@ -1,0 +1,58 @@
+from typing import Any, Set, Optional, List
+
+import redis.asyncio as redis_asyncio
+
+CacheKey = Any
+CacheValue = bytes
+
+
+class NodeCache:
+    API_SERVERS_KEY = "api_servers"
+    PUBLIC_ADDRESSES_KEY = "public_addresses"
+    redis_client: redis_asyncio.Redis
+
+    def __init__(self, redis_host: str, redis_port: int):
+        self.redis_host = redis_host
+        self.redis_port = redis_port
+
+        self.redis_client = redis_asyncio.Redis(host=redis_host, port=redis_port)
+
+    async def reset(self):
+        """
+        Resets the cache to sane defaults after a reboot of the node.
+        """
+        await self.redis_client.delete(self.PUBLIC_ADDRESSES_KEY)
+
+    async def get(self, key: CacheKey) -> Optional[CacheValue]:
+        return await self.redis_client.get(key)
+
+    async def set(self, key: CacheKey, value: Any):
+        await self.redis_client.set(key, value)
+
+    async def incr(self, key: CacheKey):
+        await self.redis_client.incr(key)
+
+    async def decr(self, key: CacheKey):
+        await self.redis_client.decr(key)
+
+    async def get_api_servers(self) -> Set[str]:
+        return set(
+            api_server.decode()
+            for api_server in await self.redis_client.smembers(self.API_SERVERS_KEY)
+        )
+
+    async def add_api_server(self, api_server: str) -> None:
+        await self.redis_client.sadd(self.API_SERVERS_KEY, api_server)
+
+    async def has_api_server(self, api_server: str) -> bool:
+        return await self.redis_client.sismember(self.API_SERVERS_KEY, api_server)
+
+    async def remove_api_server(self, api_server: str) -> None:
+        await self.redis_client.srem(self.API_SERVERS_KEY, api_server)
+
+    async def add_public_address(self, public_address: str) -> None:
+        await self.redis_client.sadd(self.PUBLIC_ADDRESSES_KEY, public_address)
+
+    async def get_public_addresses(self) -> List[str]:
+        addresses = await self.redis_client.smembers(self.PUBLIC_ADDRESSES_KEY)
+        return [addr.decode() for addr in addresses]

--- a/src/aleph/services/p2p/__init__.py
+++ b/src/aleph/services/p2p/__init__.py
@@ -4,9 +4,9 @@ from aleph_p2p_client import AlephP2PServiceClient, make_p2p_service_client
 from configmanager import Config
 
 from aleph.services.ipfs import IpfsService
-from . import singleton
 from .manager import initialize_host
 from aleph.types.db_session import DbSessionFactory
+from ..cache.node_cache import NodeCache
 
 
 async def init_p2p_client(config: Config, service_name: str) -> AlephP2PServiceClient:
@@ -30,7 +30,7 @@ async def init_p2p(
     session_factory: DbSessionFactory,
     service_name: str,
     ipfs_service: IpfsService,
-    api_servers: List[str],
+    node_cache: NodeCache,
     listen: bool = True,
 ) -> Tuple[AlephP2PServiceClient, List[Coroutine]]:
 
@@ -42,7 +42,7 @@ async def init_p2p(
         session_factory=session_factory,
         p2p_client=p2p_client,
         ipfs_service=ipfs_service,
-        api_servers=api_servers,
+        node_cache=node_cache,
         host=config.p2p.daemon_host.value,
         port=port,
         listen=listen,

--- a/src/aleph/services/p2p/http.py
+++ b/src/aleph/services/p2p/http.py
@@ -6,11 +6,9 @@ import asyncio
 import base64
 import logging
 from random import sample
-from typing import Optional
+from typing import Optional, List, Sequence
 
 import aiohttp
-
-from . import singleton
 
 LOGGER = logging.getLogger("P2P.HTTP")
 
@@ -59,13 +57,10 @@ async def get_peer_hash_content(
     return result
 
 
-async def request_hash(item_hash: str, timeout: int = 1) -> Optional[bytes]:
-    if singleton.api_servers is None:
-        raise ValueError("Configuration error, api_servers is null.")
-
-    # random.sample is not compatible with multiprocessing lists like api_servers
-    uris = list(singleton.api_servers)
-    uris = sample(uris, k=len(uris))
+async def request_hash(
+    api_servers: Sequence[str], item_hash: str, timeout: int = 1
+) -> Optional[bytes]:
+    uris: List[str] = sample(api_servers, k=len(api_servers))
 
     for uri in uris:
         content = await get_peer_hash_content(uri, item_hash, timeout=timeout)

--- a/src/aleph/services/p2p/manager.py
+++ b/src/aleph/services/p2p/manager.py
@@ -4,31 +4,27 @@ from typing import Coroutine, List
 
 from aleph_p2p_client import AlephP2PServiceClient
 from configmanager import Config
-from aleph.types.db_session import DbSessionFactory
 
+from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
 from aleph.services.peers.monitor import monitor_hosts_ipfs, monitor_hosts_p2p
 from aleph.services.peers.publish import publish_host
 from aleph.services.utils import get_IP
+from aleph.types.db_session import DbSessionFactory
 
 LOGGER = logging.getLogger(__name__)
-
-
-# Save published adress to present them in the web process later
-public_adresses = []
 
 
 async def initialize_host(
     config: Config,
     session_factory: DbSessionFactory,
+    node_cache: NodeCache,
     p2p_client: AlephP2PServiceClient,
     ipfs_service: IpfsService,
-    api_servers: List[str],
     host: str = "0.0.0.0",
     port: int = 4025,
     listen: bool = True,
 ) -> List[Coroutine]:
-
     from .jobs import reconnect_p2p_job, tidy_http_peers_job
 
     tasks: List[Coroutine]
@@ -40,13 +36,15 @@ async def initialize_host(
             config=config, session_factory=session_factory, p2p_client=p2p_client
         ),
         tidy_http_peers_job(
-            config=config, session_factory=session_factory, api_servers=api_servers
+            config=config, session_factory=session_factory, node_cache=node_cache
         ),
     ]
     if listen:
         start_time = time.perf_counter()
         peer_id = (await p2p_client.identify()).peer_id
-        LOGGER.info("Got identify info in %.3f seconds", time.perf_counter() - start_time)
+        LOGGER.info(
+            "Got identify info in %.3f seconds", time.perf_counter() - start_time
+        )
         LOGGER.info("Listening on " + f"{transport_opt}/p2p/{peer_id}")
 
         start_time = time.perf_counter()
@@ -54,7 +52,8 @@ async def initialize_host(
         LOGGER.info("Got IP info in %.3f seconds", time.perf_counter() - start_time)
         public_address = f"/ip4/{ip}/tcp/{port}/p2p/{peer_id}"
         http_port = config.p2p.http_port.value
-        public_adresses.append(public_address)
+
+        await node_cache.add_public_address(public_address)
 
         public_http_address = f"http://{ip}:{http_port}"
 

--- a/src/aleph/services/p2p/singleton.py
+++ b/src/aleph/services/p2p/singleton.py
@@ -1,6 +1,0 @@
-from typing import List, Optional
-
-# TODO: this global variable is currently used to distribute the list of HTTP nodes
-#       on the network. Rewrite the retry and storage modules to pass this state
-#       as a parameter instead.
-api_servers: Optional[List[str]] = None

--- a/src/aleph/web/controllers/app_state_getters.py
+++ b/src/aleph/web/controllers/app_state_getters.py
@@ -11,16 +11,16 @@ from aiohttp import web
 from aleph_p2p_client import AlephP2PServiceClient
 from configmanager import Config
 
+from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
 from aleph.storage import StorageService
 from aleph.types.db_session import DbSessionFactory
 
 APP_STATE_CONFIG = "config"
-APP_STATE_EXTRA_CONFIG = "extra_config"
 APP_STATE_MQ_CONN = "mq_conn"
+APP_STATE_NODE_CACHE = "node_cache"
 APP_STATE_P2P_CLIENT = "p2p_client"
 APP_STATE_SESSION_FACTORY = "session_factory"
-APP_STATE_SHARED_STATS = "shared_stats"
 APP_STATE_STORAGE_SERVICE = "storage_service"
 
 
@@ -43,6 +43,10 @@ def get_ipfs_service_from_request(request: web.Request) -> Optional[IpfsService]
 
 def get_mq_conn_from_request(request: web.Request) -> aio_pika.abc.AbstractConnection:
     return cast(aio_pika.abc.AbstractConnection, request.app[APP_STATE_MQ_CONN])
+
+
+def get_node_cache_from_request(request: web.Request) -> NodeCache:
+    return cast(NodeCache, request.app[APP_STATE_NODE_CACHE])
 
 
 def get_p2p_client_from_request(request: web.Request) -> AlephP2PServiceClient:

--- a/src/aleph/web/controllers/info.py
+++ b/src/aleph/web/controllers/info.py
@@ -1,5 +1,7 @@
 from aiohttp import web
 
+from aleph.web.controllers.app_state_getters import get_node_cache_from_request
+
 
 async def public_multiaddress(request):
     """Broadcast public node addresses
@@ -7,7 +9,8 @@ async def public_multiaddress(request):
     According to multiaddr spec https://multiformats.io/multiaddr/
     """
 
-    output = {
-        "node_multi_addresses": request.config_dict["extra_config"]["public_adresses"],
-    }
+    node_cache = get_node_cache_from_request(request)
+    public_addresses = await node_cache.get_public_addresses()
+
+    output = {"node_multi_addresses": public_addresses}
     return web.json_response(output)

--- a/src/aleph/web/controllers/main.py
+++ b/src/aleph/web/controllers/main.py
@@ -7,6 +7,7 @@ import aiohttp_jinja2
 from aiohttp import web
 
 from aleph.types.db_session import DbSessionFactory
+from aleph.web.controllers.app_state_getters import get_node_cache_from_request, get_session_factory_from_request
 from aleph.web.controllers.metrics import format_dataclass_for_prometheus, get_metrics
 
 logger = logging.getLogger(__name__)
@@ -15,23 +16,24 @@ logger = logging.getLogger(__name__)
 @aiohttp_jinja2.template("index.html")
 async def index(request) -> Dict:
     """Index of aleph."""
-    shared_stats = request.config_dict["shared_stats"]
-    session_factory: DbSessionFactory = request.app["session_factory"]
+
+    session_factory: DbSessionFactory = get_session_factory_from_request(request)
+    node_cache = get_node_cache_from_request(request)
     with session_factory() as session:
-        return asdict(await get_metrics(session=session, shared_stats=shared_stats))
+        return asdict(await get_metrics(session=session, node_cache=node_cache))
 
 
 async def status_ws(request):
     ws = web.WebSocketResponse()
     await ws.prepare(request)
-    session_factory: DbSessionFactory = request.app["session_factory"]
+
+    session_factory: DbSessionFactory = get_session_factory_from_request(request)
+    node_cache = get_node_cache_from_request(request)
 
     previous_status = None
     while True:
-        shared_stats = request.config_dict["shared_stats"]
-
         with session_factory() as session:
-            status = await get_metrics(session=session, shared_stats=shared_stats)
+            status = await get_metrics(session=session, node_cache=node_cache)
 
         if status != previous_status:
             try:
@@ -51,23 +53,24 @@ async def metrics(request):
     Naming convention:
     https://prometheus.io/docs/practices/naming/
     """
-    shared_stats = request.config_dict["shared_stats"]
-    session_factory: DbSessionFactory = request.app["session_factory"]
+    session_factory: DbSessionFactory = get_session_factory_from_request(request)
+    node_cache = get_node_cache_from_request(request)
+
     with session_factory() as session:
         return web.Response(
             text=format_dataclass_for_prometheus(
-                await get_metrics(session=session, shared_stats=shared_stats)
+                await get_metrics(session=session, node_cache=node_cache)
             )
         )
 
 
 async def metrics_json(request):
     """JSON version of the Prometheus metrics."""
-    shared_stats = request.config_dict["shared_stats"]
-    session_factory: DbSessionFactory = request.app["session_factory"]
+    session_factory: DbSessionFactory = get_session_factory_from_request(request)
+    node_cache = get_node_cache_from_request(request)
 
     with session_factory() as session:
         return web.Response(
-            text=(await get_metrics(session=session, shared_stats=shared_stats)).to_json(),
+            text=(await get_metrics(session=session, node_cache=node_cache)).to_json(),
             content_type="application/json",
         )

--- a/tests/message_processing/conftest.py
+++ b/tests/message_processing/conftest.py
@@ -76,7 +76,9 @@ async def fixture_post_messages(
 def message_processor(mocker, mock_config: Config, session_factory: DbSessionFactory):
     storage_engine = InMemoryStorageEngine(files={})
     storage_service = StorageService(
-        storage_engine=storage_engine, ipfs_service=mocker.AsyncMock()
+        storage_engine=storage_engine,
+        ipfs_service=mocker.AsyncMock(),
+        node_cache=mocker.AsyncMock(),
     )
     chain_service = ChainService(
         session_factory=session_factory, storage_service=storage_service

--- a/tests/message_processing/test_process_aggregates.py
+++ b/tests/message_processing/test_process_aggregates.py
@@ -31,7 +31,9 @@ async def test_process_aggregate_first_element(
     fixture_aggregate_messages: List[Dict],
 ):
     storage_service = StorageService(
-        storage_engine=mocker.AsyncMock(), ipfs_service=mocker.AsyncMock()
+        storage_engine=mocker.AsyncMock(),
+        ipfs_service=mocker.AsyncMock(),
+        node_cache=mocker.AsyncMock(),
     )
     chain_service = mocker.AsyncMock()
     message_handler = MessageHandler(
@@ -143,7 +145,6 @@ async def process_aggregates_one_by_one(
     message_processor: PendingMessageProcessor,
     aggregates: Iterable[PendingMessageDb],
 ) -> Sequence[MessageDb]:
-
     messages = []
     for pending_aggregate in aggregates:
         session.add(pending_aggregate)

--- a/tests/message_processing/test_process_stores.py
+++ b/tests/message_processing/test_process_stores.py
@@ -72,6 +72,7 @@ async def test_process_store(
             }
         ),
         ipfs_service=mocker.AsyncMock(),
+        node_cache=mocker.AsyncMock(),
     )
     chain_service = mocker.AsyncMock()
     message_handler = MessageHandler(
@@ -121,6 +122,7 @@ async def test_process_store_no_signature(
             }
         ),
         ipfs_service=mocker.AsyncMock(),
+        node_cache=mocker.AsyncMock(),
     )
     message_processor.message_handler.storage_service = storage_service
     storage_handler = message_processor.message_handler.content_handlers[

--- a/tests/services/test_node_cache.py
+++ b/tests/services/test_node_cache.py
@@ -1,0 +1,49 @@
+import pytest
+
+from aleph.services.cache.node_cache import NodeCache
+
+
+@pytest.mark.asyncio
+async def test_get_set(node_cache: NodeCache):
+    key = "test_get_set"
+
+    await node_cache.set(key, 12)
+    assert await node_cache.get(key) == b"12"
+
+    await node_cache.set(key, "hello")
+    assert await node_cache.get(key) == b"hello"
+
+
+@pytest.mark.asyncio
+async def test_incr_decr(node_cache: NodeCache):
+    key = "test_incr_decr"
+    await node_cache.redis_client.delete(key)
+
+    await node_cache.set(key, 42)
+    await node_cache.incr(key)
+    assert await node_cache.get(key) == b"43"
+
+    await node_cache.decr(key)
+    assert await node_cache.get(key) == b"42"
+
+
+@pytest.mark.asyncio
+async def test_api_servers_cache(node_cache: NodeCache):
+    await node_cache.redis_client.delete(node_cache.API_SERVERS_KEY)
+
+    assert await node_cache.get_api_servers() == set()
+
+    api_server_1 = "https://api1.aleph.im"
+    api_server_2 = "https://api2.aleph.im"
+
+    await node_cache.add_api_server(api_server_2)
+    assert await node_cache.get_api_servers() == {api_server_2}
+    assert not await node_cache.has_api_server(api_server_1)
+    assert await node_cache.has_api_server(api_server_2)
+
+    await node_cache.add_api_server(api_server_1)
+    assert await node_cache.get_api_servers() == {api_server_1, api_server_2}
+    assert await node_cache.has_api_server(api_server_1)
+    assert await node_cache.has_api_server(api_server_2)
+
+    await node_cache.redis_client.delete(node_cache.API_SERVERS_KEY)

--- a/tests/storage/test_get_content.py
+++ b/tests/storage/test_get_content.py
@@ -13,7 +13,6 @@ from aleph.storage import StorageService
 
 
 class MockStorageEngine(StorageEngine):
-
     def __init__(self, files: Dict[str, bytes]):
         self.files = files
 
@@ -41,6 +40,7 @@ async def test_hash_content_from_db(mocker, use_network: bool, use_ipfs: bool):
     storage_manager = StorageService(
         MockStorageEngine(files={"1234": b"fluctuat nec mergitur"}),
         ipfs_service=mocker.AsyncMock(),
+        node_cache=mocker.AsyncMock(),
     )
 
     expected_content = b"fluctuat nec mergitur"
@@ -66,7 +66,9 @@ async def test_hash_content_from_network(mocker, use_ipfs: bool):
 
     # No files in the local storage
     storage_manager = StorageService(
-        MockStorageEngine(files={}), ipfs_service=mocker.AsyncMock()
+        MockStorageEngine(files={}),
+        ipfs_service=mocker.AsyncMock(),
+        node_cache=mocker.AsyncMock(),
     )
 
     content = await storage_manager.get_hash_content(
@@ -90,7 +92,9 @@ async def test_hash_content_from_network_store_value(mocker, use_ipfs: bool):
     )
 
     storage_manager = StorageService(
-        MockStorageEngine(files={}), ipfs_service=mocker.AsyncMock()
+        MockStorageEngine(files={}),
+        ipfs_service=mocker.AsyncMock(),
+        node_cache=mocker.AsyncMock(),
     )
 
     content = await storage_manager.get_hash_content(
@@ -118,7 +122,9 @@ async def test_hash_content_from_network_invalid_hash(mocker):
     ipfs_service = IpfsService(ipfs_client=ipfs_client)
 
     storage_manager = StorageService(
-        MockStorageEngine(files={}), ipfs_service=ipfs_service
+        MockStorageEngine(files={}),
+        ipfs_service=ipfs_service,
+        node_cache=mocker.AsyncMock(),
     )
 
     with pytest.raises(InvalidContent):
@@ -142,7 +148,9 @@ async def test_hash_content_from_ipfs(mocker):
     ipfs_service = IpfsService(ipfs_client=ipfs_client)
 
     storage_manager = StorageService(
-        MockStorageEngine(files={}), ipfs_service=ipfs_service
+        MockStorageEngine(files={}),
+        ipfs_service=ipfs_service,
+        node_cache=mocker.AsyncMock(),
     )
 
     with pytest.raises(InvalidContent):
@@ -160,6 +168,7 @@ async def test_get_valid_json(mocker):
     storage_manager = StorageService(
         MockStorageEngine(files={content_hash: json_bytes}),
         ipfs_service=mocker.AsyncMock(),
+        node_cache=mocker.AsyncMock(),
     )
 
     content = await storage_manager.get_json(content_hash)
@@ -178,6 +187,7 @@ async def test_get_invalid_json(mocker):
     storage_manager = StorageService(
         MockStorageEngine(files={"1234": non_json_content}),
         ipfs_service=mocker.AsyncMock(),
+        node_cache=mocker.AsyncMock(),
     )
 
     with pytest.raises(InvalidContent):
@@ -203,7 +213,9 @@ async def test_get_inline_content_full_message(mocker):
     }
 
     storage_manager = StorageService(
-        MockStorageEngine(files={}), ipfs_service=mocker.AsyncMock()
+        MockStorageEngine(files={}),
+        ipfs_service=mocker.AsyncMock(),
+        node_cache=mocker.AsyncMock(),
     )
 
     message = parse_message(message_dict)
@@ -236,7 +248,8 @@ async def test_get_stored_message_content(mocker):
     message = parse_message(message_dict)
     storage_manager = StorageService(
         MockStorageEngine(files={message.item_hash: json_bytes}),
-        ipfs_service=mocker.AsyncMock()
+        ipfs_service=mocker.AsyncMock(),
+        node_cache=mocker.AsyncMock(),
     )
 
     content = await storage_manager.get_message_content(message)

--- a/tests/storage/test_store_message.py
+++ b/tests/storage/test_store_message.py
@@ -82,6 +82,7 @@ async def test_handle_new_storage_file(
     storage_service = StorageService(
         storage_engine=mocker.AsyncMock(),
         ipfs_service=IpfsService(ipfs_client=mock_ipfs_client),
+        node_cache=mocker.AsyncMock(),
     )
     storage_service.get_hash_content = get_hash_content_mock = mocker.AsyncMock(return_value=raw_content)  # type: ignore
     store_message_handler = StoreMessageHandler(storage_service=storage_service)
@@ -127,6 +128,7 @@ async def test_handle_new_storage_directory(
     storage_service = StorageService(
         storage_engine=storage_engine,
         ipfs_service=IpfsService(ipfs_client=mock_ipfs_client),
+        node_cache=mocker.AsyncMock(),
     )
     store_message_handler = StoreMessageHandler(storage_service=storage_service)
 


### PR DESCRIPTION
Problem: the inter-process cache uses the Python multiprocessing shared memory manager. This cache must be passed as argument to the other processes, meaning they must be spawned by the main process. We wish to separate the API into its own process, and may want to write different processes in different languages in the future.

Solution: replace the shared stats cache by Redis.