### PR TITLE
Feature: authenticated file upload

### DIFF
--- a/src/aleph/__init__.py
+++ b/src/aleph/__init__.py
@@ -3,11 +3,17 @@ import subprocess
 
 from pkg_resources import get_distribution, DistributionNotFound
 
+
+def _get_git_version() -> str:
+    output = subprocess.check_output(("git", "describe", "--tags"))
+    return output.decode().strip()
+
+
 try:
     # Change here if project is renamed and does not equal the package name
     dist_name = __name__
     __version__ = get_distribution(dist_name).version
 except DistributionNotFound:
-    __version__ = "1.4"
+    __version__ = _get_git_version()
 finally:
     del get_distribution, DistributionNotFound

--- a/src/aleph/__init__.py
+++ b/src/aleph/__init__.py
@@ -3,17 +3,11 @@ import subprocess
 
 from pkg_resources import get_distribution, DistributionNotFound
 
-
-def _get_git_version() -> str:
-    output = subprocess.check_output(("git", "describe", "--tags"))
-    return output.decode().strip()
-
-
 try:
     # Change here if project is renamed and does not equal the package name
     dist_name = __name__
     __version__ = get_distribution(dist_name).version
 except DistributionNotFound:
-    __version__ = _get_git_version()
+    __version__ = "1.4"
 finally:
     del get_distribution, DistributionNotFound

