### PR TITLE
Fix: return 422 on POST /messages if body is not JSON

### DIFF
--- a/src/aleph/web/controllers/p2p.py
+++ b/src/aleph/web/controllers/p2p.py
@@ -190,6 +190,9 @@ async def pub_message(request: web.Request):
         request_data = PubMessageRequest.parse_obj(await request.json())
     except ValidationError as e:
         raise web.HTTPUnprocessableEntity(body=e.json(indent=4))
+    except ValueError:
+        # Body must be valid JSON
+        raise web.HTTPUnprocessableEntity()
 
     pending_message = _validate_message_dict(request_data.message_dict)
 


### PR DESCRIPTION
Problem: Posting to /messages without a body causes a 500.
Solution: catch the error and raise a 422 instead.