### PR TITLE
Fix: do not send confirmations to message websocket

### DIFF
--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -29,10 +29,9 @@ from aleph.types.db_session import DbSessionFactory
 from .job_utils import (
     prepare_loop,
     MessageJob,
-    MessageProcessingResult,
-    ProcessedMessage,
 )
 from ..services.cache.node_cache import NodeCache
+from ..types.message_processing_result import MessageProcessingResult
 
 LOGGER = getLogger(__name__)
 
@@ -99,11 +98,12 @@ class PendingMessageProcessor(MessageJob):
                     break
 
                 try:
-                    message = await self.message_handler.process(
-                        session=session, pending_message=pending_message
+                    result: MessageProcessingResult = (
+                        await self.message_handler.process(
+                            session=session, pending_message=pending_message
+                        )
                     )
                     session.commit()
-                    result: MessageProcessingResult = ProcessedMessage(message)
 
                 except Exception as e:
                     session.rollback()

--- a/src/aleph/types/message_processing_result.py
+++ b/src/aleph/types/message_processing_result.py
@@ -1,0 +1,59 @@
+from typing import Protocol
+
+from aleph.db.models import PendingMessageDb, MessageDb
+from aleph.types.message_status import (
+    ErrorCode,
+    MessageProcessingStatus,
+)
+
+
+class MessageProcessingResult(Protocol):
+    status: MessageProcessingStatus
+
+    @property
+    def item_hash(self) -> str:
+        pass
+
+
+class ProcessedMessage(MessageProcessingResult):
+    def __init__(self, message: MessageDb, is_confirmation: bool = False):
+        self.message = message
+        self.status = (
+            MessageProcessingStatus.PROCESSED_CONFIRMATION
+            if is_confirmation
+            else MessageProcessingStatus.PROCESSED_NEW_MESSAGE
+        )
+
+    @property
+    def item_hash(self) -> str:
+        return self.message.item_hash
+
+
+class FailedMessage(MessageProcessingResult):
+    status = MessageProcessingStatus.FAILED_WILL_RETRY
+
+    def __init__(
+        self, pending_message: PendingMessageDb, error_code: ErrorCode, will_retry: bool
+    ):
+        self.pending_message = pending_message
+        self.error_code = error_code
+
+        self.status = (
+            MessageProcessingStatus.FAILED_WILL_RETRY
+            if will_retry
+            else MessageProcessingStatus.FAILED_REJECTED
+        )
+
+    @property
+    def item_hash(self) -> str:
+        return self.pending_message.item_hash
+
+
+class WillRetryMessage(FailedMessage):
+    def __init__(self, pending_message: PendingMessageDb, error_code: ErrorCode):
+        super().__init__(pending_message, error_code, will_retry=True)
+
+
+class RejectedMessage(FailedMessage):
+    def __init__(self, pending_message: PendingMessageDb, error_code: ErrorCode):
+        super().__init__(pending_message, error_code, will_retry=False)

--- a/tests/helpers/message_test_helpers.py
+++ b/tests/helpers/message_test_helpers.py
@@ -6,10 +6,10 @@ from typing import List, Optional, Union, Any, Mapping, Sequence, Iterable
 from aleph_message.models import ItemType, MessageConfirmation
 
 from aleph.db.models import MessageDb, PendingMessageDb, MessageStatusDb
-from aleph.jobs.job_utils import MessageProcessingResult
 from aleph.jobs.process_pending_messages import PendingMessageProcessor
 from aleph.toolkit.timestamp import utc_now
 from aleph.types.db_session import DbSession
+from aleph.types.message_processing_result import MessageProcessingResult
 from aleph.types.message_status import MessageStatus
 
 

--- a/tests/message_processing/test_process_aggregates.py
+++ b/tests/message_processing/test_process_aggregates.py
@@ -14,12 +14,12 @@ from aleph.db.accessors.aggregates import get_aggregate_by_key, get_aggregate_el
 from aleph.db.models import PendingMessageDb, MessageDb, AggregateElementDb, AggregateDb
 from aleph.handlers.content.aggregate import AggregateMessageHandler
 from aleph.handlers.message_handler import MessageHandler
-from aleph.jobs.job_utils import ProcessedMessage
 from aleph.jobs.process_pending_messages import PendingMessageProcessor
 from aleph.storage import StorageService
 from aleph.toolkit.timestamp import timestamp_to_datetime
 from aleph.types.channel import Channel
 from aleph.types.db_session import DbSessionFactory, DbSession
+from aleph.types.message_processing_result import ProcessedMessage
 from message_test_helpers import process_pending_messages
 
 

--- a/tests/message_processing/test_process_forgets.py
+++ b/tests/message_processing/test_process_forgets.py
@@ -22,12 +22,12 @@ from aleph.handlers.content.forget import ForgetMessageHandler
 from aleph.handlers.content.post import PostMessageHandler
 from aleph.handlers.content.program import ProgramMessageHandler
 from aleph.handlers.content.store import StoreMessageHandler
-from aleph.jobs.job_utils import ProcessedMessage, RejectedMessage
 from aleph.jobs.process_pending_messages import PendingMessageProcessor
 from aleph.toolkit.timestamp import timestamp_to_datetime
 from aleph.types.channel import Channel
 from aleph.types.db_session import DbSessionFactory
 from aleph.types.files import FileType
+from aleph.types.message_processing_result import ProcessedMessage, RejectedMessage
 from aleph.types.message_status import MessageStatus
 from message_test_helpers import (
     process_pending_messages,


### PR DESCRIPTION
Problem: websocket users report messages appearing twice, as they are received on both the P2P and IPFS pubsub topics.

Solution: ignore confirmations. The scaffolding was already in place, we just need to return a `ProcessedMessage` instead of a raw `MessageDb` from `MessageHandler.process()`.