### PR TITLE
Fix: filter amended posts by ref on /api/v0/posts.json

### DIFF
--- a/src/aleph/db/accessors/posts.py
+++ b/src/aleph/db/accessors/posts.py
@@ -124,7 +124,7 @@ def make_select_merged_post_with_message_info_stmt() -> Select:
                 "item_type"
             ),
             Original.owner.label("owner"),
-            func.coalesce(Amend.ref, Original.ref).label("ref"),
+            Original.ref.label("ref"),
             func.coalesce(Amend.creation_datetime, Original.creation_datetime).label(
                 "last_updated"
             ),

--- a/tests/api/test_posts.py
+++ b/tests/api/test_posts.py
@@ -1,9 +1,13 @@
-from typing import Dict, Iterable, Sequence
+from typing import Dict, Iterable, Sequence, Tuple
 
 import aiohttp
 import pytest
 
+from aleph.db.models import MessageDb
 from aleph.db.models.posts import PostDb
+import datetime as dt
+
+from aleph.types.db_session import DbSessionFactory
 
 POSTS_URI = "/api/v1/posts.json"
 
@@ -49,3 +53,183 @@ async def test_get_posts(ccn_api_client, fixture_posts: Sequence[PostDb]):
     # 1 POST = 1 message.
     posts = await get_posts_expect_success(ccn_api_client)
     assert_posts_equal(posts, fixture_posts)
