### PR TITLE
Internal: TX processing is now event-based

### DIFF
--- a/src/aleph/chains/bsc.py
+++ b/src/aleph/chains/bsc.py
@@ -1,8 +1,8 @@
 from aleph_message.models import Chain
 from configmanager import Config
 
-from aleph.chains.chain_data_service import ChainDataService
 from aleph.chains.abc import ChainReader
+from aleph.chains.chain_data_service import PendingTxPublisher
 from aleph.chains.indexer_reader import AlephIndexerReader
 from aleph.types.chain_sync import ChainEventType
 from aleph.types.db_session import DbSessionFactory
@@ -10,12 +10,14 @@ from aleph.types.db_session import DbSessionFactory
 
 class BscConnector(ChainReader):
     def __init__(
-        self, session_factory: DbSessionFactory, chain_data_service: ChainDataService
+        self,
+        session_factory: DbSessionFactory,
+        pending_tx_publisher: PendingTxPublisher,
     ):
         self.indexer_reader = AlephIndexerReader(
             chain=Chain.BSC,
             session_factory=session_factory,
-            chain_data_service=chain_data_service,
+            pending_tx_publisher=pending_tx_publisher,
         )
 
     async def fetcher(self, config: Config):

--- a/src/aleph/chains/chain_data_service.py
+++ b/src/aleph/chains/chain_data_service.py
@@ -222,7 +222,7 @@ class ChainDataService:
 
 async def make_pending_tx_exchange(config: Config) -> aio_pika.abc.AbstractExchange:
     mq_conn = await aio_pika.connect_robust(
-        host=config.rabbitmq.host.value,
+        host=config.p2p.mq_host.value,
         port=config.rabbitmq.port.value,
         login=config.rabbitmq.username.value,
         password=config.rabbitmq.password.value,

--- a/src/aleph/chains/chain_data_service.py
+++ b/src/aleph/chains/chain_data_service.py
@@ -1,8 +1,10 @@
 import asyncio
 from io import StringIO
-from typing import Dict, Optional, List, Any, Mapping, Set, cast, Type, Union
+from typing import Dict, Optional, List, Any, Mapping, Set, cast, Type, Union, Self
 
+import aio_pika.abc
 from aleph_message.models import StoreContent, ItemType, Chain, MessageType
+from configmanager import Config
 from pydantic import ValidationError
 
 from aleph.chains.common import LOGGER
@@ -36,7 +38,9 @@ from aleph.utils import get_sha256
 
 class ChainDataService:
     def __init__(
-        self, session_factory: DbSessionFactory, storage_service: StorageService
+        self,
+        session_factory: DbSessionFactory,
+        storage_service: StorageService,
     ):
         self.session_factory = session_factory
         self.storage_service = storage_service
@@ -215,11 +219,54 @@ class ChainDataService:
                 LOGGER.info("%s", error_msg)
                 raise InvalidContent(error_msg)
 
+
+async def make_pending_tx_exchange(config: Config) -> aio_pika.abc.AbstractExchange:
+    mq_conn = await aio_pika.connect_robust(
+        host=config.rabbitmq.host.value,
+        port=config.rabbitmq.port.value,
+        login=config.rabbitmq.username.value,
+        password=config.rabbitmq.password.value,
+    )
+    channel = await mq_conn.channel()
+    pending_tx_exchange = await channel.declare_exchange(
+        name=config.rabbitmq.pending_tx_exchange.value,
+        type=aio_pika.ExchangeType.TOPIC,
+        auto_delete=False,
+    )
+    return pending_tx_exchange
+
+
+class PendingTxPublisher:
+    def __init__(self, pending_tx_exchange: aio_pika.abc.AbstractExchange):
+        self.pending_tx_exchange = pending_tx_exchange
+
     @staticmethod
-    async def incoming_chaindata(session: DbSession, tx: ChainTxDb):
-        """Incoming data from a chain.
-        Content can be inline of "offchain" through an ipfs hash.
-        For now, we only add it to the database, it will be processed later.
-        """
+    def add_pending_tx(session: DbSession, tx: ChainTxDb):
         upsert_chain_tx(session=session, tx=tx)
         upsert_pending_tx(session=session, tx_hash=tx.hash)
+
+    async def publish_pending_tx(self, tx: ChainTxDb):
+        message = aio_pika.Message(body=tx.hash.encode("utf-8"))
+        await self.pending_tx_exchange.publish(
+            message=message, routing_key=f"{tx.chain.value}.{tx.publisher}.{tx.hash}"
+        )
+
+    async def add_and_publish_pending_tx(self, session: DbSession, tx: ChainTxDb):
+        """
+        Add an event published on one of the supported chains.
+        Adds the tx to the database, creates a pending tx entry in the pending tx table
+        and publishes a message on the pending tx exchange.
+
+        Note that this function commits changes to the database for consistency
+        between the DB and the message queue.
+        """
+        self.add_pending_tx(session=session, tx=tx)
+        session.commit()
+        await self.publish_pending_tx(tx)
+
+    @classmethod
+    async def new(cls, config: Config) -> Self:
+        pending_tx_exchange = await make_pending_tx_exchange(config=config)
+        return cls(
+            pending_tx_exchange=pending_tx_exchange,
+        )

--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -23,7 +23,7 @@ import sentry_sdk
 from configmanager import Config
 
 import aleph.config
-from aleph.chains.chain_data_service import ChainDataService
+from aleph.chains.chain_data_service import ChainDataService, PendingTxPublisher
 from aleph.chains.connector import ChainConnector
 from aleph.cli.args import parse_args
 from aleph.db.connection import make_engine, make_session_factory, make_db_url
@@ -44,7 +44,6 @@ from aleph.toolkit.monitoring import setup_sentry
 __author__ = "Moshe Malawach"
 __copyright__ = "Moshe Malawach"
 __license__ = "mit"
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -138,10 +137,14 @@ async def main(args: List[str]) -> None:
         node_cache=node_cache,
     )
     chain_data_service = ChainDataService(
-        session_factory=session_factory, storage_service=storage_service
+        session_factory=session_factory,
+        storage_service=storage_service,
     )
