### PR TITLE
Fix: reopen the API MQ channels if they are closed

### DIFF
--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -301,7 +301,7 @@ async def messages_ws(request: web.Request) -> web.WebSocketResponse:
 
     config = get_config_from_request(request)
     session_factory = get_session_factory_from_request(request)
-    mq_channel = get_mq_ws_channel_from_request(request)
+    mq_channel = await get_mq_ws_channel_from_request(request=request, logger=LOGGER)
 
     try:
         query_params = WsMessageQueryParams.parse_obj(request.query)

--- a/src/aleph/web/controllers/p2p.py
+++ b/src/aleph/web/controllers/p2p.py
@@ -197,7 +197,7 @@ async def pub_message(request: web.Request):
     config = get_config_from_request(request)
 
     if request_data.sync:
-        mq_channel = get_mq_channel_from_request(request)
+        mq_channel = await get_mq_channel_from_request(request=request, logger=LOGGER)
         mq_queue = await mq_make_aleph_message_topic_queue(
             channel=mq_channel,
             config=config,


### PR DESCRIPTION
Problem: the MQ channels can close for a variety of issues. Once closed, the channel cannot be used anymore.

Solution: detect if the channel is closed and reopen it if needed.