### PR TITLE
Internal: remove test-only method of MessageHandler

### DIFF
--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -9,7 +9,6 @@ from configmanager import Config
 from pydantic import ValidationError
 from sqlalchemy import insert
 
-from aleph.chains.connector import ChainConnector
 from aleph.chains.signature_verifier import SignatureVerifier
 from aleph.db.accessors.files import insert_content_file_pin, upsert_file
 from aleph.db.accessors.messages import (
@@ -34,8 +33,8 @@ from aleph.handlers.content.aggregate import AggregateMessageHandler
 from aleph.handlers.content.content_handler import ContentHandler
 from aleph.handlers.content.forget import ForgetMessageHandler
 from aleph.handlers.content.post import PostMessageHandler
-from aleph.handlers.content.vm import VmMessageHandler
 from aleph.handlers.content.store import StoreMessageHandler
+from aleph.handlers.content.vm import VmMessageHandler
 from aleph.schemas.pending_messages import parse_message
 from aleph.storage import StorageService
 from aleph.toolkit.timestamp import timestamp_to_datetime
@@ -335,9 +334,3 @@ class MessageHandler:
     async def check_permissions(self, session: DbSession, message: MessageDb):
         content_handler = self.get_content_handler(message.type)
         await content_handler.check_permissions(session=session, message=message)
-
-    # TODO: this method is only used in tests. Consider removing it.
-    async def fetch_and_process_one_message_db(self, pending_message: PendingMessageDb):
-        with self.session_factory() as session:
-            _ = await self.process(session=session, pending_message=pending_message)
-            session.commit()

--- a/tests/message_processing/test_process_aggregates.py
+++ b/tests/message_processing/test_process_aggregates.py
@@ -55,9 +55,8 @@ async def test_process_aggregate_first_element(
             )
         ).scalar_one()
 
-    await message_handler.fetch_and_process_one_message_db(
-        pending_message=pending_message
-    )
+        await message_handler.process(session=session, pending_message=pending_message)
+        session.commit()
 
     # Check the aggregate
     content = json.loads(pending_message.item_content)

--- a/tests/message_processing/test_process_stores.py
+++ b/tests/message_processing/test_process_stores.py
@@ -84,7 +84,11 @@ async def test_process_store(
         config=mock_config,
     )
 
-    await message_handler.fetch_and_process_one_message_db(fixture_store_message)
+    with session_factory() as session:
+        await message_handler.process(
+            session=session, pending_message=fixture_store_message
+        )
+        session.commit()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Problem: the `fetch_and_process_one_message_db` method of the message handler is only used in tests and is only a light wrapper around `process()`.

Solution: remove it and replace it by calls to `MessageHandler.process()`.