### PR TITLE
Internal: split message handler

### DIFF
--- a/src/aleph/jobs/fetch_pending_messages.py
+++ b/src/aleph/jobs/fetch_pending_messages.py
@@ -174,7 +174,6 @@ async def fetch_messages_task(config: Config):
     )
     signature_verifier = SignatureVerifier()
     message_handler = MessageHandler(
-        session_factory=session_factory,
         signature_verifier=signature_verifier,
         storage_service=storage_service,
         config=config,

--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -154,7 +154,6 @@ async def fetch_and_process_messages_task(config: Config):
     )
     signature_verifier = SignatureVerifier()
     message_handler = MessageHandler(
-        session_factory=session_factory,
         signature_verifier=signature_verifier,
         storage_service=storage_service,
         config=config,

--- a/src/aleph/network.py
+++ b/src/aleph/network.py
@@ -6,7 +6,7 @@ from aleph_p2p_client import AlephP2PServiceClient
 
 import aleph.toolkit.json as aleph_json
 from aleph.chains.signature_verifier import SignatureVerifier
-from aleph.handlers.message_handler import MessageHandler
+from aleph.handlers.message_handler import MessageHandler, MessagePublisher
 from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
 from aleph.services.ipfs.common import make_ipfs_client
@@ -52,10 +52,8 @@ def listener_tasks(
         ipfs_service=ipfs_service,
         node_cache=node_cache,
     )
-    signature_verifier = SignatureVerifier()
-    message_handler = MessageHandler(
+    message_publisher = MessagePublisher(
         session_factory=session_factory,
-        signature_verifier=signature_verifier,
         storage_service=storage_service,
         config=config,
     )
@@ -65,7 +63,7 @@ def listener_tasks(
         incoming_p2p_channel(
             p2p_client=p2p_client,
             topic=config.aleph.queue_topic.value,
-            message_handler=message_handler,
+            message_publisher=message_publisher,
         )
     ]
     if config.ipfs.enabled.value:
@@ -73,7 +71,7 @@ def listener_tasks(
             incoming_ipfs_channel(
                 ipfs_service=ipfs_service,
                 topic=config.aleph.queue_topic.value,
-                message_handler=message_handler,
+                message_publisher=message_publisher,
             )
         )
     return tasks

--- a/src/aleph/services/ipfs/pubsub.py
+++ b/src/aleph/services/ipfs/pubsub.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 
 # TODO: add type hint for message_processor, it currently causes a cyclical import
 async def incoming_channel(
-    ipfs_service: IpfsService, topic: str, message_handler
+    ipfs_service: IpfsService, topic: str, message_publisher
 ) -> None:
     from aleph.network import decode_pubsub_message
 
@@ -19,7 +19,7 @@ async def incoming_channel(
             async for mvalue in ipfs_service.sub(topic):
                 try:
                     message_dict = await decode_pubsub_message(mvalue["data"])
-                    await message_handler.add_pending_message(
+                    await message_publisher.add_pending_message(
                         message_dict=message_dict, reception_time=utc_now()
                     )
                 except InvalidMessageException:

--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -3,7 +3,7 @@ import logging
 
 from aleph_p2p_client import AlephP2PServiceClient
 
-from aleph.handlers.message_handler import MessageHandler
+from aleph.handlers.message_handler import MessageHandler, MessagePublisher
 from aleph.network import decode_pubsub_message
 from aleph.toolkit.timestamp import utc_now
 from aleph.types.message_status import InvalidMessageException
@@ -12,7 +12,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 async def incoming_channel(
-    p2p_client: AlephP2PServiceClient, topic: str, message_handler: MessageHandler
+    p2p_client: AlephP2PServiceClient, topic: str, message_publisher: MessagePublisher
 ) -> None:
     LOGGER.debug("incoming channel started...")
 
@@ -42,7 +42,7 @@ async def incoming_channel(
                         )
                         continue
 
-                    await message_handler.add_pending_message(
+                    await message_publisher.add_pending_message(
                         message_dict=message_dict, reception_time=utc_now()
                     )
                 except Exception:

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -206,7 +206,6 @@ def message_processor(mocker, mock_config: Config, session_factory: DbSessionFac
     )
     signature_verifier = SignatureVerifier()
     message_handler = MessageHandler(
-        session_factory=session_factory,
         signature_verifier=signature_verifier,
         storage_service=storage_service,
         config=mock_config,

--- a/tests/chains/test_confirmation.py
+++ b/tests/chains/test_confirmation.py
@@ -73,7 +73,6 @@ async def test_confirm_message(
 
     signature_verifier = SignatureVerifier()
     message_handler = MessageHandler(
-        session_factory=session_factory,
         signature_verifier=signature_verifier,
         storage_service=test_storage_service,
         config=mock_config,
@@ -138,7 +137,6 @@ async def test_process_confirmed_message(
 
     signature_verifier = SignatureVerifier()
     message_handler = MessageHandler(
-        session_factory=session_factory,
         signature_verifier=signature_verifier,
         storage_service=test_storage_service,
         config=mock_config,

--- a/tests/message_processing/conftest.py
+++ b/tests/message_processing/conftest.py
@@ -83,7 +83,6 @@ def message_processor(mocker, mock_config: Config, session_factory: DbSessionFac
     )
     signature_verifier = SignatureVerifier()
     message_handler = MessageHandler(
-        session_factory=session_factory,
         signature_verifier=signature_verifier,
         storage_service=storage_service,
         config=mock_config,

--- a/tests/message_processing/test_process_aggregates.py
+++ b/tests/message_processing/test_process_aggregates.py
@@ -38,7 +38,6 @@ async def test_process_aggregate_first_element(
     )
     signature_verifier = SignatureVerifier()
     message_handler = MessageHandler(
-        session_factory=session_factory,
         signature_verifier=signature_verifier,
         storage_service=storage_service,
         config=mock_config,

--- a/tests/message_processing/test_process_pending_txs.py
+++ b/tests/message_processing/test_process_pending_txs.py
@@ -7,12 +7,11 @@ from aleph_message.models import Chain, MessageType, PostContent
 from configmanager import Config
 from sqlalchemy import select
 
-from aleph.chains.signature_verifier import SignatureVerifier
 from aleph.chains.chain_data_service import ChainDataService
 from aleph.db.models import PendingMessageDb, MessageStatusDb
 from aleph.db.models.chains import ChainTxDb
 from aleph.db.models.pending_txs import PendingTxDb
-from aleph.handlers.message_handler import MessageHandler
+from aleph.handlers.message_handler import MessagePublisher
 from aleph.jobs.process_pending_txs import PendingTxProcessor
 from aleph.schemas.chains.tezos_indexer_response import MessageEventPayload
 from aleph.storage import StorageService
@@ -40,13 +39,11 @@ async def test_process_pending_tx_on_chain_protocol(
 ):
     chain_data_service = mocker.AsyncMock()
     chain_data_service.get_tx_messages = get_fixture_chaindata_messages
-    signature_verifier = SignatureVerifier()
     pending_tx_processor = PendingTxProcessor(
         session_factory=session_factory,
         storage_service=test_storage_service,
-        message_handler=MessageHandler(
+        message_publisher=MessagePublisher(
             session_factory=session_factory,
-            signature_verifier=signature_verifier,
             storage_service=test_storage_service,
             config=mock_config,
         ),
@@ -115,13 +112,11 @@ async def _process_smart_contract_tx(
     chain_data_service = ChainDataService(
         session_factory=session_factory, storage_service=mocker.AsyncMock()
     )
-    signature_verifier = SignatureVerifier()
     pending_tx_processor = PendingTxProcessor(
         session_factory=session_factory,
         storage_service=test_storage_service,
-        message_handler=MessageHandler(
+        message_publisher=MessagePublisher(
             session_factory=session_factory,
-            signature_verifier=signature_verifier,
             storage_service=test_storage_service,
             config=mock_config,
         ),

--- a/tests/message_processing/test_process_stores.py
+++ b/tests/message_processing/test_process_stores.py
@@ -78,7 +78,6 @@ async def test_process_store(
     # Disable signature verification
     signature_verifier = mocker.AsyncMock()
     message_handler = MessageHandler(
-        session_factory=session_factory,
         signature_verifier=signature_verifier,
         storage_service=storage_service,
         config=mock_config,

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -109,7 +109,6 @@ async def test_incoming_inline_content(
 
     signature_verifier = SignatureVerifier()
     message_handler = MessageHandler(
-        session_factory=session_factory,
         signature_verifier=signature_verifier,
         storage_service=test_storage_service,
         config=mock_config,


### PR DESCRIPTION
Problem: the message handler implements two functionalities:
1. validate + add pending messages to the DB
2. process pending messages.

The dependencies for each task are starting to diverge so it makes sense to split the message handler.

Solution: put all common functionalities in the `BaseMessageHandler` base class and add a new `MessagePublisher` class that is in charge of validating and adding pending messages to the DB.