### PR TITLE
Fix: storage API bugs

### DIFF
--- a/deployment/migrations/versions/0016_77e68941d36c_fix_ipfs_files_size.py
+++ b/deployment/migrations/versions/0016_77e68941d36c_fix_ipfs_files_size.py
@@ -1,0 +1,80 @@
+"""fix ipfs files size
+
+Revision ID: 77e68941d36c
+Revises: 039c56d3b33e
+Create Date: 2023-04-25 10:53:44.111572
+
+"""
+import asyncio
+import logging
+from threading import Thread
+from time import sleep
+
+import aioipfs
+from alembic import op
+from sqlalchemy import select, update
+
+from aleph.config import get_config
+from aleph.db.models import StoredFileDb
+from aleph.services.ipfs.common import make_ipfs_client
+from aleph.types.files import FileType
+
+# revision identifiers, used by Alembic.
+revision = "77e68941d36c"
+down_revision = "039c56d3b33e"
+branch_labels = None
+depends_on = None
+
+
+logger = logging.getLogger("alembic")
+
+
+async def stat_ipfs(ipfs_client: aioipfs.AsyncIPFS, cid: str):
+    try:
+        return await asyncio.wait_for(ipfs_client.files.stat(f"/ipfs/{cid}"), 5)
+    except TimeoutError:
+        return None
+
+
+async def upgrade_async() -> None:
+    conn = op.get_bind()
+    files = conn.execute(
+        select(StoredFileDb.hash).where(
+            (StoredFileDb.hash.like("Qm%") | StoredFileDb.hash.like("bafy%"))
+            & (StoredFileDb.type == FileType.FILE)
+        )
+    ).all()
+
+    config = get_config()
+    ipfs_client = make_ipfs_client(config)
+
+    for file in files:
+        stats = await stat_ipfs(ipfs_client, cid=file.hash)
+        if stats is None:
+            logger.warning("Could not stat file: %s", file.hash)
+
+        op.execute(
+            update(StoredFileDb)
+            .where(StoredFileDb.hash == file.hash)
+            .values(size=stats["Size"])
+        )
+
+    await ipfs_client.close()
+
+
+def upgrade_thread():
+    asyncio.run(upgrade_async())
+
+
+def upgrade() -> None:
+    # We can reach this point from sync and async code, resulting in errors if an event loop
+    # is already running if we just try to run the upgrade_async coroutine. The easiest
+    # solution here is to start another thread and run the migration from there.
+    thread = Thread(target=upgrade_thread, daemon=True)
+    thread.start()
+    thread.join()
+
+
+def downgrade() -> None:
+    # Don't reset sizes, it's pointless.
+    pass

--- a/src/aleph/api_entrypoint.py
+++ b/src/aleph/api_entrypoint.py
@@ -80,5 +80,4 @@ async def create_app() -> web.Application:
 
 if __name__ == "__main__":
     import asyncio
-    app = asyncio.run(create_app())
-    web.run_app(app, host="localhost", port=8000)
+    web.run_app(create_app(), host="localhost", port=8000)

--- a/src/aleph/chains/chaindata.py
+++ b/src/aleph/chains/chaindata.py
@@ -47,10 +47,11 @@ class ChainDataService:
         self.session_factory = session_factory
         self.storage_service = storage_service
 
+    # TODO: split this function in severa
     async def get_chaindata(
-        self, messages: List[MessageDb], bulk_threshold: int = 2000
+        self, session: DbSession, messages: List[MessageDb], bulk_threshold: int = 2000
     ):
-        """Returns content ready to be broadcasted on-chain (aka chaindata).
+        """Returns content ready to be broadcast on-chain (aka chaindata).
 
         If message length is over bulk_threshold (default 2000 chars), store list
         in IPFS and store the object hash instead of raw list.
@@ -80,7 +81,9 @@ class ChainDataService:
         }
         content = json.dumps(chaindata)
         if len(content) > bulk_threshold:
