### PR TITLE
Dev feature: easily run a debuggable test server

### DIFF
--- a/src/aleph/api_entrypoint.py
+++ b/src/aleph/api_entrypoint.py
@@ -76,3 +76,9 @@ async def create_app() -> web.Application:
         setup_sentry(config)
 
     return await configure_aiohttp_app(config=config)
+
+
+if __name__ == "__main__":
+    import asyncio
+    app = asyncio.run(create_app())
+    web.run_app(app, host="localhost", port=8000)


### PR DESCRIPTION
Problem: running the API with gunicorn is not ideal when developing as we get multiple processes and no debugging.

Solution: start a test server when running the `api_entrypoint` module.