### PR TITLE
Internal: improve chain data service

### DIFF
--- a/src/aleph/chains/bsc.py
+++ b/src/aleph/chains/bsc.py
@@ -1,7 +1,7 @@
 from aleph_message.models import Chain
 from configmanager import Config
 
-from aleph.chains.chaindata import ChainDataService
+from aleph.chains.chain_data_service import ChainDataService
 from aleph.chains.abc import ChainReader
 from aleph.chains.indexer_reader import AlephIndexerReader
 from aleph.types.chain_sync import ChainEventType

--- a/src/aleph/chains/connector.py
+++ b/src/aleph/chains/connector.py
@@ -8,7 +8,7 @@ from configmanager import Config
 from aleph.storage import StorageService
 from aleph.types.db_session import DbSessionFactory
 from .bsc import BscConnector
-from .chaindata import ChainDataService
+from .chain_data_service import ChainDataService
 from .abc import ChainReader, ChainWriter
 from .ethereum import EthereumConnector
 from .nuls2 import Nuls2Connector

--- a/src/aleph/chains/ethereum.py
+++ b/src/aleph/chains/ethereum.py
@@ -27,7 +27,7 @@ from aleph.schemas.pending_messages import BasePendingMessage
 from aleph.toolkit.timestamp import utc_now
 from aleph.types.db_session import DbSessionFactory
 from aleph.utils import run_in_executor
-from .chaindata import ChainDataService
+from .chain_data_service import ChainDataService
 from .abc import ChainWriter, Verifier, ChainReader
 from .indexer_reader import AlephIndexerReader
 from ..db.models import ChainTxDb
@@ -346,8 +346,8 @@ class EthereumConnector(ChainWriter):
                 LOGGER.info("Chain sync: %d unconfirmed messages")
 
                 # This function prepares a chain data file and makes it downloadable from the node.
-                content = await self.chain_data_service.get_chaindata(
-                    session=session, messages=messages, bulk_threshold=200
+                sync_event_payload = await self.chain_data_service.prepare_sync_event_payload(
+                    session=session, messages=messages
                 )
                 # Required to apply update to the files table in get_chaindata
                 session.commit()
@@ -360,7 +360,7 @@ class EthereumConnector(ChainWriter):
                     account,
                     int(gas_price * 1.1),
                     nonce,
-                    content,
+                    sync_event_payload.json(),
                 )
                 LOGGER.info("Broadcast %r on %s" % (response, CHAIN_NAME))
 

--- a/src/aleph/chains/indexer_reader.py
+++ b/src/aleph/chains/indexer_reader.py
@@ -21,7 +21,7 @@ from aleph_message.models import Chain
 from pydantic import BaseModel
 
 import aleph.toolkit.json as aleph_json
