### PR TITLE
Fix: increase shared memory size for PostgreSQL container

### DIFF
--- a/deployment/docker-build/docker-compose.yml
+++ b/deployment/docker-build/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       POSTGRES_DB: aleph
     networks:
       - pyaleph
+    shm_size: "2gb"
 
   redis:
     restart: always

--- a/deployment/samples/docker-compose/docker-compose.yml
+++ b/deployment/samples/docker-compose/docker-compose.yml
@@ -80,6 +80,7 @@ services:
       POSTGRES_DB: aleph
     networks:
       - pyaleph
+    shm_size: "2gb"
 
   rabbitmq:
     restart: always

--- a/deployment/samples/docker-monitoring/docker-compose.yml
+++ b/deployment/samples/docker-monitoring/docker-compose.yml
@@ -82,6 +82,7 @@ services:
       POSTGRES_DB: aleph
     networks:
       - pyaleph
+    shm_size: "2gb"
 
   rabbitmq:
     restart: always


### PR DESCRIPTION
Problem: some SQL queries end up requiring more than the (limited) amount of shared memory allocated to Docker containers by default.

Solution: increase it to 2GB.