### PR TITLE
Fix: Revise latest alembic migration to use previous, latest head

### DIFF
--- a/deployment/migrations/versions/0021_e682fc8f9506_fix_vm_costs_view.py
+++ b/deployment/migrations/versions/0021_e682fc8f9506_fix_vm_costs_view.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 revision = 'e682fc8f9506'
-down_revision = '3bf484f2cc95'
+down_revision = '08602db6c78f'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Broke because merging #527 and #528 without rebasing alembic migration files