### PR TITLE
Fix: wrong network name for Prometheus

### DIFF
--- a/deployment/samples/docker-monitoring/docker-compose.yml
+++ b/deployment/samples/docker-monitoring/docker-compose.yml
@@ -125,7 +125,7 @@ services:
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
     networks:
-      - pyaleph-api
+      - pyaleph
       - grafana
 
   grafana:


### PR DESCRIPTION
Revert a typo in the Prometheus network in the monitoring Docker Compose.