### PR TITLE
Fix: ignore trusted messages for on-chain sync

### DIFF
--- a/src/aleph/db/accessors/messages.py
+++ b/src/aleph/db/accessors/messages.py
@@ -250,7 +250,7 @@ def get_unconfirmed_messages(
         )
 
     select_stmt = select(MessageDb).where(
-        ~select_message_confirmations.exists()
+        MessageDb.signature.isnot(None) & (~select_message_confirmations.exists())
     )
 
     return (session.execute(select_stmt.limit(limit))).scalars()

--- a/tests/db/test_messages.py
+++ b/tests/db/test_messages.py
@@ -319,6 +319,18 @@ async def test_get_unconfirmed_messages(
 
 
 @pytest.mark.asyncio
+async def test_get_unconfirmed_messages_trusted_messages(session_factory:DbSessionFactory, fixture_message: MessageDb):
+    fixture_message.signature = None
+    with session_factory() as session:
+        session.add(fixture_message)
+        session.commit()
+
+    with session_factory() as session:
+        unconfirmed_messages = list(get_unconfirmed_messages(session))
+        assert unconfirmed_messages == []
+
+
+@pytest.mark.asyncio
 async def test_get_distinct_channels(
     session_factory: DbSessionFactory, fixture_message: MessageDb
 ):


### PR DESCRIPTION
Problem: trusted messages were included in the results of `get_unconfirmed_messages` when confirming messages on-chain.

Solution: remove trusted messages from the query.