### PR TITLE
Fix: cannot publish message from the API to IPFS pubsub

### DIFF
--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -163,5 +163,8 @@ class IpfsService:
                 LOGGER.exception("Error handling message")
 
     async def pub(self, topic: str, message: Union[str, bytes]):
+        # aioipfs only accepts strings
+        message_str = message if isinstance(message, str) else message.decode("utf-8")
+
         ipfs_client = self.ipfs_client
-        await ipfs_client.pubsub.pub(topic, message)
+        await ipfs_client.pubsub.pub(topic, message_str)


### PR DESCRIPTION
Problem: the POST /messages/ endpoint fails to publish on the IPFS pubsub because the payload is bytes instead of a string as expected by aioipfs. This originates from the shift to `orjson` which encodes JSON as bytes.

Solution: convert to string before publishing.