### PR TITLE
Fix: 500 error when submitting instance message

### DIFF
--- a/src/aleph/schemas/pending_messages.py
+++ b/src/aleph/schemas/pending_messages.py
@@ -22,6 +22,7 @@ from typing import Any, Literal, Generic
 from aleph_message.models import (
     AggregateContent,
     ForgetContent,
+    InstanceContent,
     PostContent,
     ProgramContent,
     StoreContent,
@@ -103,6 +104,12 @@ class PendingForgetMessage(
     pass
 
 
+class PendingInstanceMessage(
+    BasePendingMessage[Literal[MessageType.instance], InstanceContent]  # type: ignore
+):
+    pass
+
+
 class PendingPostMessage(BasePendingMessage[Literal[MessageType.post], PostContent]):  # type: ignore
     pass
 
@@ -120,6 +127,7 @@ class PendingStoreMessage(BasePendingMessage[Literal[MessageType.store], StoreCo
 MESSAGE_TYPE_TO_CLASS = {
     MessageType.aggregate: PendingAggregateMessage,
     MessageType.forget: PendingForgetMessage,
+    MessageType.instance: PendingInstanceMessage,
     MessageType.post: PendingPostMessage,
     MessageType.program: PendingProgramMessage,
     MessageType.store: PendingStoreMessage,

--- a/tests/message_processing/test_process_forgets.py
+++ b/tests/message_processing/test_process_forgets.py
@@ -36,13 +36,15 @@ from message_test_helpers import (
 
 @pytest.fixture
 def forget_handler(mocker) -> ForgetMessageHandler:
+    vm_handler = VmMessageHandler()
     content_handlers = {
         MessageType.aggregate: AggregateMessageHandler(),
+        MessageType.instance: vm_handler,
         MessageType.post: PostMessageHandler(
             balances_addresses=["nope"],
             balances_post_type="no-balances-in-tests",
         ),
-        MessageType.program: VmMessageHandler(),
+        MessageType.program: vm_handler,
         MessageType.store: StoreMessageHandler(storage_service=mocker.AsyncMock()),
     }
     return ForgetMessageHandler(content_handlers=content_handlers)


### PR DESCRIPTION
Problem: the instance message type was missing from a dictionary.
Solution: add it.