--- a/src/aleph/api_entrypoint.py
+++ b/src/aleph/api_entrypoint.py
@@ -74,7 +74,7 @@ async def configure_aiohttp_app(
         app[APP_STATE_NODE_CACHE] = node_cache
         app[APP_STATE_STORAGE_SERVICE] = storage_service
         app[APP_STATE_SESSION_FACTORY] = session_factory
-        # app[APP_STATE_CHAIN_SERVICE] = chain_service
+        app[APP_STATE_CHAIN_SERVICE] = chain_service
 
     return app
 

--- a/src/aleph/api_entrypoint.py
+++ b/src/aleph/api_entrypoint.py
@@ -6,6 +6,7 @@ from aiohttp import web
 from configmanager import Config
 
 import aleph.config
+from aleph.chains.chain_service import ChainService
 from aleph.db.connection import make_engine, make_session_factory
 from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
@@ -21,7 +22,10 @@ from aleph.web.controllers.app_state_getters import (
     APP_STATE_NODE_CACHE,
     APP_STATE_P2P_CLIENT,
     APP_STATE_SESSION_FACTORY,
-    APP_STATE_STORAGE_SERVICE, APP_STATE_MQ_CHANNEL, APP_STATE_MQ_WS_CHANNEL,
+    APP_STATE_STORAGE_SERVICE,
+    APP_STATE_MQ_CHANNEL,
+    APP_STATE_MQ_WS_CHANNEL,
+    APP_STATE_CHAIN_SERVICE,
 )
 
 
@@ -49,6 +53,9 @@ async def configure_aiohttp_app(
             ipfs_service=ipfs_service,
             node_cache=node_cache,
         )
+        chain_service = ChainService(
+            storage_service=storage_service, session_factory=session_factory
+        )
 
         app = create_aiohttp_app()
 
@@ -67,6 +74,7 @@ async def configure_aiohttp_app(
         app[APP_STATE_NODE_CACHE] = node_cache
         app[APP_STATE_STORAGE_SERVICE] = storage_service
         app[APP_STATE_SESSION_FACTORY] = session_factory
+        # app[APP_STATE_CHAIN_SERVICE] = chain_service
 
     return app
 

--- a/src/aleph/schemas/pending_messages.py
+++ b/src/aleph/schemas/pending_messages.py
@@ -124,6 +124,11 @@ class PendingStoreMessage(BasePendingMessage[Literal[MessageType.store], StoreCo
     pass
 
 
+class PendingInlineStoreMessage(PendingStoreMessage):
+    item_content: str
+    item_type: Literal[ItemType.inline]
+
+
 MESSAGE_TYPE_TO_CLASS = {
     MessageType.aggregate: PendingAggregateMessage,
     MessageType.forget: PendingForgetMessage,

--- a/src/aleph/schemas/pending_messages.py
+++ b/src/aleph/schemas/pending_messages.py
@@ -126,7 +126,7 @@ class PendingStoreMessage(BasePendingMessage[Literal[MessageType.store], StoreCo
 
 class PendingInlineStoreMessage(PendingStoreMessage):
     item_content: str
-    item_type: Literal[ItemType.inline]
+    item_type: Literal[ItemType.inline]     # type: ignore[valid-type]
 
 
 MESSAGE_TYPE_TO_CLASS = {

--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -22,7 +22,9 @@ from aleph.services.storage.engine import StorageEngine
 from aleph.types.db_session import DbSession
 from aleph.types.files import FileType
 from aleph.utils import get_sha256
-
+from aleph.schemas.pending_messages import (
+    parse_message,
+)
 LOGGER = logging.getLogger(__name__)
 
 
@@ -271,7 +273,6 @@ class StorageService:
         elif engine == ItemType.storage:
             file_content = fileobject.read()
             file_hash = sha256(file_content).hexdigest()
-
         else:
             raise ValueError(f"Unsupported item type: {engine}")
 

--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -273,6 +273,7 @@ class StorageService:
         elif engine == ItemType.storage:
             file_content = fileobject.read()
             file_hash = sha256(file_content).hexdigest()
+            fileobject.seek(0)
         else:
             raise ValueError(f"Unsupported item type: {engine}")
 

--- a/src/aleph/web/controllers/app_state_getters.py
+++ b/src/aleph/web/controllers/app_state_getters.py
@@ -11,6 +11,7 @@ from aiohttp import web
 from aleph_p2p_client import AlephP2PServiceClient
 from configmanager import Config
 
+from aleph.chains.chain_service import ChainService
 from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
 from aleph.storage import StorageService
@@ -27,7 +28,7 @@ APP_STATE_NODE_CACHE = "node_cache"
 APP_STATE_P2P_CLIENT = "p2p_client"
 APP_STATE_SESSION_FACTORY = "session_factory"
 APP_STATE_STORAGE_SERVICE = "storage_service"
-
+APP_STATE_CHAIN_SERVICE = "chain_service"
 
 T = TypeVar("T")
 
@@ -103,3 +104,7 @@ def get_session_factory_from_request(request: web.Request) -> DbSessionFactory:
 
 def get_storage_service_from_request(request: web.Request) -> StorageService:
     return cast(StorageService, request.app[APP_STATE_STORAGE_SERVICE])
+
+
+def get_chain_service_from_request(request: web.Request) -> ChainService:
+    return cast(ChainService, request.app[APP_STATE_CHAIN_SERVICE])

--- a/src/aleph/web/controllers/ipfs.py
+++ b/src/aleph/web/controllers/ipfs.py
@@ -8,7 +8,7 @@ from aleph.web.controllers.app_state_getters import (
     get_ipfs_service_from_request,
     get_session_factory_from_request,
 )
-from aleph.web.controllers.utils import multidict_proxy_to_io
+from aleph.web.controllers.utils import file_field_to_io
 
 
 async def ipfs_add_file(request: web.Request):
@@ -20,7 +20,12 @@ async def ipfs_add_file(request: web.Request):
 
     # No need to pin it here anymore.
     post = await request.post()
-    ipfs_add_response = await ipfs_service.add_file(multidict_proxy_to_io(post))
+    try:
+        file_field = post["file"]
+    except KeyError:
+        raise web.HTTPUnprocessableEntity(reason="Missing 'file' in multipart form.")
+
+    ipfs_add_response = await ipfs_service.add_file(file_field_to_io(file_field))
 
     cid = ipfs_add_response["Hash"]
     name = ipfs_add_response["Name"]

--- a/src/aleph/web/controllers/p2p.py
+++ b/src/aleph/web/controllers/p2p.py
@@ -1,53 +1,30 @@
 import asyncio
 import json
 import logging
-from typing import Dict, cast, Optional, Any, Mapping, List, Union
+from typing import Dict, cast, Optional, Any, List, Union
 
-import aio_pika.abc
 from aiohttp import web
 from aleph_p2p_client import AlephP2PServiceClient
 from configmanager import Config
 from pydantic import BaseModel, Field, ValidationError
 
-import aleph.toolkit.json as aleph_json
-from aleph.schemas.pending_messages import parse_message, BasePendingMessage
 from aleph.services.ipfs import IpfsService
 from aleph.services.p2p.pubsub import publish as pub_p2p
 from aleph.toolkit.shield import shielded
-from aleph.types.message_status import (
-    InvalidMessageException,
-    MessageStatus,
-    MessageProcessingStatus,
-)
 from aleph.types.protocol import Protocol
 from aleph.web.controllers.app_state_getters import (
     get_config_from_request,
     get_ipfs_service_from_request,
     get_p2p_client_from_request,
-    get_mq_channel_from_request,
 )
 from aleph.web.controllers.utils import (
-    mq_make_aleph_message_topic_queue,
-    processing_status_to_http_status,
-    mq_read_one_message,
     validate_message_dict,
+    broadcast_and_process_message,
+    PublicationStatus,
+    broadcast_status_to_http_status,
 )
 
 LOGGER = logging.getLogger(__name__)
-
-
-class PublicationStatus(BaseModel):
-    status: str
-    failed: List[Protocol]
-
-    @classmethod
-    def from_failures(cls, failed_publications: List[Protocol]):
-        status = {
-            0: "success",
-            1: "warning",
-            2: "error",
-        }[len(failed_publications)]
-        return cls(status=status, failed=failed_publications)
 
 
 def _validate_request_data(config: Config, request_data: Dict) -> None:
@@ -145,11 +122,6 @@ class PubMessageRequest(BaseModel):
     message_dict: Dict[str, Any] = Field(alias="message")
 
 
-class PubMessageResponse(BaseModel):
-    publication_status: PublicationStatus
-    message_status: Optional[MessageStatus]
-
-
 @shielded
 async def pub_message(request: web.Request):
     try:
@@ -161,75 +133,13 @@ async def pub_message(request: web.Request):
         raise web.HTTPUnprocessableEntity()
 
     pending_message = validate_message_dict(request_data.message_dict)
-
-    # In sync mode, wait for a message processing event. We need to create the queue
-    # before publishing the message on P2P topics in order to guarantee that the event
-    # will be picked up.
-    config = get_config_from_request(request)
-
-    if request_data.sync:
-        mq_channel = await get_mq_channel_from_request(request=request, logger=LOGGER)
-        mq_queue = await mq_make_aleph_message_topic_queue(
-            channel=mq_channel,
-            config=config,
-            routing_key=f"*.{pending_message.item_hash}",
-        )
-    else:
-        mq_queue = None
-
-    # We publish the message on P2P topics early, for 3 reasons:
-    # 1. Just because this node is unable to process the message does not
-    #    necessarily mean the message is incorrect (ex: bug in a new version).
-    # 2. If the publication fails after the processing, we end up in a situation where
-    #    a message exists without being propagated to the other nodes, ultimately
-    #    causing sync issues on the network.
-    # 3. The message is currently fed to this node using the P2P service client
-    #    loopback mechanism.
-    ipfs_service = get_ipfs_service_from_request(request)
-    p2p_client = get_p2p_client_from_request(request)
-
-    message_topic = config.aleph.queue_topic.value
-    failed_publications = await _pub_on_p2p_topics(
-        p2p_client=p2p_client,
-        ipfs_service=ipfs_service,
-        topic=message_topic,
-        payload=aleph_json.dumps(request_data.message_dict),
-    )
-    pub_status = PublicationStatus.from_failures(failed_publications)
-    if pub_status.status == "error":
-        return web.json_response(
-            text=PubMessageResponse(
-                publication_status=pub_status, message_status=None
-            ).json(),
-            status=500,
-        )
-
-    status = PubMessageResponse(
-        publication_status=pub_status, message_status=MessageStatus.PENDING
+    broadcast_status = await broadcast_and_process_message(
+        pending_message=pending_message,
+        message_dict=request_data.message_dict,
+        sync=request_data.sync,
+        request=request,
+        logger=LOGGER,
     )
 
-    # When publishing in async mode, just respond with 202 (Accepted).
-    message_accepted_response = web.json_response(text=status.json(), status=202)
-    if not request_data.sync:
-        return message_accepted_response
-
-    # Ignore type checking here, we know that mq_queue is set at this point
-    assert mq_queue is not None
-    response = await mq_read_one_message(mq_queue, timeout=30)
-
-    # Delete the queue immediately
-    await mq_queue.delete(if_empty=False)
-
-    # If the message was not processed before the timeout, return a 202.
-    if response is None:
-        return message_accepted_response
-
-    routing_key = response.routing_key
-    assert routing_key is not None  # again, for type checking
-    status_str, _item_hash = routing_key.split(".")
-    processing_status = MessageProcessingStatus(status_str)
-    status_code = processing_status_to_http_status(processing_status)
-
-    status.message_status = processing_status.to_message_status()
-
-    return web.json_response(text=status.json(), status=status_code)
+    status_code = broadcast_status_to_http_status(broadcast_status)
+    return web.json_response(text=broadcast_status.json(), status=status_code)

--- a/src/aleph/web/controllers/p2p.py
+++ b/src/aleph/web/controllers/p2p.py
@@ -26,8 +26,12 @@ from aleph.web.controllers.app_state_getters import (
     get_p2p_client_from_request,
     get_mq_channel_from_request,
 )
-from aleph.web.controllers.utils import mq_make_aleph_message_topic_queue, processing_status_to_http_status, \
-    mq_read_one_message, validate_message_dict
+from aleph.web.controllers.utils import (
+    mq_make_aleph_message_topic_queue,
+    processing_status_to_http_status,
+    mq_read_one_message,
+    validate_message_dict,
+)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -170,7 +170,7 @@ async def storage_add_file_with_message(
 
     session.add(pending_message_db)
     session.commit()
-    if storage_metadata.sync and mq_queue:
+    if mq_queue:
         mq_message = await mq_read_one_message(mq_queue, 30)
 
         if mq_message is None:

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -112,7 +112,7 @@ async def _verify_user_balance(
         session=session, address=pending_message_db.sender
     )
     if current_balance < (Decimal(required_balance) + current_cost_for_user):
-        raise web.HTTPPaymentRequired
+        raise web.HTTPPaymentRequired()
 
 
 async def _verify_user_file(message: PendingStoreMessage, size: int, file_io) -> None:

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -116,7 +116,6 @@ async def _verify_user_balance(
 
 
 async def _verify_user_file(message: PendingStoreMessage, size: int, file_io) -> None:
-    file_io.seek(0)
     content = file_io.read(size)
     item_content = {}
     if message.item_content:
@@ -204,7 +203,6 @@ async def storage_add_file(request: web.Request):
     except Exception as e:
         if metadata:
             raise web.HTTPUnprocessableEntity()
-
     if metadata is None:
         if len(file_io.read()) > (25 * MiB):
             raise web.HTTPUnauthorized()

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -123,15 +123,6 @@ async def get_message_content(
     return message_dict, int(str(value))
 
 
-async def init_mq_con(config):
-    return await aio_pika.connect_robust(
-        host=config.p2p.mq_host.value,
-        port=config.rabbitmq.port.value,
-        login=config.rabbitmq.username.value,
-        password=config.rabbitmq.password.value,
-    )
-
-
 async def verify_and_handle_request(
     pending_message_db, file_io, message, size, session_factory
 ):

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -206,8 +206,9 @@ async def storage_add_file(request: web.Request):
     else:
         # User did not provide a message
         try:
-            content_length_str = post["file"].headers["Content-Length"]
-            file_size = int(content_length_str)
+            if isinstance(post["file"], FileField):
+                content_length_str = post["file"].headers["Content-Length"]
+                file_size = int(content_length_str)
         except (KeyError, ValueError) as e:
             raise web.HTTPBadRequest(reason="Missing Content-Length header") from e
 

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -111,7 +111,7 @@ async def _verify_user_balance(
     current_cost_for_user = get_total_cost_for_address(
         session=session, address=pending_message_db.sender
     )
-    if current_balance < (Decimal(required_balance) + current_cost_for_user):
+    if current_balance < (Decimal(required_balance) + current_cost_for_user) and size > 25 * MiB:
         raise web.HTTPPaymentRequired()
 
 

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -29,13 +29,10 @@ from aleph.web.controllers.app_state_getters import (
     get_config_from_request,
     get_mq_channel_from_request,
 )
-from aleph.web.controllers.p2p import (
-    _mq_read_one_message,
-    _processing_status_to_http_status,
-)
+
 from aleph.web.controllers.utils import (
     multidict_proxy_to_io,
-    mq_make_aleph_message_topic_queue,
+    mq_make_aleph_message_topic_queue, processing_status_to_http_status, mq_read_one_message,
 )
 from aleph.schemas.pending_messages import BasePendingMessage
 
@@ -182,7 +179,7 @@ async def storage_add_file_with_message(request: web.Request):
         )
         session.add(pending_message_db)
         session.commit()
-    mq_message = await _mq_read_one_message(mq_queue, 30)
+    mq_message = await mq_read_one_message(mq_queue, 30)
 
     if mq_message is None:
         output = {"status": "accepted"}
@@ -190,7 +187,7 @@ async def storage_add_file_with_message(request: web.Request):
     if mq_message.routing_key is not None:
         status_str, _item_hash = mq_message.routing_key.split(".")
         processing_status = MessageProcessingStatus(status_str)
-        status_code = _processing_status_to_http_status(processing_status)
+        status_code = processing_status_to_http_status(processing_status)
         return web.json_response(status=status_code, text=file_hash)
 
 

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -111,8 +111,9 @@ async def _verify_user_balance(
     current_cost_for_user = get_total_cost_for_address(
         session=session, address=pending_message_db.sender
     )
-    if current_balance < (Decimal(required_balance) + current_cost_for_user) and size > 25 * MiB:
-        raise web.HTTPPaymentRequired()
+    if size > 25 * MiB:
+        if current_balance < (Decimal(required_balance) + current_cost_for_user):
+            raise web.HTTPPaymentRequired()
 
 
 async def _verify_user_file(message: PendingStoreMessage, size: int, file_io) -> None:

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -215,6 +215,7 @@ async def storage_add_file(request: web.Request):
         file_hash = await storage_service.add_file(
             session=session, fileobject=file_io, engine=ItemType.storage
         )
+        session.commit()
     output = {"status": "success", "hash": file_hash}
     return web.json_response(output)
 

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -22,6 +22,7 @@ from aiohttp.web_request import FileField
 from aleph_message.models import ItemType
 from multidict import MultiDictProxy
 from aleph.db.accessors.balances import get_total_balance
+from aleph.db.accessors.cost import get_total_cost_for_address
 from aleph.db.accessors.files import count_file_pins, get_file
 from aleph.db.models import PendingMessageDb
 from aleph.exceptions import AlephStorageException, UnknownHashError
@@ -107,11 +108,10 @@ async def _verify_user_balance(
         session=session, address=pending_message_db.sender
     ) or Decimal(0)
     required_balance = (size / MiB) / 3
-    # Need to merge to get this functions
-    # current_cost_for_user = get_total_cost_for_address(
-    #    session=session, address=pending_message_db.sender
-    # )
-    if current_balance < Decimal(required_balance):
+    current_cost_for_user = get_total_cost_for_address(
+        session=session, address=pending_message_db.sender
+    )
+    if current_balance < (Decimal(required_balance) + current_cost_for_user):
         raise web.HTTPPaymentRequired
 
 

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -8,6 +8,7 @@ from typing import Union, Tuple
 import aio_pika
 from eth_account import Account
 from eth_account.messages import encode_defunct
+from mypy.dmypy_server import MiB
 
 from aleph.chains.chain_service import ChainService
 from aleph.chains.common import get_verification_buffer
@@ -126,7 +127,7 @@ async def verify_and_handle_request(
     elif actual_item_hash != c_item_hash:
         output = {"status": "Unprocessable Content"}
         return web.json_response(output, status=422)
-    elif len(content) > 25_000 and not message:
+    elif len(content) > 25 * MiB and not message:
         output = {"status": "Unauthorized"}
         return web.json_response(output, status=401)
     else:

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -187,8 +187,9 @@ async def storage_add_file(request: web.Request):
     post = await request.post()
     sync = False
 
-    if post.get("message", b"") is None:
+    if post.get("message", b"") is None and len(file_io.read()) > (25 * MiB):
         raise web.HTTPUnauthorized()
+    file_io.seek(0)
 
     sync_value = post.get("sync")
     if sync_value is not None:

--- a/src/aleph/web/controllers/utils.py
+++ b/src/aleph/web/controllers/utils.py
@@ -157,10 +157,11 @@ async def mq_make_aleph_message_topic_queue(
         auto_delete=False,
     )
     mq_queue = await channel.declare_queue(
-        auto_delete=True, exclusive=True,
+        auto_delete=True,
+        exclusive=True,
         # Auto-delete the queue after 30 seconds. This guarantees that queues are deleted even
         # if a bug makes the consumer crash before cleanup.
-        arguments={"x-expires": 30000}
+        arguments={"x-expires": 30000},
     )
     await mq_queue.bind(mq_message_exchange, routing_key=routing_key)
     return mq_queue
@@ -203,3 +204,4 @@ def validate_message_dict(message_dict: Mapping[str, Any]) -> BasePendingMessage
         return parse_message(message_dict)
     except InvalidMessageException as e:
         raise web.HTTPUnprocessableEntity(body=str(e))
+

--- a/src/aleph/web/controllers/utils.py
+++ b/src/aleph/web/controllers/utils.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from io import BytesIO, StringIO
 from math import ceil
-from typing import Optional, Union, IO, Mapping, Any
+from typing import Optional, Union, IO, Mapping, Any, overload
 
 import aio_pika
 import aiohttp_jinja2
@@ -19,9 +19,22 @@ DEFAULT_PAGE = 1
 LIST_FIELD_SEPARATOR = ","
 
 
-def multidict_proxy_to_io(
-    multi_dict: MultiDictProxy[Union[str, bytes, FileField]]
-) -> IO:
+@overload
+def multidict_proxy_to_io(multi_dict: MultiDictProxy[bytes]) -> BytesIO:
+    ...
+
+
+@overload
+def multidict_proxy_to_io(multi_dict: MultiDictProxy[str]) -> StringIO:
+    ...
+
+
+@overload
+def multidict_proxy_to_io(multi_dict: MultiDictProxy[FileField]) -> IO:
+    ...
+
+
+def multidict_proxy_to_io(multi_dict):
     file_field = multi_dict["file"]
     if isinstance(file_field, bytes):
         return BytesIO(file_field)
@@ -204,4 +217,3 @@ def validate_message_dict(message_dict: Mapping[str, Any]) -> BasePendingMessage
         return parse_message(message_dict)
     except InvalidMessageException as e:
         raise web.HTTPUnprocessableEntity(body=str(e))
-

--- a/src/aleph/web/controllers/utils.py
+++ b/src/aleph/web/controllers/utils.py
@@ -20,22 +20,21 @@ LIST_FIELD_SEPARATOR = ","
 
 
 @overload
-def multidict_proxy_to_io(multi_dict: MultiDictProxy[bytes]) -> BytesIO:
+def file_field_to_io(multi_dict: bytes) -> BytesIO:
     ...
 
 
 @overload
-def multidict_proxy_to_io(multi_dict: MultiDictProxy[str]) -> StringIO:
+def file_field_to_io(multi_dict: str) -> StringIO:
     ...
 
 
 @overload
-def multidict_proxy_to_io(multi_dict: MultiDictProxy[FileField]) -> IO:
+def file_field_to_io(multi_dict: FileField) -> BytesIO:
     ...
 
 
-def multidict_proxy_to_io(multi_dict):
-    file_field = multi_dict["file"]
+def file_field_to_io(file_field):
     if isinstance(file_field, bytes):
         return BytesIO(file_field)
     elif isinstance(file_field, str):

--- a/src/aleph/web/controllers/utils.py
+++ b/src/aleph/web/controllers/utils.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 from io import BytesIO, StringIO
 from math import ceil
-from typing import Optional, Union, IO
+from typing import Optional, Union, IO, Mapping, Any
 
 import aio_pika
 import aiohttp_jinja2
@@ -11,7 +11,8 @@ from aiohttp.web_request import FileField
 from configmanager import Config
 from multidict import MultiDictProxy
 
-from aleph.types.message_status import MessageProcessingStatus
+from aleph.schemas.pending_messages import BasePendingMessage, parse_message
+from aleph.types.message_status import MessageProcessingStatus, InvalidMessageException
 
 DEFAULT_MESSAGES_PER_PAGE = 20
 DEFAULT_PAGE = 1
@@ -195,3 +196,10 @@ async def mq_read_one_message(
         return None
     finally:
         await mq_queue.cancel(consumer_tag)
+
+
+def validate_message_dict(message_dict: Mapping[str, Any]) -> BasePendingMessage:
+    try:
+        return parse_message(message_dict)
+    except InvalidMessageException as e:
+        raise web.HTTPUnprocessableEntity(body=str(e))

--- a/tests/api/test_p2p.py
+++ b/tests/api/test_p2p.py
@@ -69,16 +69,16 @@ async def test_pubsub_pub_errors(ccn_api_client, mock_config: Config):
 @pytest.mark.asyncio
 async def test_post_message_sync(ccn_api_client, mocker):
     # Mock the functions used to create the RabbitMQ queue
-    mocker.patch("aleph.web.controllers.p2p.get_mq_channel_from_request")
+    mocker.patch("aleph.web.controllers.utils.get_mq_channel_from_request")
     mocked_queue = mocker.patch(
-        "aleph.web.controllers.p2p.mq_make_aleph_message_topic_queue"
+        "aleph.web.controllers.utils.mq_make_aleph_message_topic_queue"
     )
 
     # Create a mock MQ response object
     mock_mq_message = mocker.Mock()
     mock_mq_message.routing_key = f"processed.{MESSAGE_DICT['item_hash']}"
     mocker.patch(
-        "aleph.web.controllers.p2p._mq_read_one_message", return_value=mock_mq_message
+        "aleph.web.controllers.utils.mq_read_one_message", return_value=mock_mq_message
     )
 
     response = await ccn_api_client.post(

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -1,7 +1,7 @@
 import base64
 import json
 from decimal import Decimal
-from typing import Any
+from typing import Any, Optional
 
 import aiohttp
 import orjson
@@ -167,7 +167,6 @@ async def add_file_with_message(
         "file_size": int(size),
         "sync": True,
     }
-    print(data)
     form_data.add_field("metadata", json.dumps(data), content_type="application/json")
 
     response = await api_client.post(uri, data=form_data)

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -10,6 +10,7 @@ import pytest
 from aleph_message.models import ItemHash, MessageType, Chain, ItemType
 from configmanager import Config
 
+from aleph.chains.chain_service import ChainService
 from aleph.handlers.message_handler import MessageHandler
 from aleph.schemas.pending_messages import (
     parse_message,
@@ -147,6 +148,7 @@ async def add_file_with_message(
     mocked_queue = mocker.patch(
         "aleph.web.controllers.storage.mq_make_aleph_message_topic_queue"
     )
+    mocker.patch("aleph.web.controllers.storage.get_chain_service_from_request")
 
     # Create a mock MQ response object
     mock_mq_message = mocker.Mock()
@@ -191,13 +193,12 @@ async def add_file_with_message_202(
     mocked_queue = mocker.patch(
         "aleph.web.controllers.storage.mq_make_aleph_message_topic_queue"
     )
+    mocker.patch("aleph.web.controllers.storage.get_chain_service_from_request")
 
     # Create a mock MQ response object
     mock_mq_message = mocker.Mock()
     mock_mq_message.routing_key = f"processed.{MESSAGE_DICT['item_hash']}"
-    mocker.patch(
-        "aleph.web.controllers.storage.mq_read_one_message", return_value=None
-    )
+    mocker.patch("aleph.web.controllers.storage.mq_read_one_message", return_value=None)
 
     with session_factory() as session:
         session.add(

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -98,6 +98,11 @@ def api_client(ccn_api_client, mocker):
         node_cache=mocker.AsyncMock(),
     )
 
+    ccn_api_client.app["chain_service"] = ChainService(
+        session_factory=ccn_api_client.app["session_factory"],
+        storage_service=ccn_api_client.app["storage_service"],
+    )
+
     return ccn_api_client
 
 
@@ -148,7 +153,6 @@ async def add_file_with_message(
     mocked_queue = mocker.patch(
         "aleph.web.controllers.storage.mq_make_aleph_message_topic_queue"
     )
-    mocker.patch("aleph.web.controllers.storage.get_chain_service_from_request")
 
     # Create a mock MQ response object
     mock_mq_message = mocker.Mock()
@@ -197,8 +201,6 @@ async def add_file_with_message_202(
     mocked_queue = mocker.patch(
         "aleph.web.controllers.storage.mq_make_aleph_message_topic_queue"
     )
-    mocker.patch("aleph.web.controllers.storage.get_chain_service_from_request")
-
     # Create a mock MQ response object
     mock_mq_message = mocker.Mock()
     mock_mq_message.routing_key = f"processed.{MESSAGE_DICT['item_hash']}"
@@ -222,7 +224,7 @@ async def add_file_with_message_202(
     data = {
         "message": MESSAGE_DICT,
         "file_size": int(size),
-        "sync": False,
+        "sync": True,
     }
     form_data.add_field("metadata", json.dumps(data), content_type="application/json")
     response = await api_client.post(uri, data=form_data)

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -56,13 +56,13 @@ MESSAGE_DICT = {
     "type": "STORE",
     "channel": "null",
     "signature": "0x2b90dcfa8f93506150df275a4fe670e826be0b4b751badd6ec323648a6a738962f47274f71a9939653fb6d49c25055821f547447fb3b33984a579008d93eca431b",
-    "time": "1692193373.7144432",
+    "time": 1692193373.7144432,
     "item_type": "inline",
     "item_content": '{"address":"0x6dA130FD646f826C1b8080C07448923DF9a79aaA","time":1692193373.714271,"item_type":"storage","item_hash":"0214e5578f5acb5d36ea62255cbf1157a4bdde7b9612b5db4899b2175e310b6f","mime_type":"text/plain"}',
     "item_hash": "8227acbc2f7c43899efd9f63ea9d8119a4cb142f3ba2db5fe499ccfab86dfaed",
     "content": {
         "address": "0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
-        "time": "1692193373.714271",
+        "time": 1692193373.714271,
         "item_type": "storage",
         "item_hash": "0214e5578f5acb5d36ea62255cbf1157a4bdde7b9612b5db4899b2175e310b6f",
         "mime_type": "text/plain",
@@ -169,12 +169,15 @@ async def add_file_with_message(
         )
         session.commit()
 
-    json_data = json.dumps(MESSAGE_DICT)
     form_data = aiohttp.FormData()
 
     form_data.add_field("file", file_content)
-    form_data.add_field("message", json_data, content_type="application/json")
-    form_data.add_field("file_size", size)
+    data = {
+        "message": MESSAGE_DICT,
+        "file_size": int(size),
+        "sync": True,
+    }
+    form_data.add_field("metadata", json.dumps(data), content_type="application/json")
 
     response = await api_client.post(uri, data=form_data)
     assert response.status == error_code, await response.text()
@@ -212,13 +215,16 @@ async def add_file_with_message_202(
         )
         session.commit()
 
-    json_data = json.dumps(MESSAGE_DICT)
     form_data = aiohttp.FormData()
 
     form_data.add_field("file", file_content)
-    form_data.add_field("message", json_data, content_type="application/json")
-    form_data.add_field("file_size", size)
-    form_data.add_field("sync", "True")
+
+    data = {
+        "message": MESSAGE_DICT,
+        "file_size": int(size),
+        "sync": False,
+    }
+    form_data.add_field("metadata", json.dumps(data), content_type="application/json")
     response = await api_client.post(uri, data=form_data)
     assert response.status == error_code, await response.text()
 

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -249,7 +249,7 @@ async def test_storage_add_file(api_client, session_factory: DbSessionFactory):
             b"Hello Aleph.im\n",
             "0214e5578f5acb5d36ea62255cbf1157a4bdde7b9612b5db4899b2175e310b6f",
             "15",
-            "402",
+            "200",
             "0",
         ),
         (

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -174,7 +174,8 @@ async def add_file_with_message(
 
     form_data.add_field("file", file_content)
     form_data.add_field("message", json_data, content_type="application/json")
-    form_data.add_field("size", size)
+    form_data.add_field("file_size", size)
+
     response = await api_client.post(uri, data=form_data)
     assert response.status == error_code, await response.text()
 
@@ -216,7 +217,8 @@ async def add_file_with_message_202(
 
     form_data.add_field("file", file_content)
     form_data.add_field("message", json_data, content_type="application/json")
-    form_data.add_field("size", size)
+    form_data.add_field("file_size", size)
+    form_data.add_field("sync", "True")
     response = await api_client.post(uri, data=form_data)
     assert response.status == error_code, await response.text()
 

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -181,6 +181,7 @@ async def add_file_with_message(
         "file_size": int(size),
         "sync": True,
     }
+    print(data)
     form_data.add_field("metadata", json.dumps(data), content_type="application/json")
 
     response = await api_client.post(uri, data=form_data)

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -118,20 +118,7 @@ async def add_file_with_message(
         file_content: bytes,
         expected_file_hash: str,
 ):
-
     data = {
-        "item_hash": "bb6e53f2738e5934b9a2125a9dc3d76211720e5152bdbcd4b236363d18d4f8a3",
-        "type": "STORE",
-        "chain": "ETH",
-        "sender": "0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106",
-        "item_content":'{"address": "0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106", "time": 1665478676.6585264, "item_type": "storage", "item_hash": "2086c8b69830df060f49bdf03a89e508688db7f5e5387bb875a6a0ed2d7a1d63", "mime_type": "text/plain"}',
-        "signature": "0xb9d164e6e43a8fcd341abc01eda47bed0333eaf480e888f2ed2ae0017048939d18850a33352e7281645e95e8673bad733499b6a8ce4069b9da9b9a79ddc1a0b31b",
-        "item_type": ItemType.storage,
-        "time": str(1616021679.055),
-        "channel": "TEST",
-        "trusted": "True",
-    }
-    test = {
         "chain": "ETH",
         "sender": "0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
         "type": "STORE",
@@ -149,35 +136,16 @@ async def add_file_with_message(
             "mime_type": "text/plain"
         },
     }
-    data["time"] = str(data["time"])
 
-    json_data = json.dumps(test)
+    json_data = json.dumps(data)
     form_data = aiohttp.FormData()
-    actual_item_hash = sha256(file_content).hexdigest()
+
     form_data.add_field("file", file_content)
     form_data.add_field("message", json_data, content_type='application/json')
     form_data.add_field("size", str(len(file_content)))
     post_response = await api_client.post(uri, data=form_data)
     assert post_response.status == 200, await post_response.text()
     #post_response_json = await post_response.json()
-    # data["time"] = 1644409598.782
-    # pending_message = PendingMessageDb.from_message_dict(
-    #    data, fetched=True, reception_time=dt.datetime(2022, 1, 1)
-
-def test_storage_add_file_with_message_only_parse():
-    message_dict = {
-        "chain": "ETH",
-        "item_hash": "30cc40533aa3ccf16a7c7c8a40da5633f64a83e4b89dcc7815f3a0af2149e1ac",
-        "sender": "0x7332eA1229c11C627C10eB24c1A6F77BceD1D5c1",
-        "type": "STORE",
-        "channel": "EVIDENZ",
-        "item_content": None,
-        "item_type": "storage",
-        "signature": "23d1d099dd111ae3251efea537f57767cf43b2ae3611bf9051760e0a9bc2bd4429563a130e3e391668086d101f8a197f55377f50b15d4c0303ff957d90a258a31b",
-        "time": 1616021679.055,
-    }
-
-    message = parse_message(message_dict)
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -1,16 +1,31 @@
 import base64
+import datetime
+import json
+from hashlib import sha256
 from typing import Any
 
 import aiohttp
 import orjson
 import pytest
-from aleph_message.models import ItemHash
+from aleph_message.models import ItemHash, MessageType, Chain, ItemType
+from configmanager import Config
+
+from aleph.handlers.message_handler import MessageHandler
+from aleph.schemas.pending_messages import (
+    parse_message,
+)
+from decimal import Decimal
 
 from aleph.db.accessors.files import get_file
+from aleph.db.models import PendingMessageDb, AlephBalanceDb
+from aleph.schemas.pending_messages import BasePendingMessage, PendingStoreMessage
 from aleph.storage import StorageService
+from aleph.toolkit.timestamp import timestamp_to_datetime
+from aleph.types.channel import Channel
 from aleph.types.db_session import DbSessionFactory
 from aleph.types.files import FileType
 from in_memory_storage_engine import InMemoryStorageEngine
+import datetime as dt
 
 IPFS_ADD_FILE_URI = "/api/v0/ipfs/add_file"
 IPFS_ADD_JSON_URI = "/api/v0/ipfs/add_json"
@@ -63,11 +78,11 @@ def api_client(ccn_api_client, mocker):
 
 
 async def add_file(
-    api_client,
-    session_factory: DbSessionFactory,
-    uri: str,
-    file_content: bytes,
-    expected_file_hash: str,
+        api_client,
+        session_factory: DbSessionFactory,
+        uri: str,
+        file_content: bytes,
+        expected_file_hash: str,
 ):
     form_data = aiohttp.FormData()
     form_data.add_field("file", file_content)
@@ -95,14 +110,96 @@ async def add_file(
     assert response_data == file_content
 
 
+
+async def add_file_with_message(
+        api_client,
+        session_factory: DbSessionFactory,
+        uri: str,
+        file_content: bytes,
+        expected_file_hash: str,
+):
+
+    data = {
+        "item_hash": "bb6e53f2738e5934b9a2125a9dc3d76211720e5152bdbcd4b236363d18d4f8a3",
+        "type": "STORE",
+        "chain": "ETH",
+        "sender": "0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106",
+        "item_content":'{"address": "0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106", "time": 1665478676.6585264, "item_type": "storage", "item_hash": "2086c8b69830df060f49bdf03a89e508688db7f5e5387bb875a6a0ed2d7a1d63", "mime_type": "text/plain"}',
+        "signature": "0xb9d164e6e43a8fcd341abc01eda47bed0333eaf480e888f2ed2ae0017048939d18850a33352e7281645e95e8673bad733499b6a8ce4069b9da9b9a79ddc1a0b31b",
+        "item_type": ItemType.storage,
+        "time": str(1616021679.055),
+        "channel": "TEST",
+        "trusted": "True",
+    }
+    test = {
+        "chain": "ETH",
+        "sender": "0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+        "type": "STORE",
+        "channel": "null",
+        "signature": "0x2b90dcfa8f93506150df275a4fe670e826be0b4b751badd6ec323648a6a738962f47274f71a9939653fb6d49c25055821f547447fb3b33984a579008d93eca431b",
+        "time": "1692193373.7144432",
+        "item_type": "inline",
+        "item_content": "{\"address\":\"0x6dA130FD646f826C1b8080C07448923DF9a79aaA\",\"time\":1692193373.714271,\"item_type\":\"storage\",\"item_hash\":\"0214e5578f5acb5d36ea62255cbf1157a4bdde7b9612b5db4899b2175e310b6f\",\"mime_type\":\"text/plain\"}",
+        "item_hash": "8227acbc2f7c43899efd9f63ea9d8119a4cb142f3ba2db5fe499ccfab86dfaed",
+        "content": {
+            "address": "0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+            "time": "1692193373.714271",
+            "item_type": "storage",
+            "item_hash": "0214e5578f5acb5d36ea62255cbf1157a4bdde7b9612b5db4899b2175e310b6f",
+            "mime_type": "text/plain"
+        },
+    }
+    data["time"] = str(data["time"])
+
+    json_data = json.dumps(test)
+    form_data = aiohttp.FormData()
+    actual_item_hash = sha256(file_content).hexdigest()
+    form_data.add_field("file", file_content)
+    form_data.add_field("message", json_data, content_type='application/json')
+    form_data.add_field("size", str(len(file_content)))
+    post_response = await api_client.post(uri, data=form_data)
+    assert post_response.status == 200, await post_response.text()
+    #post_response_json = await post_response.json()
+    # data["time"] = 1644409598.782
+    # pending_message = PendingMessageDb.from_message_dict(
+    #    data, fetched=True, reception_time=dt.datetime(2022, 1, 1)
+
+def test_storage_add_file_with_message_only_parse():
+    message_dict = {
+        "chain": "ETH",
+        "item_hash": "30cc40533aa3ccf16a7c7c8a40da5633f64a83e4b89dcc7815f3a0af2149e1ac",
+        "sender": "0x7332eA1229c11C627C10eB24c1A6F77BceD1D5c1",
+        "type": "STORE",
+        "channel": "EVIDENZ",
+        "item_content": None,
+        "item_type": "storage",
+        "signature": "23d1d099dd111ae3251efea537f57767cf43b2ae3611bf9051760e0a9bc2bd4429563a130e3e391668086d101f8a197f55377f50b15d4c0303ff957d90a258a31b",
+        "time": 1616021679.055,
+    }
+
+    message = parse_message(message_dict)
+
+
 @pytest.mark.asyncio
 async def test_storage_add_file(api_client, session_factory: DbSessionFactory):
+
     await add_file(
         api_client,
         session_factory,
         uri=STORAGE_ADD_FILE_URI,
         file_content=FILE_CONTENT,
         expected_file_hash=EXPECTED_FILE_SHA256,
+    )
+
+
+@pytest.mark.asyncio
+async def test_storage_add_file_with_message(api_client, session_factory: DbSessionFactory):
+    await add_file_with_message(
+        api_client,
+        session_factory,
+        uri=STORAGE_ADD_FILE_URI,
+        file_content=b"Hello Aleph.im\n",
+        expected_file_hash="c25b0525bc308797d3e35763faf5c560f2974dab802cb4a734ae4e9d1040319e",
     )
 
 
@@ -118,11 +215,11 @@ async def test_ipfs_add_file(api_client, session_factory: DbSessionFactory):
 
 
 async def add_json(
-    api_client,
-    session_factory: DbSessionFactory,
-    uri: str,
-    json: Any,
-    expected_file_hash: ItemHash,
+        api_client,
+        session_factory: DbSessionFactory,
+        uri: str,
+        json: Any,
+        expected_file_hash: ItemHash,
 ):
     serialized_json = orjson.dumps(json)
 

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -110,7 +110,7 @@ async def add_file(
     form_data = aiohttp.FormData()
     form_data.add_field("file", file_content)
 
-    post_response = await api_client.post(uri, data=form_data, sync=True)
+    post_response = await api_client.post(uri, data=form_data)
     assert post_response.status == 200, await post_response.text()
     post_response_json = await post_response.json()
     assert post_response_json["status"] == "success"

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -152,7 +152,7 @@ async def add_file_with_message(
     mock_mq_message = mocker.Mock()
     mock_mq_message.routing_key = f"processed.{MESSAGE_DICT['item_hash']}"
     mocker.patch(
-        "aleph.web.controllers.storage._mq_read_one_message",
+        "aleph.web.controllers.storage.mq_read_one_message",
         return_value=mock_mq_message,
     )
 
@@ -196,7 +196,7 @@ async def add_file_with_message_202(
     mock_mq_message = mocker.Mock()
     mock_mq_message.routing_key = f"processed.{MESSAGE_DICT['item_hash']}"
     mocker.patch(
-        "aleph.web.controllers.storage._mq_read_one_message", return_value=None
+        "aleph.web.controllers.storage.mq_read_one_message", return_value=None
     )
 
     with session_factory() as session:


### PR DESCRIPTION
Problem: file upload is performed in two steps, one to push the file and one to push the associated STORE message.

Solution: improve `/api/v0/storage/add_file` to allow the user to send a STORE message along with his file, making upload an atomic operation.
