### PR TITLE
Fix: Old method upload

### DIFF
--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -218,8 +218,8 @@ async def test_storage_add_file(api_client, session_factory: DbSessionFactory):
         api_client,
         session_factory,
         uri=STORAGE_ADD_FILE_URI,
-        file_content=FILE_CONTENT,
-        expected_file_hash=EXPECTED_FILE_SHA256,
+        file_content=b"Hello Aleph.im\n",
+        expected_file_hash="0214e5578f5acb5d36ea62255cbf1157a4bdde7b9612b5db4899b2175e310b6f",
     )
 
 


### PR DESCRIPTION
Problem:
We require the old upload method to remain functional. In some cases, it may crash due to the HTTP client not setting the multipart header for the file_field.

Solution:
If no message is sent, we don't need to know the file size. We can simply read chunks until we reach the maximum size for unauthenticated uploads or end of file.