### PR TITLE
Fix: warning on failure to close node cache properly

### DIFF
--- a/src/aleph/api_entrypoint.py
+++ b/src/aleph/api_entrypoint.py
@@ -45,6 +45,9 @@ async def configure_aiohttp_app(
         node_cache = NodeCache(
             redis_host=config.redis.host.value, redis_port=config.redis.port.value
         )
+        # TODO: find a way to close the node cache when exiting the API process, not closing it causes
+        #       a warning.
+        await node_cache.open()
 
         ipfs_client = make_ipfs_client(config)
         ipfs_service = IpfsService(ipfs_client=ipfs_client)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,9 +109,11 @@ def mock_config(mocker):
 
 @pytest_asyncio.fixture
 async def node_cache(mock_config: Config):
-    return NodeCache(
+    async with NodeCache(
         redis_host=mock_config.redis.host.value, redis_port=mock_config.redis.port.value
-    )
+    ) as node_cache:
+        yield node_cache
+
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
Problem: a warning occurs in the tests because of an improper cleanup of the Redis client object.

Solution: make the NodeCache class an asynchronous context manager and make it clean up after itself.