### PR TITLE
Fix: no DB calls in message websocket

### DIFF
--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -119,10 +119,10 @@ class PendingMessageProcessor(MessageJob):
     async def publish_to_mq(
         self, message_iterator: AsyncIterator[Sequence[MessageProcessingResult]]
     ) -> AsyncIterator[Sequence[MessageProcessingResult]]:
+
         async for processing_results in message_iterator:
             for result in processing_results:
-                body = {"item_hash": result.item_hash}
-                mq_message = aio_pika.Message(body=aleph_json.dumps(body))
+                mq_message = aio_pika.Message(body=aleph_json.dumps(result.to_dict()))
                 await self.mq_message_exchange.publish(
                     mq_message,
                     routing_key=f"{result.status.value}.{result.item_hash}",

--- a/src/aleph/schemas/api/messages.py
+++ b/src/aleph/schemas/api/messages.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel, Field
 from pydantic.generics import GenericModel
 
 import aleph.toolkit.json as aleph_json
+from aleph.db.models import MessageDb
 from aleph.types.message_status import MessageStatus, ErrorCode
 
 MType = TypeVar("MType", bound=MessageType)
@@ -120,9 +121,17 @@ AlephMessage = Annotated[
 ]
 
 
-def format_message(message: Any) -> AlephMessage:
-    message_cls = MESSAGE_CLS_DICT[message.type]
-    return message_cls.from_orm(message)    # type: ignore[return-value]
+def format_message(message: MessageDb) -> AlephMessage:
+    message_type = message.type
+
+    message_cls = MESSAGE_CLS_DICT[message_type]
+    return message_cls.from_orm(message)  # type: ignore[return-value]
+
+
+def format_message_dict(message: Dict[str, Any]) -> AlephMessage:
+    message_type = message.get("type")
+    message_cls = MESSAGE_CLS_DICT[message_type]
+    return message_cls.parse_obj(message)
 
 
 class BaseMessageStatus(BaseModel):

--- a/src/aleph/schemas/api/messages.py
+++ b/src/aleph/schemas/api/messages.py
@@ -131,7 +131,7 @@ def format_message(message: MessageDb) -> AlephMessage:
 def format_message_dict(message: Dict[str, Any]) -> AlephMessage:
     message_type = message.get("type")
     message_cls = MESSAGE_CLS_DICT[message_type]
-    return message_cls.parse_obj(message)
+    return message_cls.parse_obj(message)  # type: ignore[return-value]
 
 
 class BaseMessageStatus(BaseModel):

--- a/src/aleph/schemas/api/messages.py
+++ b/src/aleph/schemas/api/messages.py
@@ -97,11 +97,6 @@ MESSAGE_CLS_DICT = {
 }
 
 
-def format_message(message: Any) -> AlephMessage:
-    message_cls = MESSAGE_CLS_DICT[message.type]
-    return message_cls.from_orm(message)
-
-
 AlephMessage = Union[
     AggregateMessage,
     ForgetMessage,
@@ -110,6 +105,11 @@ AlephMessage = Union[
     ProgramMessage,
     StoreMessage,
 ]
+
+
+def format_message(message: Any) -> AlephMessage:
+    message_cls = MESSAGE_CLS_DICT[message.type]
+    return message_cls.from_orm(message)
 
 
 class BaseMessageStatus(BaseModel):

--- a/src/aleph/schemas/api/messages.py
+++ b/src/aleph/schemas/api/messages.py
@@ -9,7 +9,6 @@ from aleph_message.models import (
     PostContent,
     ProgramContent,
     StoreContent,
-    AlephMessage,
     InstanceContent,
 )
 from aleph_message.models import MessageType, ItemType
@@ -107,7 +106,7 @@ AlephMessage = Union[
 ]
 
 
-def format_message(message: Any) -> AlephMessage:
+def format_message(message: Any) -> BaseMessage:
     message_cls = MESSAGE_CLS_DICT[message.type]
     return message_cls.from_orm(message)
 
@@ -150,7 +149,7 @@ class ProcessedMessageStatus(BaseMessageStatus):
         orm_mode = True
 
     status: MessageStatus = MessageStatus.PROCESSED
-    message: AlephMessage
+    message: BaseMessage
 
 
 class ForgottenMessage(BaseModel):

--- a/src/aleph/schemas/api/messages.py
+++ b/src/aleph/schemas/api/messages.py
@@ -1,5 +1,16 @@
 import datetime as dt
-from typing import Optional, Generic, TypeVar, Literal, List, Any, Union, Dict, Mapping
+from typing import (
+    Optional,
+    Generic,
+    TypeVar,
+    Literal,
+    List,
+    Any,
+    Union,
+    Dict,
+    Mapping,
+    Annotated,
+)
 
 from aleph_message.models import (
     AggregateContent,
@@ -12,7 +23,7 @@ from aleph_message.models import (
     InstanceContent,
 )
 from aleph_message.models import MessageType, ItemType
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.generics import GenericModel
 
 import aleph.toolkit.json as aleph_json
@@ -96,19 +107,22 @@ MESSAGE_CLS_DICT = {
 }
 
 
-AlephMessage = Union[
-    AggregateMessage,
-    ForgetMessage,
-    InstanceMessage,
-    PostMessage,
-    ProgramMessage,
-    StoreMessage,
+AlephMessage = Annotated[
+    Union[
+        AggregateMessage,
+        ForgetMessage,
+        InstanceMessage,
+        PostMessage,
+        ProgramMessage,
+        StoreMessage,
+    ],
+    Field(discriminator="type"),
 ]
 
 
-def format_message(message: Any) -> BaseMessage:
+def format_message(message: Any) -> AlephMessage:
     message_cls = MESSAGE_CLS_DICT[message.type]
-    return message_cls.from_orm(message)
+    return message_cls.from_orm(message)    # type: ignore[return-value]
 
 
 class BaseMessageStatus(BaseModel):
@@ -149,7 +163,7 @@ class ProcessedMessageStatus(BaseMessageStatus):
         orm_mode = True
 
     status: MessageStatus = MessageStatus.PROCESSED
-    message: BaseMessage
+    message: AlephMessage
 
 
 class ForgottenMessage(BaseModel):

--- a/src/aleph/types/message_processing_result.py
+++ b/src/aleph/types/message_processing_result.py
@@ -1,6 +1,7 @@
-from typing import Protocol
+from typing import Any, Dict, Protocol
 
 from aleph.db.models import PendingMessageDb, MessageDb
+from aleph.schemas.api.messages import format_message
 from aleph.types.message_status import (
     ErrorCode,
     MessageProcessingStatus,
@@ -12,6 +13,9 @@ class MessageProcessingResult(Protocol):
 
     @property
     def item_hash(self) -> str:
+        pass
+
+    def to_dict(self) -> Dict[str, Any]:
         pass
 
 
@@ -28,10 +32,11 @@ class ProcessedMessage(MessageProcessingResult):
     def item_hash(self) -> str:
         return self.message.item_hash
 
+    def to_dict(self) -> Dict[str, Any]:
+        return {"status": self.status.value, "message": format_message(self.message)}
+
 
 class FailedMessage(MessageProcessingResult):
-    status = MessageProcessingStatus.FAILED_WILL_RETRY
-
     def __init__(
         self, pending_message: PendingMessageDb, error_code: ErrorCode, will_retry: bool
     ):
@@ -47,6 +52,12 @@ class FailedMessage(MessageProcessingResult):
     @property
     def item_hash(self) -> str:
         return self.pending_message.item_hash
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "item_hash": self.item_hash,
+        }
 
 
 class WillRetryMessage(FailedMessage):

--- a/src/aleph/types/message_processing_result.py
+++ b/src/aleph/types/message_processing_result.py
@@ -33,7 +33,7 @@ class ProcessedMessage(MessageProcessingResult):
         return self.message.item_hash
 
     def to_dict(self) -> Dict[str, Any]:
-        return {"status": self.status.value, "message": format_message(self.message)}
+        return {"status": self.status.value, "message": format_message(self.message).dict()}
 
 
 class FailedMessage(MessageProcessingResult):

--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -27,7 +27,7 @@ from aleph.schemas.api.messages import (
     ForgottenMessage,
     RejectedMessageStatus,
     PendingMessage,
-    AlephMessage, BaseMessage,
+    AlephMessage,
 )
 from aleph.types.db_session import DbSessionFactory, DbSession
 from aleph.types.message_status import MessageStatus
@@ -252,7 +252,7 @@ async def _send_history_to_ws(
 
 
 def message_matches_filters(
-    message: BaseMessage, query_params: WsMessageQueryParams
+    message: AlephMessage, query_params: WsMessageQueryParams
 ) -> bool:
     if message_type := query_params.message_type:
         if message.type != message_type:

--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -27,7 +27,7 @@ from aleph.schemas.api.messages import (
     ForgottenMessage,
     RejectedMessageStatus,
     PendingMessage,
-    AlephMessage,
+    AlephMessage, BaseMessage,
 )
 from aleph.types.db_session import DbSessionFactory, DbSession
 from aleph.types.message_status import MessageStatus
@@ -252,7 +252,7 @@ async def _send_history_to_ws(
 
 
 def message_matches_filters(
-    message: AlephMessage, query_params: WsMessageQueryParams
+    message: BaseMessage, query_params: WsMessageQueryParams
 ) -> bool:
     if message_type := query_params.message_type:
         if message.type != message_type:

--- a/tests/api/test_get_message.py
+++ b/tests/api/test_get_message.py
@@ -175,7 +175,7 @@ async def test_get_processed_message_status(
         response = await ccn_api_client.get(
             MESSAGE_URI.format(processed_message.item_hash)
         )
-        assert response.status == 200
+        assert response.status == 200, await response.text()
         response_json = await response.json()
         parsed_response = ProcessedMessageStatus.parse_obj(response_json)
         assert parsed_response.status == MessageStatus.PROCESSED


### PR DESCRIPTION
Problem: the websocket uses the DB to apply filters to processed messages to determine whether they must be sent on the websocket. This leads to an exhaustion of DB connections when many websockets are open with the same filters.

Solution: send the full message on the RabbitMQ topic and apply filters in Python instead of using a DB query.