### PR TITLE
Fix: filtering by tags

### DIFF
--- a/src/aleph/db/accessors/messages.py
+++ b/src/aleph/db/accessors/messages.py
@@ -4,7 +4,7 @@ from typing import Optional, Sequence, Union, Iterable, Any, Mapping, overload, 
 
 from aleph_message.models import ItemHash, Chain, MessageType
 from sqlalchemy import func, select, update, text, delete, nullsfirst, nullslast
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.dialects.postgresql import insert, array
 from sqlalchemy.orm import selectinload, load_only
 from sqlalchemy.sql import Insert, Select
 from sqlalchemy.sql.elements import literal
@@ -105,7 +105,7 @@ def make_matching_messages_query(
         )
     if tags:
         select_stmt = select_stmt.where(
-            MessageDb.content["content"]["tags"].contains(tags)
+            MessageDb.content["content"]["tags"].has_any(array(tags))
         )
     if channels:
         select_stmt = select_stmt.where(MessageDb.channel.in_(channels))

--- a/src/aleph/db/accessors/posts.py
+++ b/src/aleph/db/accessors/posts.py
@@ -28,7 +28,7 @@ from sqlalchemy import (
     Float,
     case,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, array
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import Select
 
@@ -230,7 +230,7 @@ def filter_post_select_stmt(
         select_stmt = select_stmt.where(literal_column("original_type").in_(post_types))
     if tags:
         select_stmt = select_stmt.where(
-            literal_column("content", type_=JSONB)["tags"].astext.in_(tags)
+            literal_column("content", type_=JSONB)["tags"].has_any(array(tags))
         )
     if channels:
         select_stmt = select_stmt.where(literal_column("channel").in_(channels))

--- a/tests/api/test_posts.py
+++ b/tests/api/test_posts.py
@@ -5,8 +5,6 @@ import pytest
 
 from aleph.db.models import MessageDb
 from aleph.db.models.posts import PostDb
-import datetime as dt
-
 from aleph.types.db_session import DbSessionFactory
 
 POSTS_URI = "/api/v1/posts.json"
@@ -53,70 +51,6 @@ async def test_get_posts(ccn_api_client, fixture_posts: Sequence[PostDb]):
     # 1 POST = 1 message.
     posts = await get_posts_expect_success(ccn_api_client)
     assert_posts_equal(posts, fixture_posts)
-
-
-@pytest.fixture
-def post_with_refs_and_tags() -> Tuple[MessageDb, PostDb]:
-    message = MessageDb(
-        item_hash="1234",
-        sender="0xdeadbeef",
-        type="POST",
-        chain="ETH",
-        signature=None,
-        item_type="storage",
-        item_content=None,
-        content={},
-        time=dt.datetime(2023, 5, 1, tzinfo=dt.timezone.utc),
-        channel=None,
-        size=254,
-    )
-
-    post = PostDb(
-        item_hash=message.item_hash,
-        owner=message.sender,
-        type=None,
-        ref="custom-ref",
-        amends=None,
-        channel=None,
-        content={"swap": "this"},
-        creation_datetime=message.time,
-        latest_amend=None,
-    )
-
-    return message, post
-
-
-@pytest.fixture
-def amended_post_with_refs_and_tags(post_with_refs_and_tags: Tuple[MessageDb, PostDb]):
-    original_message, original_post = post_with_refs_and_tags
-
-    amend_message = MessageDb(
-        item_hash="5678",
-        sender="0xdeadbeef",
-        type="POST",
-        chain="ETH",
-        signature=None,
-        item_type="storage",
-        item_content=None,
-        content={},
-        time=dt.datetime(2023, 5, 2, tzinfo=dt.timezone.utc),
-        channel=None,
-        size=277,
-    )
-
-    amend_post = PostDb(
-        item_hash=amend_message.item_hash,
-        owner=original_message.sender,
-        type="amend",
-        ref=original_message.item_hash,
-        amends=original_message.item_hash,
-        channel=None,
-        content={"don't": "swap"},
-        creation_datetime=amend_message.time,
-        latest_amend=None,
-    )
-
-    return amend_message, amend_post
 
 
 @pytest.mark.asyncio
@@ -222,6 +156,144 @@ async def test_get_amended_posts_refs(
     # Search for several refs
     response = await ccn_api_client.get(
         "/api/v0/posts.json", params={"refs": f"{original_post_db.ref},not-a-ref"}
+    )
+    assert response.status == 200
+    response_json = await response.json()
+    assert len(response_json["posts"]) == 1
+    assert response_json["pagination_total"] == 1
+
+    post = response_json["posts"][0]
+    assert post["item_hash"] == amend_post_db.item_hash
+    assert post["original_item_hash"] == original_post_db.item_hash
+    assert post["ref"] == original_post_db.ref
+    assert post["content"] == amend_post_db.content
+
+
+@pytest.mark.asyncio
+async def test_get_posts_tags(
+    ccn_api_client,
+    session_factory: DbSessionFactory,
+    fixture_posts: Sequence[PostDb],
+    post_with_refs_and_tags: Tuple[MessageDb, PostDb],
+):
+    message_db, post_db = post_with_refs_and_tags
+
+    with session_factory() as session:
+        session.add_all(fixture_posts)
+        session.add(message_db)
+        session.add(post_db)
+        session.commit()
+
+    # Match one tag
+    response = await ccn_api_client.get(
+        "/api/v0/posts.json", params={"tags": "mainnet"}
+    )
+    assert response.status == 200, await response.text()
+    response_json = await response.json()
+    assert len(response_json["posts"]) == 1
+    assert response_json["pagination_total"] == 1
+
+    post = response_json["posts"][0]
+    assert post["item_hash"] == post_db.item_hash
+    assert post["original_item_hash"] == post_db.item_hash
+    assert post["content"] == post_db.content
+
+    # Unknown tag
+    response = await ccn_api_client.get(
+        "/api/v0/posts.json", params={"tags": "not-a-tag"}
+    )
+    assert response.status == 200
+    response_json = await response.json()
+    assert len(response_json["posts"]) == 0
+    assert response_json["pagination_total"] == 0
+
+    # Search for several tags
+    response = await ccn_api_client.get(
+        "/api/v0/posts.json", params={"tags": f"mainnet,not-a-ref"}
+    )
+    assert response.status == 200
+    response_json = await response.json()
+    assert len(response_json["posts"]) == 1
+    assert response_json["pagination_total"] == 1
+
+    post = response_json["posts"][0]
+    assert post["item_hash"] == post_db.item_hash
+    assert post["original_item_hash"] == post_db.item_hash
+    assert post["ref"] == post_db.ref
+    assert post["content"] == post_db.content
+
+    # Check for several matching tags
+    # Search for several tags
+    response = await ccn_api_client.get(
+        "/api/v0/posts.json", params={"tags": f"original,mainnet"}
+    )
+    assert response.status == 200
+    response_json = await response.json()
+    assert len(response_json["posts"]) == 1
+    assert response_json["pagination_total"] == 1
+
+    post = response_json["posts"][0]
+    assert post["item_hash"] == post_db.item_hash
+    assert post["original_item_hash"] == post_db.item_hash
+    assert post["ref"] == post_db.ref
+    assert post["content"] == post_db.content
+
+
+@pytest.mark.asyncio
+async def test_get_amended_posts_tags(
+    ccn_api_client,
+    session_factory: DbSessionFactory,
+    fixture_posts: Sequence[PostDb],
+    post_with_refs_and_tags: Tuple[MessageDb, PostDb],
+    amended_post_with_refs_and_tags: Tuple[MessageDb, PostDb],
+):
+    original_message_db, original_post_db = post_with_refs_and_tags
+    amend_message_db, amend_post_db = amended_post_with_refs_and_tags
+
+    original_post_db.latest_amend = amend_post_db.item_hash
+
+    with session_factory() as session:
+        session.add_all(fixture_posts)
+        session.add(original_message_db)
+        session.add(original_post_db)
+        session.add(amend_message_db)
+        session.add(amend_post_db)
+        session.commit()
+
+    # Match one tag
+    response = await ccn_api_client.get("/api/v0/posts.json", params={"tags": "amend"})
+    assert response.status == 200
+    response_json = await response.json()
+    assert len(response_json["posts"]) == 1
+    assert response_json["pagination_total"] == 1
+
+    post = response_json["posts"][0]
+    assert post["item_hash"] == amend_post_db.item_hash
+    assert post["original_item_hash"] == original_post_db.item_hash
+    assert post["ref"] == original_post_db.ref
+    assert post["content"] == amend_post_db.content
+
+    # Unknown tag
+    response = await ccn_api_client.get(
+        "/api/v0/posts.json", params={"tags": "not-a-tag"}
+    )
+    assert response.status == 200
+    response_json = await response.json()
+    assert len(response_json["posts"]) == 0
+    assert response_json["pagination_total"] == 0
+
+    # Tag of the original
+    response = await ccn_api_client.get(
+        "/api/v0/posts.json", params={"tags": "original"}
+    )
+    assert response.status == 200
+    response_json = await response.json()
+    assert len(response_json["posts"]) == 0
+    assert response_json["pagination_total"] == 0
+
+    # Search for several tags
+    response = await ccn_api_client.get(
+        "/api/v0/posts.json", params={"tags": "mainnet,not-a-tag"}
     )
     assert response.status == 200
     response_json = await response.json()


### PR DESCRIPTION
Problems:
* the `tags` filter in /messages.json is not additive and filters out
  messages that don't match all the specified tags, instead of returning
  messages that have at least one matching tag.
* filtering posts by tags filters out all results.

Solution: fix the SQL queries, the filter was comparing the specified
tags against the post tags as strings instead of checking for
inclusion. We now use the '?|' operator to check if the message/post
tags match at least one of the specified tags.