### PR TITLE
Fix: increase gunicorn worker timeout

### DIFF
--- a/deployment/scripts/run_aleph_ccn_api.sh
+++ b/deployment/scripts/run_aleph_ccn_api.sh
@@ -24,6 +24,7 @@ wait_for_services "${CONFIG_FILE}"
 
 NB_WORKERS="${CCN_CONFIG_API_NB_WORKERS:-4}"
 PORT=${CCN_CONFIG_API_PORT:-4024}
+TIMEOUT="${CCN_CONFIG_API_TIMEOUT:300}"
 
 echo "Starting aleph.im CCN API server on port ${PORT} (${NB_WORKERS} workers)"
 
@@ -32,4 +33,5 @@ exec gunicorn \
   --bind 0.0.0.0:${PORT} \
   --worker-class aiohttp.worker.GunicornUVLoopWebWorker \
   --workers ${NB_WORKERS} \
+  --timeout ${TIMEOUT} \
   --access-logfile "-"


### PR DESCRIPTION
Increased the timeout to 5 minutes to allow expensive API calls.