+
+
+@pytest.fixture
+def post_with_refs_and_tags() -> Tuple[MessageDb, PostDb]:
+    message = MessageDb(
+        item_hash="1234",
+        sender="0xdeadbeef",
+        type="POST",
+        chain="ETH",
+        signature=None,
+        item_type="storage",
+        item_content=None,
+        content={},
+        time=dt.datetime(2023, 5, 1, tzinfo=dt.timezone.utc),
+        channel=None,
+        size=254,
+    )
+
+    post = PostDb(
+        item_hash=message.item_hash,
+        owner=message.sender,
+        type=None,
+        ref="custom-ref",
+        amends=None,
+        channel=None,
+        content={"swap": "this"},
+        creation_datetime=message.time,
+        latest_amend=None,
+    )
+
+    return message, post
+
+
+@pytest.fixture
+def amended_post_with_refs_and_tags(post_with_refs_and_tags: Tuple[MessageDb, PostDb]):
+    original_message, original_post = post_with_refs_and_tags
+
+    amend_message = MessageDb(
+        item_hash="5678",
+        sender="0xdeadbeef",
+        type="POST",
+        chain="ETH",
+        signature=None,
+        item_type="storage",
+        item_content=None,
+        content={},
+        time=dt.datetime(2023, 5, 2, tzinfo=dt.timezone.utc),
+        channel=None,
+        size=277,
+    )
+
+    amend_post = PostDb(
+        item_hash=amend_message.item_hash,
+        owner=original_message.sender,
+        type="amend",
+        ref=original_message.item_hash,
+        amends=original_message.item_hash,
+        channel=None,
+        content={"don't": "swap"},
+        creation_datetime=amend_message.time,
+        latest_amend=None,
+    )
+
+    return amend_message, amend_post
+
+
+@pytest.mark.asyncio
+async def test_get_posts_refs(
+    ccn_api_client,
+    session_factory: DbSessionFactory,
+    fixture_posts: Sequence[PostDb],
+    post_with_refs_and_tags: Tuple[MessageDb, PostDb],
+):
+    message_db, post_db = post_with_refs_and_tags
+
+    with session_factory() as session:
+        session.add_all(fixture_posts)
+        session.add(message_db)
+        session.add(post_db)
+        session.commit()
+
+    # Match the ref
+    response = await ccn_api_client.get(
+        "/api/v0/posts.json", params={"refs": f"{post_db.ref}"}
+    )
+    assert response.status == 200
+    response_json = await response.json()
+    assert len(response_json["posts"]) == 1
+    assert response_json["pagination_total"] == 1
+
+    post = response_json["posts"][0]
+    assert post["item_hash"] == post_db.item_hash
+    assert post["original_item_hash"] == post_db.item_hash
+    assert post["ref"] == post_db.ref
+    assert post["content"] == post_db.content
+
+    # Unknown ref
+    response = await ccn_api_client.get(
+        "/api/v0/posts.json", params={"refs": "not-a-ref"}
+    )
+    assert response.status == 200
+    response_json = await response.json()
+    assert len(response_json["posts"]) == 0
+    assert response_json["pagination_total"] == 0
+
+    # Search for several refs
+    response = await ccn_api_client.get(
+        "/api/v0/posts.json", params={"refs": f"{post_db.ref},not-a-ref"}
+    )
+    assert response.status == 200
+    response_json = await response.json()
+    assert len(response_json["posts"]) == 1
+    assert response_json["pagination_total"] == 1
+
+    post = response_json["posts"][0]
+    assert post["item_hash"] == post_db.item_hash
+    assert post["original_item_hash"] == post_db.item_hash
+    assert post["ref"] == post_db.ref
+    assert post["content"] == post_db.content
+
+
+@pytest.mark.asyncio
+async def test_get_amended_posts_refs(
+    ccn_api_client,
+    session_factory: DbSessionFactory,
+    fixture_posts: Sequence[PostDb],
+    post_with_refs_and_tags: Tuple[MessageDb, PostDb],
+    amended_post_with_refs_and_tags: Tuple[MessageDb, PostDb],
+):
+    original_message_db, original_post_db = post_with_refs_and_tags
+    amend_message_db, amend_post_db = amended_post_with_refs_and_tags
+
+    original_post_db.latest_amend = amend_post_db.item_hash
+
+    with session_factory() as session:
+        session.add_all(fixture_posts)
+        session.add(original_message_db)
+        session.add(original_post_db)
+        session.add(amend_message_db)
+        session.add(amend_post_db)
+        session.commit()
+
+    # Match the ref
+    response = await ccn_api_client.get(
+        "/api/v0/posts.json", params={"refs": f"{original_post_db.ref}"}
+    )
+    assert response.status == 200
+    response_json = await response.json()
+    assert len(response_json["posts"]) == 1
+    assert response_json["pagination_total"] == 1
+
+    post = response_json["posts"][0]
+    assert post["item_hash"] == amend_post_db.item_hash
+    assert post["original_item_hash"] == original_post_db.item_hash
+    assert post["ref"] == original_post_db.ref
+    assert post["content"] == amend_post_db.content
+
+    # Unknown ref
+    response = await ccn_api_client.get(
+        "/api/v0/posts.json", params={"refs": "not-a-ref"}
+    )
+    assert response.status == 200
+    response_json = await response.json()
+    assert len(response_json["posts"]) == 0
+    assert response_json["pagination_total"] == 0
+
+    # Search for several refs
+    response = await ccn_api_client.get(
+        "/api/v0/posts.json", params={"refs": f"{original_post_db.ref},not-a-ref"}
+    )
+    assert response.status == 200
+    response_json = await response.json()
+    assert len(response_json["posts"]) == 1
+    assert response_json["pagination_total"] == 1
+
+    post = response_json["posts"][0]
+    assert post["item_hash"] == amend_post_db.item_hash
+    assert post["original_item_hash"] == original_post_db.item_hash
+    assert post["ref"] == original_post_db.ref
+    assert post["content"] == amend_post_db.content

--- a/tests/db/test_posts.py
+++ b/tests/db/test_posts.py
@@ -172,7 +172,7 @@ def assert_posts_v0_equal(
 ):
     expected_item_hash = last_amend.item_hash if last_amend else original.item_hash
     expected_content = last_amend.content if last_amend else original.content
-    expected_ref = last_amend.ref if last_amend else original.ref
+    expected_ref = original.ref
     expected_last_updated = (
         last_amend.creation_datetime if last_amend else original.creation_datetime
     )


### PR DESCRIPTION
Problem: amended posts do not appear when filtering the results of `/api/v0/posts.json` with the `refs` query parameter.
Solution: do not take the `ref` of the amend into account as it will always be equal to the `item_hash` of the original post.