### PR TITLE
Feature: modification and creation date in the aggregate messages

### DIFF
--- a/src/aleph/db/accessors/aggregates.py
+++ b/src/aleph/db/accessors/aggregates.py
@@ -38,8 +38,8 @@ def get_aggregates_by_owner(
 
 
 def get_aggregates_info_by_owner(
-    session: DbSession, owner: str, keys: Optional[Sequence[str]] = None
-) -> Iterable[Tuple[str, Dict[str, Any]]]:
+    session: DbSession, owner: str
+) -> Iterable[Tuple[str, dt.datetime, dt.datetime, str, str]]:
     query = (
         select(
             AggregateDb.key,

--- a/src/aleph/db/accessors/aggregates.py
+++ b/src/aleph/db/accessors/aggregates.py
@@ -42,19 +42,15 @@ def get_aggregates_info_by_owner(
 ) -> Iterable[Tuple[str, Dict[str, Any]]]:
     query = (
         select(
-            [
-                AggregateDb.key.label("aggregate_key"),
-                AggregateDb.creation_datetime.label("created"),
-                AggregateDb.last_revision_hash.label("last_update_item_hash"),
-                AggregateElementDb.item_hash.label("original_item_hash"),
-            ]
+            AggregateDb.key,
+            AggregateDb.creation_datetime.label("created"),
+            AggregateElementDb.creation_datetime.label("last_updated"),
+            AggregateDb.last_revision_hash.label("last_update_item_hash"),
+            AggregateElementDb.item_hash.label("original_item_hash"),
         )
-        .select_from(
-            join(
-                AggregateDb,
-                AggregateElementDb,
-                AggregateDb.last_revision_hash == AggregateElementDb.item_hash,
-            )
+        .join(
+            AggregateElementDb,
+            AggregateDb.last_revision_hash == AggregateElementDb.item_hash,
         )
         .where(AggregateDb.owner == owner)
     )

--- a/src/aleph/web/controllers/aggregates.py
+++ b/src/aleph/web/controllers/aggregates.py
@@ -1,4 +1,5 @@
 import logging
+import datetime as dt
 from typing import List, Optional, Any, Dict, Tuple
 
 from aiohttp import web
@@ -72,11 +73,9 @@ async def address_aggregate(request: web.Request) -> web.Response:
             return web.HTTPNotFound(text="No aggregate found for this address")
 
         if with_info:
-            aggregates_info = list(
-                get_aggregates_info_by_owner(
-                    session=session, owner=address, keys=query_params.keys
-                )
-            )
+            aggregates_info: List[
+                Tuple[str, dt.datetime, dt.datetime, str, str]
+            ] = list(get_aggregates_info_by_owner(session=session, owner=address))
     output = {
         "address": address,
         "data": {result[0]: result[1] for result in aggregates},
@@ -84,10 +83,17 @@ async def address_aggregate(request: web.Request) -> web.Response:
     info = {}
     if with_info:
         for result in aggregates_info:
-            aggregate_key, created, last_update_item_hash, original_item_hash = result
+            (
+                aggregate_key,
+                created,
+                last_updated,
+                original_item_hash,
+                last_update_item_hash,
+            ) = result
+
             info[aggregate_key] = {
                 "created": created.isoformat(),  # Convert datetime to ISO format
-                "last_updated": created.isoformat(),  # Use 'created' for 'last_updated' for now
+                "last_updated": last_updated.isoformat(),  # Use actual 'last_updated' value
                 "original_item_hash": original_item_hash,
                 "last_update_item_hash": last_update_item_hash,
             }

--- a/src/aleph/web/controllers/aggregates.py
+++ b/src/aleph/web/controllers/aggregates.py
@@ -66,16 +66,19 @@ async def address_aggregate(request: web.Request) -> web.Response:
             )
         )
 
-        if not aggregates:
-            return web.HTTPNotFound(text="No aggregate found for this address")
+    if not aggregates:
+        return web.HTTPNotFound(text="No aggregate found for this address")
 
     output = {
         "address": address,
-        "data": {result[0]: result[1] for result in aggregates},
+        "data": {},
     }
-    info = {}
-    if query_params.with_info:
-        for result in aggregates:
+    info: Dict = {}
+    data: Dict = {}
+
+    for result in aggregates:
+        data[result[0]] = result[1]
+        if query_params.with_info:
             (
                 aggregate_key,
                 content,
@@ -89,13 +92,14 @@ async def address_aggregate(request: web.Request) -> web.Response:
                 created = created.isoformat()
             if isinstance(last_updated, dt.datetime):
                 last_updated = last_updated.isoformat()
-
             info[aggregate_key] = {
-                "created": created,
-                "last_updated": last_updated,
-                "original_item_hash": original_item_hash,
-                "last_update_item_hash": last_update_item_hash,
+                "created": str(created),
+                "last_updated": str(last_updated),
+                "original_item_hash": str(original_item_hash),
+                "last_update_item_hash": str(last_update_item_hash),
             }
-        output["info"] = info
+
+    output["data"] = data
+    output["info"] = info
 
     return web.json_response(output)

--- a/src/aleph/web/controllers/aggregates.py
+++ b/src/aleph/web/controllers/aggregates.py
@@ -5,7 +5,11 @@ from aiohttp import web
 from pydantic import BaseModel, validator, ValidationError
 from sqlalchemy import select
 
-from aleph.db.accessors.aggregates import get_aggregates_by_owner, refresh_aggregate
+from aleph.db.accessors.aggregates import (
+    get_aggregates_by_owner,
+    refresh_aggregate,
+    get_aggregates_info_by_owner,
+)
 from aleph.db.models import AggregateDb
 from .utils import LIST_FIELD_SEPARATOR
 
@@ -34,6 +38,8 @@ async def address_aggregate(request: web.Request) -> web.Response:
     """
 
     address = request.match_info["address"]
+    with_info_param = request.query.get("with_info", "false")
+    with_info = with_info_param.lower() == "true"
 
     try:
         query_params = AggregatesQueryParams.parse_obj(request.query)
@@ -56,18 +62,35 @@ async def address_aggregate(request: web.Request) -> web.Response:
             LOGGER.info("Refreshing dirty aggregate %s/%s", address, key)
             refresh_aggregate(session=session, owner=address, key=key)
             session.commit()
-
         aggregates: List[Tuple[str, Dict[str, Any]]] = list(
             get_aggregates_by_owner(
                 session=session, owner=address, keys=query_params.keys
             )
         )
 
-    if not aggregates:
-        return web.HTTPNotFound(text="No aggregate found for this address")
+        if not aggregates:
+            return web.HTTPNotFound(text="No aggregate found for this address")
 
+        if with_info:
+            aggregates_info = list(
+                get_aggregates_info_by_owner(
+                    session=session, owner=address, keys=query_params.keys
+                )
+            )
     output = {
         "address": address,
         "data": {result[0]: result[1] for result in aggregates},
     }
+    info = {}
+    if with_info:
+        for result in aggregates_info:
+            aggregate_key, created, last_update_item_hash, original_item_hash = result
+            info[aggregate_key] = {
+                "created": created.isoformat(),  # Convert datetime to ISO format
+                "last_updated": created.isoformat(),  # Use 'created' for 'last_updated' for now
+                "original_item_hash": original_item_hash,
+                "last_update_item_hash": last_update_item_hash,
+            }
+        output["info"] = info
+
     return web.json_response(output)

--- a/tests/api/test_aggregates.py
+++ b/tests/api/test_aggregates.py
@@ -26,12 +26,15 @@ def make_uri(address: str) -> str:
     return AGGREGATES_URI.format(address=address)
 
 
-async def get_aggregates(api_client, address: str, **params) -> aiohttp.ClientResponse:
+async def get_aggregates(
+    api_client, address: str, with_info=False, **params
+) -> aiohttp.ClientResponse:
+    params["with_info"] = str(with_info)
     return await api_client.get(make_uri(address), params=params)
 
 
 async def get_aggregates_expect_success(api_client, address: str, **params):
-    response = await get_aggregates(api_client, address, **params)
+    response = await get_aggregates(api_client, address, True, **params)
     assert response.status == 200, await response.text()
     return await response.json()
 

--- a/tests/api/test_aggregates.py
+++ b/tests/api/test_aggregates.py
@@ -52,7 +52,7 @@ async def test_get_aggregates_no_update(
     assert fixture_aggregate_messages  # To avoid unused parameter warnings
 
     address = ADDRESS_2
-    aggregates = await get_aggregates_expect_success(ccn_api_client, address)
+    aggregates = await get_aggregates_expect_success(ccn_api_client, address, "False")
 
     assert aggregates["address"] == address
     assert aggregates["data"] == EXPECTED_AGGREGATES[address]
@@ -90,7 +90,7 @@ async def test_get_aggregates_filter_by_key(
 
     address, key = ADDRESS_1, "test_target"
     aggregates = await get_aggregates_expect_success(
-        ccn_api_client, address=address, keys=key
+        ccn_api_client, address=address, keys=key, with_info="False"
     )
     assert aggregates["address"] == address
     assert aggregates["data"][key] == EXPECTED_AGGREGATES[address][key]
@@ -98,7 +98,7 @@ async def test_get_aggregates_filter_by_key(
     # Multiple keys
     address, keys = ADDRESS_1, ["test_target", "test_reference"]
     aggregates = await get_aggregates_expect_success(
-        ccn_api_client, address=address, keys=",".join(keys)
+        ccn_api_client, address=address, keys=",".join(keys), with_info="False"
     )
     assert aggregates["address"] == address
     for key in keys:
@@ -121,7 +121,7 @@ async def test_get_aggregates_limit(
 
     address, key = ADDRESS_1, "test_reference"
     aggregates = await get_aggregates_expect_success(
-        ccn_api_client, address=address, keys=key, limit=1
+        ccn_api_client, address=address, keys=key, limit=1, with_info="False"
     )
     assert aggregates["address"] == address
     assert aggregates["data"][key] == {"c": 3, "d": 4}
@@ -138,7 +138,7 @@ async def test_get_aggregates_invalid_address(
 
     invalid_address = "unknown"
 
-    response = await get_aggregates(ccn_api_client, invalid_address)
+    response = await get_aggregates(ccn_api_client, invalid_address, "False")
     assert response.status == 404
 
 
@@ -152,7 +152,7 @@ async def test_get_aggregates_invalid_params(
     assert fixture_aggregate_messages  # To avoid unused parameter warnings
 
     # A string as limit
-    response = await get_aggregates(ccn_api_client, ADDRESS_1, limit="abc")
+    response = await get_aggregates(ccn_api_client, ADDRESS_1, limit="abc", with_info="False")
     assert response.status == 422
     assert response.content_type == "application/json"
 

--- a/tests/api/test_aggregates.py
+++ b/tests/api/test_aggregates.py
@@ -72,6 +72,7 @@ async def test_get_aggregates(
     assert aggregates["data"]["test_key"] == {"a": 1, "b": 2}
     assert aggregates["data"]["test_target"] == {"a": 1, "b": 2}
     assert aggregates["data"]["test_reference"] == {"a": 1, "b": 2, "c": 3, "d": 4}
+    assert aggregates["info"]["test_reference"] is not None
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_aggregates.py
+++ b/tests/api/test_aggregates.py
@@ -27,14 +27,16 @@ def make_uri(address: str) -> str:
 
 
 async def get_aggregates(
-    api_client, address: str, with_info=False, **params
+    api_client, address: str, with_info: str, **params
 ) -> aiohttp.ClientResponse:
-    params["with_info"] = str(with_info)
+    params["with_info"] = with_info
     return await api_client.get(make_uri(address), params=params)
 
 
-async def get_aggregates_expect_success(api_client, address: str, **params):
-    response = await get_aggregates(api_client, address, True, **params)
+async def get_aggregates_expect_success(
+    api_client, address: str, with_info: str, **params
+):
+    response = await get_aggregates(api_client, address, with_info, **params)
     assert response.status == 200, await response.text()
     return await response.json()
 
@@ -66,13 +68,14 @@ async def test_get_aggregates(
     assert fixture_aggregate_messages  # To avoid unused parameter warnings
 
     address = ADDRESS_1
-    aggregates = await get_aggregates_expect_success(ccn_api_client, address)
+    aggregates = await get_aggregates_expect_success(ccn_api_client, address, "True")
 
     assert address == aggregates["address"]
     assert aggregates["data"]["test_key"] == {"a": 1, "b": 2}
     assert aggregates["data"]["test_target"] == {"a": 1, "b": 2}
     assert aggregates["data"]["test_reference"] == {"a": 1, "b": 2, "c": 3, "d": 4}
     assert aggregates["info"]["test_reference"] is not None
+    print(aggregates)
 
 
 @pytest.mark.asyncio

--- a/tests/message_processing/conftest.py
+++ b/tests/message_processing/conftest.py
@@ -97,3 +97,4 @@ def message_processor(mocker, mock_config: Config, session_factory: DbSessionFac
         mq_conn=mocker.AsyncMock(),
     )
     return message_processor
+


### PR DESCRIPTION
Problem :
To avoid fetching all the messages to find the creation/modification time of a specific aggregate entry it will be useful to have this info directly in the aggregate message

Solution:
Update '/api/v0/aggregates' Endpoint

param : 
 - with_info: bool default : False 

From :

```
{
  "address": "0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10",
  "data": {
    "key1": ...,
    "key2": ...,
  }
}
```

To:
```
{
  "address": "0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10",
  "data": {
    "key1": ...,
    "key2": ...,
  }
  "info": {
    "key1": {
      "created": ...,
      "last_updated": ...,
      "original_item_hash": ...,
      "last_update_item_hash: ...,
    },
    "key2": ...
  }
}
```

Fixes #470.