-from aleph.chains.chaindata import ChainDataService
+from aleph.chains.chain_data_service import ChainDataService
 from aleph.db.accessors.chains import (
     get_missing_indexer_datetime_multirange,
     add_indexer_range,

--- a/src/aleph/chains/nuls2.py
+++ b/src/aleph/chains/nuls2.py
@@ -30,7 +30,7 @@ from aleph.schemas.pending_messages import BasePendingMessage
 from aleph.toolkit.timestamp import utc_now
 from aleph.types.db_session import DbSessionFactory
 from aleph.utils import run_in_executor
-from .chaindata import ChainDataService
+from .chain_data_service import ChainDataService
 from .abc import Verifier, ChainWriter
 from aleph.schemas.chains.tx_context import TxContext
 from ..db.models import ChainTxDb
@@ -197,12 +197,13 @@ class Nuls2Connector(ChainWriter):
 
             if len(messages):
                 # This function prepares a chain data file and makes it downloadable from the node.
-                content = await self.chain_data_service.get_chaindata(
+                sync_event_payload = await self.chain_data_service.prepare_sync_event_payload(
                     session=session, messages=messages
                 )
                 # Required to apply update to the files table in get_chaindata
                 session.commit()
 
+                content = sync_event_payload.json()
                 tx = await prepare_transfer_tx(
                     address,
                     [(target_addr, CHEAP_UNIT_FEE)],

--- a/src/aleph/chains/tezos.py
+++ b/src/aleph/chains/tezos.py
@@ -11,7 +11,7 @@ from configmanager import Config
 from nacl.exceptions import BadSignatureError
 
 import aleph.toolkit.json as aleph_json
-from aleph.chains.chaindata import ChainDataService
+from aleph.chains.chain_data_service import ChainDataService
 from aleph.chains.common import get_verification_buffer
 from aleph.chains.abc import Verifier, ChainReader
 from aleph.db.accessors.chains import get_last_height, upsert_chain_sync_status

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -11,7 +11,7 @@ from setproctitle import setproctitle
 from sqlalchemy import delete
 
 from ..chains.signature_verifier import SignatureVerifier
-from aleph.chains.chaindata import ChainDataService
+from aleph.chains.chain_data_service import ChainDataService
 from aleph.db.accessors.pending_txs import get_pending_txs
 from aleph.db.connection import make_engine, make_session_factory
 from aleph.db.models.pending_txs import PendingTxDb

--- a/src/aleph/schemas/chains/sync_events.py
+++ b/src/aleph/schemas/chains/sync_events.py
@@ -1,0 +1,52 @@
+from typing import Literal, Optional, List, Union, Annotated
+
+from aleph_message.models import ItemHash, ItemType, Chain, MessageType
+from pydantic import BaseModel, Field, validator
+
+from aleph.types.chain_sync import ChainSyncProtocol
+from aleph.types.channel import Channel
+import datetime as dt
+
+
+class OnChainMessage(BaseModel):
+    class Config:
+        orm_mode = True
+
+    sender: str
+    chain: Chain
+    signature: Optional[str]
+    type: MessageType
+    item_content: Optional[str]
+    item_type: ItemType
+    item_hash: ItemHash
+    time: float
+    channel: Optional[Channel] = None
+
+    @validator("time", pre=True)
+    def check_time(cls, v, values):
+        if isinstance(v, dt.datetime):
+            return v.timestamp()
+
+        return v
+
+
+class OnChainContent(BaseModel):
+    messages: List[OnChainMessage]
+
+
+class OnChainSyncEventPayload(BaseModel):
+    protocol: Literal[ChainSyncProtocol.ON_CHAIN_SYNC]
+    version: int
+    content: OnChainContent
+
+
+class OffChainSyncEventPayload(BaseModel):
+    protocol: Literal[ChainSyncProtocol.OFF_CHAIN_SYNC]
+    version: int
+    content: str
+
+
+SyncEventPayload = Annotated[
+    Union[OnChainSyncEventPayload, OffChainSyncEventPayload],
+    Field(discriminator="protocol"),
+]

--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -5,7 +5,6 @@ import asyncio
 import logging
 from hashlib import sha256
 from typing import Any, IO, Optional, cast, Final
-from aiohttp import web
 
 from aleph_message.models import ItemType
 
@@ -20,13 +19,9 @@ from aleph.services.ipfs import IpfsService
 from aleph.services.ipfs.common import get_cid_version
 from aleph.services.p2p.http import request_hash as p2p_http_request_hash
 from aleph.services.storage.engine import StorageEngine
-from aleph.toolkit.constants import MiB
 from aleph.types.db_session import DbSession
 from aleph.types.files import FileType
 from aleph.utils import get_sha256
-from aleph.schemas.pending_messages import (
-    parse_message,
-)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -144,7 +139,9 @@ class StorageService:
     ) -> None:
         """
         Checks that the hash of a content we fetched from the network matches the expected hash.
-        :return: True if the hashes match, False otherwise.
+        Raises an exception if the content does not match the expected hash.
+        :raises InvalidContent: The computed hash does not match.
+        :raises ContentCurrentlyUnavailable: The hash cannot be computed at this time.
         """
         config = get_config()
         ipfs_enabled = config.ipfs.enabled.value

--- a/tests/message_processing/test_process_pending_txs.py
+++ b/tests/message_processing/test_process_pending_txs.py
@@ -8,7 +8,7 @@ from configmanager import Config
 from sqlalchemy import select
 
 from aleph.chains.signature_verifier import SignatureVerifier
-from aleph.chains.chaindata import ChainDataService
+from aleph.chains.chain_data_service import ChainDataService
 from aleph.db.models import PendingMessageDb, MessageStatusDb
 from aleph.db.models.chains import ChainTxDb
 from aleph.db.models.pending_txs import PendingTxDb


### PR DESCRIPTION
Problem: a few todos are still open on the chain data service.

Solution: improve and rename the `get_chaindata` method. The new `prepare_sync_event_payload` method now always returns an off-chain sync event (on-chain sync events never occur anyway). It also returns the result as a Pydantic model for more flexibility. Serialization is left upon the caller. We now use a Pydantic model to translate `MessageDb` objects in the correct format.