### PR TITLE
Exclude `stream` payment system from balance check

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     aiohttp==3.8.4
     aioipfs@git+https://github.com/aleph-im/aioipfs.git@d671c79b2871bb4d6c8877ba1e7f3ffbe7d20b71
     alembic==1.8.1
-    aleph-message==0.4.0
+    aleph-message@git+https://github.com/aleph-im/aleph-message@mhh-pay-as-you-go-v1
     aleph-p2p-client@git+https://github.com/aleph-im/p2p-service-client-python@2c04af39c566217f629fd89505ffc3270fba8676
     aleph-pytezos@git+https://github.com/aleph-im/aleph-pytezos.git@32dd1749a4773da494275709060632cbeba9a51b
     asyncpg==0.26.0

--- a/src/aleph/handlers/content/vm.py
+++ b/src/aleph/handlers/content/vm.py
@@ -323,6 +323,9 @@ class VmMessageHandler(ContentHandler):
             if not content.on.persistent:
                 return
 
+        if content.payment.is_stream:
+            return
+
         required_tokens = compute_cost(session=session, content=content)
 
         current_balance = (

--- a/src/aleph/handlers/content/vm.py
+++ b/src/aleph/handlers/content/vm.py
@@ -323,7 +323,7 @@ class VmMessageHandler(ContentHandler):
             if not content.on.persistent:
                 return
 
-        if content.payment.is_stream:
+        if content.payment and content.payment.is_stream:
             return
 
         required_tokens = compute_cost(session=session, content=content)


### PR DESCRIPTION
Problem: Checking the balance on Pay-as-you-go payment method don't allow the message to be processed.

Solution: Exclude stream payment method on balance check system.