### PR TITLE
Fix: aiohttp assert exception on connection lost

### DIFF
--- a/deployment/docker-build/aiohttp.diff
+++ b/deployment/docker-build/aiohttp.diff
@@ -1,0 +1,13 @@
+diff --git a/aiohttp/web_protocol.py b/aiohttp/web_protocol.py
+index 10a96080..f103b167 100644
+--- a/aiohttp/web_protocol.py
++++ b/aiohttp/web_protocol.py
+@@ -299,6 +299,8 @@ class RequestHandler(BaseProtocol):
+                 exc = ConnectionResetError("Connection lost")
+             self._current_request._cancel(exc)
+ 
++        if self._task_handler is not None:
++            self._task_handler.cancel()
+         if self._waiter is not None:
+             self._waiter.cancel()
+ 

--- a/deployment/docker-build/pyaleph.dockerfile
+++ b/deployment/docker-build/pyaleph.dockerfile
@@ -51,6 +51,8 @@ COPY deployment/scripts ./deployment/scripts
 COPY .git ./.git
 COPY src ./src
 RUN pip install -e .
+COPY deployment/docker-build/aiohttp.diff /tmp/aiohttp.diff
+RUN patch /opt/venv/lib/python3.11/site-packages/aiohttp/web_protocol.py /tmp/aiohttp.diff
 
 
 FROM base

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     aiocache==0.11.1
     aiohttp-cors==0.7.0
     aiohttp-jinja2==1.5
-    aiohttp==3.8.3
+    aiohttp==3.8.4
     aioipfs@git+https://github.com/aleph-im/aioipfs.git@d671c79b2871bb4d6c8877ba1e7f3ffbe7d20b71
     alembic==1.8.1
     aleph-message==0.3.2


### PR DESCRIPTION
Problem: a bug in aiohttp causes an assertion error to appear in the logs whenever an HTTP connection is lost.

Solution: there is no mainline fix in aiohttp. It is not trivial to install a forked version of aiohttp, so the simplest solution for now is to apply the aiohttp patch directly.

Bumped aiohttp to 3.8.4 at the same time.