+    pending_tx_publisher = await PendingTxPublisher.new(config=config)
     chain_connector = ChainConnector(
-        session_factory=session_factory, chain_data_service=chain_data_service
+        session_factory=session_factory,
+        pending_tx_publisher=pending_tx_publisher,
+        chain_data_service=chain_data_service,
     )
 
     set_start_method("spawn")

--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -174,6 +174,8 @@ def get_defaults():
             "sub_exchange": "p2p-subscribe",
             # Name of the exchange used to publish processed messages (output of the message processor).
             "message_exchange": "aleph-messages",
+            "pending_message_exchange": "aleph-pending-messages",
+            "pending_tx_exchange": "aleph-pending-txs",
         },
         "redis": {
             # Hostname of the Redis service.

--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -174,7 +174,9 @@ def get_defaults():
             "sub_exchange": "p2p-subscribe",
             # Name of the exchange used to publish processed messages (output of the message processor).
             "message_exchange": "aleph-messages",
+            # Name of the RabbitMQ exchange used for pending messages (input of the message processor).
             "pending_message_exchange": "aleph-pending-messages",
+            # Name of the RabbitMQ exchange used for sync/message events (input of the TX processor).
             "pending_tx_exchange": "aleph-pending-txs",
         },
         "redis": {

--- a/src/aleph/jobs/job_utils.py
+++ b/src/aleph/jobs/job_utils.py
@@ -4,6 +4,7 @@ import logging
 from typing import Dict, Union
 from typing import Tuple
 
+import aio_pika.abc
 from configmanager import Config
 from sqlalchemy import update
 
@@ -39,7 +40,7 @@ def compute_next_retry_interval(attempts: int) -> dt.timedelta:
     :return: The time interval between the previous processing attempt and the next one.
     """
 
-    seconds = 2 ** attempts
+    seconds = 2**attempts
     return dt.timedelta(seconds=min(seconds, MAX_RETRY_INTERVAL))
 
 
@@ -84,6 +85,32 @@ def prepare_loop(config_values: Dict) -> Tuple[asyncio.AbstractEventLoop, Config
     config.load_values(config_values)
 
     return loop, config
+
+
+class MqWatcher:
+    def __init__(self, mq_queue: aio_pika.abc.AbstractQueue):
+        self.mq_queue = mq_queue
+
+        self._watcher_task = None
+        self._event = asyncio.Event()
+
+    async def _check_for_message(self):
+        async with self.mq_queue.iterator(no_ack=True) as queue_iter:
+            async for _ in queue_iter:
+                self._event.set()
+
+    async def __aenter__(self):
+        self._watcher_task = asyncio.create_task(self._check_for_message())
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if self._watcher_task is not None:
+            self._watcher_task.cancel()
+            await self._watcher_task
+
+    async def ready(self):
+        await self._event.wait()
+        self._event.clear()
 
 
 class MessageJob:

--- a/src/aleph/jobs/job_utils.py
+++ b/src/aleph/jobs/job_utils.py
@@ -88,6 +88,18 @@ def prepare_loop(config_values: Dict) -> Tuple[asyncio.AbstractEventLoop, Config
 
 
 class MqWatcher:
+    """
+    Watches a RabbitMQ message queue for new messages and maintains an asyncio Event object
+    that tracks whether there is still work to do.
+
+    This class is used by the tx/message processors to detect new pending objects in the database.
+    We use RabbitMQ messages for signaling new pending objects but the actual objects are stored
+    in the DB.
+
+    This class is an async context manager that spawns a watcher task. Callers can use the `ready()`
+    method to determine if there is work to be done.
+    """
+
     def __init__(self, mq_queue: aio_pika.abc.AbstractQueue):
         self.mq_queue = mq_queue
 

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -99,7 +99,7 @@ class PendingTxProcessor:
 
 async def make_pending_tx_queue(config: Config) -> aio_pika.abc.AbstractQueue:
     mq_conn = await aio_pika.connect_robust(
-        host=config.rabbitmq.host.value,
+        host=config.p2p.mq_host.value,
         port=config.rabbitmq.port.value,
         login=config.rabbitmq.username.value,
         password=config.rabbitmq.password.value,
@@ -113,14 +113,11 @@ async def make_pending_tx_queue(config: Config) -> aio_pika.abc.AbstractQueue:
     pending_tx_queue = await channel.declare_queue(
         name="pending-tx-queue", durable=True, auto_delete=False
     )
-    await pending_tx_queue.bind(pending_tx_exchange, routing_key="*")
+    await pending_tx_queue.bind(pending_tx_exchange, routing_key="#")
     return pending_tx_queue
 
 
 async def handle_txs_task(config: Config):
-    max_concurrent_tasks = config.aleph.jobs.pending_txs.max_concurrency.value
-    await asyncio.sleep(4)
-
     engine = make_engine(config=config, application_name="aleph-txs")
     session_factory = make_session_factory(engine)
 

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -6,14 +6,16 @@ import asyncio
 import logging
 from typing import Dict, Optional, Set
 
+import aio_pika.abc
 from configmanager import Config
 from setproctitle import setproctitle
-from sqlalchemy import delete
 
 from aleph.chains.chain_data_service import ChainDataService
-from aleph.db.accessors.pending_txs import get_pending_txs
+from aleph.db.accessors.pending_txs import (
+    get_pending_tx,
+    delete_pending_tx,
+)
 from aleph.db.connection import make_engine, make_session_factory
-from aleph.db.models.pending_txs import PendingTxDb
 from aleph.handlers.message_handler import MessagePublisher
 from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs.common import make_ipfs_client
@@ -34,86 +36,85 @@ class PendingTxProcessor:
     def __init__(
         self,
         session_factory: DbSessionFactory,
-        storage_service: StorageService,
         message_publisher: MessagePublisher,
+        chain_data_service: ChainDataService,
+        pending_tx_queue: aio_pika.abc.AbstractQueue,
     ):
         self.session_factory = session_factory
-        self.storage_service = storage_service
         self.message_publisher = message_publisher
-        self.chain_data_service = ChainDataService(
-            session_factory=session_factory, storage_service=storage_service
-        )
+        self.chain_data_service = chain_data_service
+        self.pending_tx_queue = pending_tx_queue
 
     async def handle_pending_tx(
-        self, pending_tx: PendingTxDb, seen_ids: Optional[Set[str]] = None
+        self, pending_tx_hash: str, seen_ids: Optional[Set[str]] = None
     ) -> None:
-        LOGGER.info(
-            "%s Handling TX in block %s", pending_tx.tx.chain, pending_tx.tx.height
-        )
+        with self.session_factory() as session:
+            pending_tx = get_pending_tx(session=session, tx_hash=pending_tx_hash)
 
-        tx = pending_tx.tx
+            if pending_tx is None:
+                LOGGER.warning("TX %s is not pending anymore", pending_tx_hash)
+                return
 
-        # If the chain data file is unavailable, we leave it to the pending tx
-        # processor to log the content unavailable exception and retry later.
-        messages = await self.chain_data_service.get_tx_messages(
-            tx=pending_tx.tx, seen_ids=seen_ids
-        )
+            tx = pending_tx.tx
+            LOGGER.info("%s Handling TX in block %s", tx.chain, tx.height)
 
-        if messages:
-            for i, message_dict in enumerate(messages):
-                await self.message_publisher.add_pending_message(
-                    message_dict=message_dict,
-                    reception_time=utc_now(),
-                    tx_hash=tx.hash,
-                    check_message=tx.protocol != ChainSyncProtocol.SMART_CONTRACT,
-                )
+            # If the chain data file is unavailable, we leave it to the pending tx
+            # processor to log the content unavailable exception and retry later.
+            messages = await self.chain_data_service.get_tx_messages(
+                tx=pending_tx.tx, seen_ids=seen_ids
+            )
 
-        else:
-            LOGGER.debug("TX contains no message")
+            if messages:
+                for i, message_dict in enumerate(messages):
+                    await self.message_publisher.add_pending_message(
+                        message_dict=message_dict,
+                        reception_time=utc_now(),
+                        tx_hash=tx.hash,
+                        check_message=tx.protocol != ChainSyncProtocol.SMART_CONTRACT,
+                    )
 
-        if messages is not None:
-            # bogus or handled, we remove it.
-            with self.session_factory() as session:
-                session.execute(
-                    delete(PendingTxDb).where(
-                        PendingTxDb.tx_hash == pending_tx.tx_hash
-                    ),
-                )
+            else:
+                LOGGER.debug("TX contains no message")
+
+            if messages is not None:
+                # bogus or handled, we remove it.
+                delete_pending_tx(session=session, tx_hash=pending_tx_hash)
                 session.commit()
 
-    async def process_pending_txs(self, max_concurrent_tasks: int):
+    async def process_pending_txs(self) -> None:
         """
         Process chain transactions in the Pending TX queue.
         """
 
-        tasks: Set[asyncio.Task] = set()
-
-        seen_offchain_hashes = set()
         seen_ids: Set[str] = set()
         LOGGER.info("handling TXs")
-        with self.session_factory() as session:
-            for pending_tx in get_pending_txs(session):
-                # TODO: remove this feature? It doesn't seem necessary.
-                if pending_tx.tx.protocol == ChainSyncProtocol.OFF_CHAIN_SYNC:
-                    if pending_tx.tx.content in seen_offchain_hashes:
-                        continue
-
-                if len(tasks) == max_concurrent_tasks:
-                    done, tasks = await asyncio.wait(
-                        tasks, return_when=asyncio.FIRST_COMPLETED
+        async with self.pending_tx_queue.iterator() as queue_iter:
+            async for pending_tx_message in queue_iter:
+                async with pending_tx_message.process():
+                    pending_tx_hash = pending_tx_message.body.decode("utf-8")
+                    await self.handle_pending_tx(
+                        pending_tx_hash=pending_tx_hash, seen_ids=seen_ids
                     )
 
-                if pending_tx.tx.protocol == ChainSyncProtocol.OFF_CHAIN_SYNC:
-                    seen_offchain_hashes.add(pending_tx.tx.content)
 
-                tx_task = asyncio.create_task(
-                    self.handle_pending_tx(pending_tx, seen_ids=seen_ids)
-                )
-                tasks.add(tx_task)
-
-            # Wait for the last tasks
-            if tasks:
-                done, _ = await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
+async def make_pending_tx_queue(config: Config) -> aio_pika.abc.AbstractQueue:
+    mq_conn = await aio_pika.connect_robust(
+        host=config.rabbitmq.host.value,
+        port=config.rabbitmq.port.value,
+        login=config.rabbitmq.username.value,
+        password=config.rabbitmq.password.value,
+    )
+    channel = await mq_conn.channel()
+    pending_tx_exchange = await channel.declare_exchange(
+        name=config.rabbitmq.pending_tx_exchange.value,
+        type=aio_pika.ExchangeType.TOPIC,
+        auto_delete=False,
+    )
+    pending_tx_queue = await channel.declare_queue(
+        name="pending-tx-queue", durable=True, auto_delete=False
+    )
+    await pending_tx_queue.bind(pending_tx_exchange, routing_key="*")
+    return pending_tx_queue
 
 
 async def handle_txs_task(config: Config):
@@ -138,15 +139,20 @@ async def handle_txs_task(config: Config):
         storage_service=storage_service,
         config=config,
     )
+    chain_data_service = ChainDataService(
+        session_factory=session_factory, storage_service=storage_service
+    )
+    pending_tx_queue = await make_pending_tx_queue(config=config)
     pending_tx_processor = PendingTxProcessor(
         session_factory=session_factory,
-        storage_service=storage_service,
         message_publisher=message_publisher,
+        chain_data_service=chain_data_service,
+        pending_tx_queue=pending_tx_queue,
     )
 
     while True:
         try:
-            await pending_tx_processor.process_pending_txs(max_concurrent_tasks)
+            await pending_tx_processor.process_pending_txs()
             await asyncio.sleep(5)
         except Exception:
             LOGGER.exception("Error in pending txs job")

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -11,11 +11,9 @@ from configmanager import Config
 from setproctitle import setproctitle
 
 from aleph.chains.chain_data_service import ChainDataService
-from aleph.db.accessors.pending_txs import (
-    get_pending_tx,
-    delete_pending_tx,
-)
+from aleph.db.accessors.pending_txs import get_pending_txs, delete_pending_tx
 from aleph.db.connection import make_engine, make_session_factory
+from aleph.db.models import PendingTxDb
 from aleph.handlers.message_handler import MessagePublisher
 from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs.common import make_ipfs_client
@@ -27,74 +25,9 @@ from aleph.toolkit.monitoring import setup_sentry
 from aleph.toolkit.timestamp import utc_now
 from aleph.types.chain_sync import ChainSyncProtocol
 from aleph.types.db_session import DbSessionFactory
-from .job_utils import prepare_loop
+from .job_utils import prepare_loop, MqWatcher
 
 LOGGER = logging.getLogger(__name__)
-
-
-class PendingTxProcessor:
-    def __init__(
-        self,
-        session_factory: DbSessionFactory,
-        message_publisher: MessagePublisher,
-        chain_data_service: ChainDataService,
-        pending_tx_queue: aio_pika.abc.AbstractQueue,
-    ):
-        self.session_factory = session_factory
-        self.message_publisher = message_publisher
-        self.chain_data_service = chain_data_service
-        self.pending_tx_queue = pending_tx_queue
-
-    async def handle_pending_tx(
-        self, pending_tx_hash: str, seen_ids: Optional[Set[str]] = None
-    ) -> None:
-        with self.session_factory() as session:
-            pending_tx = get_pending_tx(session=session, tx_hash=pending_tx_hash)
-
-            if pending_tx is None:
-                LOGGER.warning("TX %s is not pending anymore", pending_tx_hash)
-                return
-
-            tx = pending_tx.tx
-            LOGGER.info("%s Handling TX in block %s", tx.chain, tx.height)
-
-            # If the chain data file is unavailable, we leave it to the pending tx
-            # processor to log the content unavailable exception and retry later.
-            messages = await self.chain_data_service.get_tx_messages(
-                tx=pending_tx.tx, seen_ids=seen_ids
-            )
-
-            if messages:
-                for i, message_dict in enumerate(messages):
-                    await self.message_publisher.add_pending_message(
-                        message_dict=message_dict,
-                        reception_time=utc_now(),
-                        tx_hash=tx.hash,
-                        check_message=tx.protocol != ChainSyncProtocol.SMART_CONTRACT,
-                    )
-
-            else:
-                LOGGER.debug("TX contains no message")
-
-            if messages is not None:
-                # bogus or handled, we remove it.
-                delete_pending_tx(session=session, tx_hash=pending_tx_hash)
-                session.commit()
-
-    async def process_pending_txs(self) -> None:
-        """
-        Process chain transactions in the Pending TX queue.
-        """
-
-        seen_ids: Set[str] = set()
-        LOGGER.info("handling TXs")
-        async with self.pending_tx_queue.iterator() as queue_iter:
-            async for pending_tx_message in queue_iter:
-                async with pending_tx_message.process():
-                    pending_tx_hash = pending_tx_message.body.decode("utf-8")
-                    await self.handle_pending_tx(
-                        pending_tx_hash=pending_tx_hash, seen_ids=seen_ids
-                    )
 
 
 async def make_pending_tx_queue(config: Config) -> aio_pika.abc.AbstractQueue:
@@ -117,9 +50,95 @@ async def make_pending_tx_queue(config: Config) -> aio_pika.abc.AbstractQueue:
     return pending_tx_queue
 
 
+class PendingTxProcessor(MqWatcher):
+    def __init__(
+        self,
+        session_factory: DbSessionFactory,
+        message_publisher: MessagePublisher,
+        chain_data_service: ChainDataService,
+        pending_tx_queue: aio_pika.abc.AbstractQueue,
+    ):
+        super().__init__(mq_queue=pending_tx_queue)
+
+        self.session_factory = session_factory
+        self.message_publisher = message_publisher
+        self.chain_data_service = chain_data_service
+        self.pending_tx_queue = pending_tx_queue
+
+    async def handle_pending_tx(
+        self, pending_tx: PendingTxDb, seen_ids: Optional[Set[str]] = None
+    ) -> None:
+        LOGGER.info(
+            "%s Handling TX in block %s", pending_tx.tx.chain, pending_tx.tx.height
+        )
+
+        tx = pending_tx.tx
+
+        # If the chain data file is unavailable, we leave it to the pending tx
+        # processor to log the content unavailable exception and retry later.
+        messages = await self.chain_data_service.get_tx_messages(
+            tx=pending_tx.tx, seen_ids=seen_ids
+        )
+
+        if messages:
+            for i, message_dict in enumerate(messages):
+                await self.message_publisher.add_pending_message(
+                    message_dict=message_dict,
+                    reception_time=utc_now(),
+                    tx_hash=tx.hash,
+                    check_message=tx.protocol != ChainSyncProtocol.SMART_CONTRACT,
+                )
+
+            # bogus or handled, we remove it.
+            with self.session_factory() as session:
+                delete_pending_tx(session=session, tx_hash=tx.hash)
+                session.commit()
+
+        else:
+            LOGGER.debug("TX contains no message")
+
+    async def process_pending_txs(self, max_concurrent_tasks: int):
+        """
+        Process chain transactions in the Pending TX queue.
+        """
+
+        tasks: Set[asyncio.Task] = set()
+
+        seen_offchain_hashes = set()
+        seen_ids: Set[str] = set()
+        LOGGER.info("handling TXs")
+        with self.session_factory() as session:
+            for pending_tx in get_pending_txs(session):
+                # TODO: remove this feature? It doesn't seem necessary.
+                if pending_tx.tx.protocol == ChainSyncProtocol.OFF_CHAIN_SYNC:
+                    if pending_tx.tx.content in seen_offchain_hashes:
+                        continue
+
+                if len(tasks) == max_concurrent_tasks:
+                    done, tasks = await asyncio.wait(
+                        tasks, return_when=asyncio.FIRST_COMPLETED
+                    )
+
+                if pending_tx.tx.protocol == ChainSyncProtocol.OFF_CHAIN_SYNC:
+                    seen_offchain_hashes.add(pending_tx.tx.content)
+
+                tx_task = asyncio.create_task(
+                    self.handle_pending_tx(pending_tx, seen_ids=seen_ids)
+                )
+                tasks.add(tx_task)
+
+            # Wait for the last tasks
+            if tasks:
+                done, _ = await asyncio.wait(tasks, return_when=asyncio.ALL_COMPLETED)
+
+
 async def handle_txs_task(config: Config):
+    max_concurrent_tasks = config.aleph.jobs.pending_txs.max_concurrency.value
+
     engine = make_engine(config=config, application_name="aleph-txs")
     session_factory = make_session_factory(engine)
+
+    pending_tx_queue = await make_pending_tx_queue(config=config)
 
     node_cache = NodeCache(
         redis_host=config.redis.host.value, redis_port=config.redis.port.value
@@ -139,7 +158,6 @@ async def handle_txs_task(config: Config):
     chain_data_service = ChainDataService(
         session_factory=session_factory, storage_service=storage_service
     )
-    pending_tx_queue = await make_pending_tx_queue(config=config)
     pending_tx_processor = PendingTxProcessor(
         session_factory=session_factory,
         message_publisher=message_publisher,
@@ -147,14 +165,19 @@ async def handle_txs_task(config: Config):
         pending_tx_queue=pending_tx_queue,
     )
 
-    while True:
-        try:
-            await pending_tx_processor.process_pending_txs()
-            await asyncio.sleep(5)
-        except Exception:
-            LOGGER.exception("Error in pending txs job")
+    async with pending_tx_processor:
+        while True:
+            try:
+                await pending_tx_processor.process_pending_txs(
+                    max_concurrent_tasks=max_concurrent_tasks
+                )
+            except Exception:
+                LOGGER.exception("Error in pending txs job")
 
-        await asyncio.sleep(0.01)
+            try:
+                await asyncio.wait_for(pending_tx_processor.ready(), 5)
+            except TimeoutError:
+                pass
 
 
 def pending_txs_subprocess(config_values: Dict):

--- a/tests/message_processing/test_process_pending_txs.py
+++ b/tests/message_processing/test_process_pending_txs.py
@@ -41,12 +41,13 @@ async def test_process_pending_tx_on_chain_protocol(
     chain_data_service.get_tx_messages = get_fixture_chaindata_messages
     pending_tx_processor = PendingTxProcessor(
         session_factory=session_factory,
-        storage_service=test_storage_service,
         message_publisher=MessagePublisher(
             session_factory=session_factory,
             storage_service=test_storage_service,
             config=mock_config,
         ),
+        chain_data_service=chain_data_service,
+        pending_tx_queue=mocker.AsyncMock(),
     )
     pending_tx_processor.chain_data_service = chain_data_service
 
@@ -69,7 +70,7 @@ async def test_process_pending_tx_on_chain_protocol(
 
     seen_ids: Set[str] = set()
     await pending_tx_processor.handle_pending_tx(
-        pending_tx=pending_tx, seen_ids=seen_ids
+        pending_tx_hash=pending_tx.tx_hash, seen_ids=seen_ids
     )
 
     fixture_messages = load_fixture_messages(f"{pending_tx.tx.content}.json")
@@ -114,12 +115,13 @@ async def _process_smart_contract_tx(
     )
     pending_tx_processor = PendingTxProcessor(
         session_factory=session_factory,
-        storage_service=test_storage_service,
         message_publisher=MessagePublisher(
             session_factory=session_factory,
             storage_service=test_storage_service,
             config=mock_config,
         ),
+        chain_data_service=chain_data_service,
+        pending_tx_queue=mocker.AsyncMock(),
     )
     pending_tx_processor.chain_data_service = chain_data_service
 
@@ -140,7 +142,7 @@ async def _process_smart_contract_tx(
         session.add(pending_tx)
         session.commit()
 
-    await pending_tx_processor.handle_pending_tx(pending_tx=pending_tx)
+    await pending_tx_processor.handle_pending_tx(pending_tx_hash=pending_tx.tx_hash)
 
     with session_factory() as session:
         pending_txs = session.execute(select(PendingTxDb)).scalars().all()

--- a/tests/message_processing/test_process_pending_txs.py
+++ b/tests/message_processing/test_process_pending_txs.py
@@ -70,7 +70,7 @@ async def test_process_pending_tx_on_chain_protocol(
 
     seen_ids: Set[str] = set()
     await pending_tx_processor.handle_pending_tx(
-        pending_tx_hash=pending_tx.tx_hash, seen_ids=seen_ids
+        pending_tx=pending_tx, seen_ids=seen_ids
     )
 
     fixture_messages = load_fixture_messages(f"{pending_tx.tx.content}.json")
@@ -142,7 +142,7 @@ async def _process_smart_contract_tx(
         session.add(pending_tx)
         session.commit()
 
-    await pending_tx_processor.handle_pending_tx(pending_tx_hash=pending_tx.tx_hash)
+    await pending_tx_processor.handle_pending_tx(pending_tx=pending_tx)
 
     with session_factory() as session:
         pending_txs = session.execute(select(PendingTxDb)).scalars().all()


### PR DESCRIPTION
Problem: the pending TX processor uses a polling loop to determine which transactions must be processed. This leads to some latency when adding a new transaction when there is no currently pending transaction as the task sleeps while waiting for new transactions.

Solution: make the TX processor event-based by using a RabbitMQ exchange
+ message queue. Upon receiving a new transaction from on-chain, we now publish a RabbitMQ message containing the hash of the transaction. The processor can then find the transaction in the DB.

We still store an entry in the pending TXs table for monitoring purposes.