### PR TITLE
Fix: 400 error on indexer queries

### DIFF
--- a/src/aleph/chains/indexer_reader.py
+++ b/src/aleph/chains/indexer_reader.py
@@ -51,7 +51,7 @@ def make_account_state_query(
     return """
 {
   state: accountState(
-    blockchain: %s
+    blockchain: "%s"
     account: %s
     type: %s
   ) {
@@ -95,7 +95,7 @@ def make_events_query(
 
     fields = "\n".join(model.__fields__.keys())
     params: Dict[str, Any] = {
-        "blockchain": blockchain.value,
+        "blockchain": f'"{blockchain.value}"',
         "limit": limit,
         "reverse": "false",
     }


### PR DESCRIPTION
Problem: indexer queries fail because of a breaking change. The blockchain parameter is now a literal string instead of an enum value, requiring additional quotes.

Solution: add quotes around the blockchain parameter value.