### PR TITLE
Revert: downgrade Kubo from 0.23.0 to 0.15.0

### DIFF
--- a/deployment/docker-build/docker-compose.yml
+++ b/deployment/docker-build/docker-compose.yml
@@ -44,7 +44,7 @@ services:
 
   ipfs:
     restart: always
-    image: ipfs/kubo:v0.23.0
+    image: ipfs/kubo:v0.15.0
     ports:
       - "4001:4001"
       - "4001:4001/udp"

--- a/deployment/samples/docker-compose/docker-compose.yml
+++ b/deployment/samples/docker-compose/docker-compose.yml
@@ -102,7 +102,7 @@ services:
 
   ipfs:
     restart: always
-    image: ipfs/kubo:v0.23.0
+    image: ipfs/kubo:v0.15.0
     ports:
       - "4001:4001"
       - "4001:4001/udp"

--- a/deployment/samples/docker-monitoring/docker-compose.yml
+++ b/deployment/samples/docker-monitoring/docker-compose.yml
@@ -104,7 +104,7 @@ services:
 
   ipfs:
     restart: always
-    image: ipfs/kubo:v0.23.0
+    image: ipfs/kubo:v0.15.0
     ports:
       - "4001:4001"
       - "4001:4001/udp"


### PR DESCRIPTION
The upgrade seems to create issues when syncing a new node. This needs to be investigated for a later release.