-            ipfs_id = await self.storage_service.add_json(chaindata)
+            ipfs_id = await self.storage_service.add_json(
+                session=session, value=chaindata
+            )
             return json.dumps(
                 {
                     "protocol": ChainSyncProtocol.OFF_CHAIN_SYNC,

--- a/src/aleph/chains/ethereum.py
+++ b/src/aleph/chains/ethereum.py
@@ -341,9 +341,12 @@ class EthereumConnector(Verifier, ChainWriter):
                 )
 
             if len(messages):
+                # This function prepares a chain data file and makes it downloadable from the node.
                 content = await self.chain_data_service.get_chaindata(
-                    messages, bulk_threshold=200
+                    session=session, messages=messages, bulk_threshold=200
                 )
+                # Required to apply update to the files table in get_chaindata
+                session.commit()
                 response = await run_in_executor(
                     None,
                     self._broadcast_content,

--- a/src/aleph/chains/nuls2.py
+++ b/src/aleph/chains/nuls2.py
@@ -190,7 +190,10 @@ class Nuls2Connector(Verifier, ChainWriter):
                 )
 
             if len(messages):
-                content = await self.chain_data_service.get_chaindata(messages)
+                # This function prepares a chain data file and makes it downloadable from the node.
+                content = await self.chain_data_service.get_chaindata(session=session, messages=messages)
+                # Required to apply update to the files table in get_chaindata
+                session.commit()
 
                 tx = await prepare_transfer_tx(
                     address,

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -139,7 +139,7 @@ class IpfsService:
                 break
 
     async def add_file(self, fileobject: IO):
-        url = f"{self.ipfs_client.api_url}/api/v0/add"
+        url = f"{self.ipfs_client.api_url}add"
 
         async with aiohttp.ClientSession() as session:
             data = aiohttp.FormData()

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -4,15 +4,15 @@ import logging
 from aiohttp import web
 from aleph_message.models import ItemType
 
-from aleph.db.accessors.files import count_file_pins, is_pinned_file, get_file
+from aleph.db.accessors.files import count_file_pins, get_file
 from aleph.exceptions import AlephStorageException, UnknownHashError
-from aleph.storage import StorageService
 from aleph.types.db_session import DbSessionFactory, DbSession
 from aleph.utils import run_in_executor, item_type_from_hash
 from aleph.web.controllers.app_state_getters import (
     get_session_factory_from_request,
     get_storage_service_from_request,
 )
+from aleph.web.controllers.utils import multidict_proxy_to_io
 
 logger = logging.getLogger(__name__)
 
@@ -20,39 +20,55 @@ logger = logging.getLogger(__name__)
 MAX_FILE_SIZE = 100 * 1024 * 1024
 
 
-async def add_ipfs_json_controller(request):
+async def add_ipfs_json_controller(request: web.Request):
     """Forward the json content to IPFS server and return an hash"""
-    storage_service: StorageService = request.app["storage_service"]
+    storage_service = get_storage_service_from_request(request)
+    session_factory = get_session_factory_from_request(request)
 
     data = await request.json()
-    output = {
-        "status": "success",
-        "hash": await storage_service.add_json(data, engine=ItemType.ipfs),
-    }
+    with session_factory() as session:
+        output = {
+            "status": "success",
+            "hash": await storage_service.add_json(
+                session=session, value=data, engine=ItemType.ipfs
+            ),
+        }
+        session.commit()
+
     return web.json_response(output)
 
 
-async def add_storage_json_controller(request):
+async def add_storage_json_controller(request: web.Request):
     """Forward the json content to IPFS server and return an hash"""
-    storage_service: StorageService = request.app["storage_service"]
+    storage_service = get_storage_service_from_request(request)
+    session_factory = get_session_factory_from_request(request)
 
     data = await request.json()
-    output = {
-        "status": "success",
-        "hash": await storage_service.add_json(data, engine=ItemType.storage),
-    }
+    with session_factory() as session:
+        output = {
+            "status": "success",
+            "hash": await storage_service.add_json(
+                session=session, value=data, engine=ItemType.storage
+            ),
+        }
+        session.commit()
+
     return web.json_response(output)
 
 
-async def storage_add_file(request):
-    storage_service: StorageService = request.app["storage_service"]
+async def storage_add_file(request: web.Request):
+    storage_service = get_storage_service_from_request(request)
+    session_factory = get_session_factory_from_request(request)
 
     # No need to pin it here anymore.
     # TODO: find a way to specify linked ipfs hashes in posts/aggr.
     post = await request.post()
-    file_hash = await storage_service.add_file(
-        post["file"].file, engine=ItemType.storage
-    )
+    file_io = multidict_proxy_to_io(post)
+    with session_factory() as session:
+        file_hash = await storage_service.add_file(
+            session=session, fileobject=file_io, engine=ItemType.storage
+        )
+        session.commit()
 
     output = {"status": "success", "hash": file_hash}
     return web.json_response(output)

--- a/src/aleph/web/controllers/utils.py
+++ b/src/aleph/web/controllers/utils.py
@@ -1,15 +1,30 @@
 import json
+from io import BytesIO, StringIO
 from math import ceil
-from typing import Optional
+from typing import Optional, Union, IO
 
 import aio_pika
 import aiohttp_jinja2
 from aiohttp import web
+from aiohttp.web_request import FileField
 from configmanager import Config
+from multidict import MultiDictProxy
 
 DEFAULT_MESSAGES_PER_PAGE = 20
 DEFAULT_PAGE = 1
 LIST_FIELD_SEPARATOR = ","
+
+
+def multidict_proxy_to_io(
+    multi_dict: MultiDictProxy[Union[str, bytes, FileField]]
+) -> IO:
+    file_field = multi_dict["file"]
+    if isinstance(file_field, bytes):
+        return BytesIO(file_field)
+    elif isinstance(file_field, str):
+        return StringIO(file_field)
+
+    return file_field.file
 
 
 def get_path_page(request: web.Request) -> Optional[int]:

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -44,6 +44,15 @@ def api_client(ccn_api_client, mocker):
         }
     )
     ipfs_service.get_ipfs_content = mocker.AsyncMock(return_value=FILE_CONTENT)
