### PR TITLE
Fix: support very large number of open websockets

### DIFF
--- a/src/aleph/web/controllers/app_state_getters.py
+++ b/src/aleph/web/controllers/app_state_getters.py
@@ -18,6 +18,7 @@ from aleph.types.db_session import DbSessionFactory
 
 APP_STATE_CONFIG = "config"
 APP_STATE_MQ_CONN = "mq_conn"
+APP_STATE_MQ_CHANNEL = "mq_channel"
 APP_STATE_NODE_CACHE = "node_cache"
 APP_STATE_P2P_CLIENT = "p2p_client"
 APP_STATE_SESSION_FACTORY = "session_factory"
@@ -43,6 +44,10 @@ def get_ipfs_service_from_request(request: web.Request) -> Optional[IpfsService]
 
 def get_mq_conn_from_request(request: web.Request) -> aio_pika.abc.AbstractConnection:
     return cast(aio_pika.abc.AbstractConnection, request.app[APP_STATE_MQ_CONN])
+
+
+def get_mq_channel_from_request(request: web.Request) -> aio_pika.abc.AbstractChannel:
+    return cast(aio_pika.abc.AbstractChannel, request.app[APP_STATE_MQ_CHANNEL])
 
 
 def get_node_cache_from_request(request: web.Request) -> NodeCache:

--- a/src/aleph/web/controllers/utils.py
+++ b/src/aleph/web/controllers/utils.py
@@ -143,11 +143,10 @@ def cond_output(request, context, template):
 
 
 async def mq_make_aleph_message_topic_queue(
-    mq_conn: aio_pika.abc.AbstractConnection,
+    channel: aio_pika.abc.AbstractChannel,
     config: Config,
     routing_key: Optional[str] = None,
 ) -> aio_pika.abc.AbstractQueue:
-    channel = await mq_conn.channel()
     mq_message_exchange = await channel.declare_exchange(
         name=config.rabbitmq.message_exchange.value,
         type=aio_pika.ExchangeType.TOPIC,


### PR DESCRIPTION
Problem: opening more than ~2000 message websockets hits the channel limit of RabbitMQ and resets the connection.

Solution: create one channel per API process, as they are long-lived and should not be created for each operation according to the doc.