### PR TITLE
Fix: avoid channel closed exception in message websocket

### DIFF
--- a/src/aleph/web/controllers/utils.py
+++ b/src/aleph/web/controllers/utils.py
@@ -152,6 +152,11 @@ async def mq_make_aleph_message_topic_queue(
         type=aio_pika.ExchangeType.TOPIC,
         auto_delete=False,
     )
-    mq_queue = await channel.declare_queue(auto_delete=True)
+    mq_queue = await channel.declare_queue(
+        auto_delete=True, exclusive=True,
+        # Auto-delete the queue after 30 seconds. This guarantees that queues are deleted even
+        # if a bug makes the consumer crash before cleanup.
+        arguments={"x-expires": 30000}
+    )
     await mq_queue.bind(mq_message_exchange, routing_key=routing_key)
     return mq_queue


### PR DESCRIPTION
Problem: upon closing, the message websocket may attempt to close the RabbitMQ channel. This appears to be caused by the handling of `CancellationError` in the `close()` method of the queue iterator.

Solution: replace the `iterator` implementation with a simpler `consume` + callback implementation. This guarantees that the secondary task will never attempt to close the channel. Replace task cancellation by a call to `queue.cancel()` as aiormq handles cancellation exceptions by closing the channel.