+    ipfs_service.ipfs_client.files.stat = mocker.AsyncMock(
+        return_value={
+            "Hash": EXPECTED_FILE_CID,
+            "Size": 34,
+            "CumulativeSize": 42,
+            "Blocks": 0,
+            "Type": "file",
+        }
+    )
 
     ccn_api_client.app["storage_service"] = StorageService(
         storage_engine=InMemoryStorageEngine(files={}),

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -1,0 +1,173 @@
+import base64
+from typing import Any
+
+import aiohttp
+import orjson
+import pytest
+from aleph_message.models import ItemHash
+
+from aleph.db.accessors.files import get_file
+from aleph.storage import StorageService
+from aleph.types.db_session import DbSessionFactory
+from aleph.types.files import FileType
+from in_memory_storage_engine import InMemoryStorageEngine
+
+IPFS_ADD_FILE_URI = "/api/v0/ipfs/add_file"
+IPFS_ADD_JSON_URI = "/api/v0/ipfs/add_json"
+STORAGE_ADD_FILE_URI = "/api/v0/storage/add_file"
+STORAGE_ADD_JSON_URI = "/api/v0/storage/add_json"
+
+GET_STORAGE_URI = "/api/v0/storage"
+GET_STORAGE_RAW_URI = "/api/v0/storage/raw"
+
+FILE_CONTENT = b"Hello earthlings, I come in pieces"
+EXPECTED_FILE_SHA256 = (
+    "bb6e53f2738e5934b9a2125a9dc3d76211720e5152bdbcd4b236363d18d4f8a3"
+)
+EXPECTED_FILE_CID = "QmPoBEaYRf2HDHHFsD7tYkCcSdpLbx5CYDgCgDtW4ywhSK"
+
+JSON_CONTENT = {"first name": "Jay", "last_name": "Son"}
+EXPECTED_JSON_FILE_SHA256 = (
+    "b7c7b2db0bcec890b8c859b2b76e7c998de15e31ccc945bc7425c4bdc091a0b2"
+)
+
+
+@pytest.fixture
+def api_client(ccn_api_client, mocker):
+    ipfs_service = mocker.AsyncMock()
+    ipfs_service.add_bytes = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
+    ipfs_service.add_file = mocker.AsyncMock(
+        return_value={
+            "Hash": EXPECTED_FILE_CID,
+            "Size": 34,
+            "Name": "hello-earthlings.txt",
+        }
+    )
+    ipfs_service.get_ipfs_content = mocker.AsyncMock(return_value=FILE_CONTENT)
+
+    ccn_api_client.app["storage_service"] = StorageService(
+        storage_engine=InMemoryStorageEngine(files={}),
+        ipfs_service=ipfs_service,
+        node_cache=mocker.AsyncMock(),
+    )
+    return ccn_api_client
+
+
+async def add_file(
+    api_client,
+    session_factory: DbSessionFactory,
+    uri: str,
+    file_content: bytes,
+    expected_file_hash: str,
+):
+    form_data = aiohttp.FormData()
+    form_data.add_field("file", file_content)
+
+    post_response = await api_client.post(uri, data=form_data)
+    assert post_response.status == 200, await post_response.text()
+    post_response_json = await post_response.json()
+    assert post_response_json["status"] == "success"
+    file_hash = post_response_json["hash"]
+    assert file_hash == expected_file_hash
+
+    # Assert that the file is downloadable
+    get_file_response = await api_client.get(f"{GET_STORAGE_RAW_URI}/{file_hash}")
+    assert get_file_response.status == 200
+    response_data = await get_file_response.read()
+
+    # Check that the file appears in the DB
+    with session_factory() as session:
+        file = get_file(session=session, file_hash=file_hash)
+        assert file is not None
+        assert file.hash == file_hash
+        assert file.type == FileType.FILE
+        assert file.size == len(file_content)
+
+    assert response_data == file_content
+
+
+@pytest.mark.asyncio
+async def test_storage_add_file(api_client, session_factory: DbSessionFactory):
+    await add_file(
+        api_client,
+        session_factory,
+        uri=STORAGE_ADD_FILE_URI,
+        file_content=FILE_CONTENT,
+        expected_file_hash=EXPECTED_FILE_SHA256,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ipfs_add_file(api_client, session_factory: DbSessionFactory):
+    await add_file(
+        api_client,
+        session_factory,
+        uri=IPFS_ADD_FILE_URI,
+        file_content=FILE_CONTENT,
+        expected_file_hash=EXPECTED_FILE_CID,
+    )
+
+
+async def add_json(
+    api_client,
+    session_factory: DbSessionFactory,
+    uri: str,
+    json: Any,
+    expected_file_hash: ItemHash,
+):
+    serialized_json = orjson.dumps(json)
+
+    post_response = await api_client.post(uri, json=json)
+    assert post_response.status == 200, await post_response.text()
+    post_response_json = await post_response.json()
+    assert post_response_json["status"] == "success"
+    file_hash = post_response_json["hash"]
+    assert file_hash == expected_file_hash
+
+    # Assert that the JSON content is gettable
+    get_json_response = await api_client.get(f"{GET_STORAGE_URI}/{file_hash}")
+    assert get_json_response.status == 200
+
+    response_json = await get_json_response.json()
+    assert response_json["status"] == "success"
+    assert response_json["hash"] == file_hash
+    assert response_json["engine"] == expected_file_hash.item_type.value
+    assert base64.b64decode(response_json["content"]) == serialized_json
+
+    # Assert that the corresponding file is downloadable
+    get_file_response = await api_client.get(f"{GET_STORAGE_RAW_URI}/{file_hash}")
+    assert get_file_response.status == 200
+    assert await get_file_response.read() == serialized_json
+
+    # Check that the file appears in the DB
+    with session_factory() as session:
+        file = get_file(session=session, file_hash=file_hash)
+        assert file is not None
+        assert file.hash == file_hash
+        assert file.type == FileType.FILE
+
+    # Ch
+
+
+@pytest.mark.asyncio
+async def test_storage_add_json(api_client, session_factory: DbSessionFactory):
+    await add_json(
+        api_client,
+        session_factory,
+        uri=STORAGE_ADD_JSON_URI,
+        json=JSON_CONTENT,
+        expected_file_hash=ItemHash(EXPECTED_JSON_FILE_SHA256),
+    )
+
+
+@pytest.mark.asyncio
+async def test_ipfs_add_json(api_client, session_factory: DbSessionFactory):
+    await add_json(
+        api_client,
+        session_factory,
+        uri=IPFS_ADD_JSON_URI,
+        json=JSON_CONTENT,
+        # Note: we mock the call to the IPFS daemon, so we reuse the same CID to avoid
+        # creating a second fixture.
+        expected_file_hash=ItemHash(EXPECTED_FILE_CID),
+    )


### PR DESCRIPTION
Four fixes:

* files uploaded with the add_file/add_json endpoints are not downloadable.
* /ipfs/add_file is broken.
* /ipfs/add_file returned the wrong size, and we store the wrong size for IPFS files above 1MB when processing STORE messages.
* Unrelated, but the test API server was unable to use the IPFS client, making the fixes above harder to test locally.