### PR TITLE
Fix: Chain writer failed due to `TypeError`

### DIFF
--- a/src/aleph/chains/chain_data_service.py
+++ b/src/aleph/chains/chain_data_service.py
@@ -1,5 +1,5 @@
 import asyncio
-from io import StringIO
+from io import BytesIO
 from typing import Dict, Optional, List, Any, Mapping, Set, cast, Type, Union, Self
 
 import aio_pika.abc
@@ -70,10 +70,10 @@ class ChainDataService:
                 messages=[OnChainMessage.from_orm(message) for message in messages]
             ),
         )
-        archive_content = archive.json()
+        archive_content: bytes = archive.json().encode("utf-8")
 
         ipfs_cid = await self.storage_service.add_file(
-            session=session, fileobject=StringIO(archive_content), engine=ItemType.ipfs
+            session=session, fileobject=BytesIO(archive_content), engine=ItemType.ipfs
         )
         return OffChainSyncEventPayload(
             protocol=ChainSyncProtocol.OFF_CHAIN_SYNC, version=1, content=ipfs_cid

--- a/src/aleph/chains/chain_data_service.py
+++ b/src/aleph/chains/chain_data_service.py
@@ -72,9 +72,11 @@ class ChainDataService:
         )
         archive_content: bytes = archive.json().encode("utf-8")
 
-        ipfs_cid = await self.storage_service.add_file(
-            session=session, fileobject=BytesIO(archive_content), engine=ItemType.ipfs
-        )
+        with BytesIO(archive_content) as archive_file:
+            ipfs_cid = await self.storage_service.add_file(
+                session=session, fileobject=archive_file, engine=ItemType.ipfs
+            )
+
         return OffChainSyncEventPayload(
             protocol=ChainSyncProtocol.OFF_CHAIN_SYNC, version=1, content=ipfs_cid
         )

--- a/src/aleph/chains/chain_data_service.py
+++ b/src/aleph/chains/chain_data_service.py
@@ -73,8 +73,8 @@ class ChainDataService:
         )
         archive_content: bytes = archive.json().encode("utf-8")
 
-        # with BytesIO(archive_content) as archive_file:
-        with NamedTemporaryFile(mode='wb', delete_on_close=False) as archive_file:
+        # Create a file object that is not deleted on .close()
+        with NamedTemporaryFile(mode='wb', delete=False) as archive_file:
             archive_file.write(archive_content)
             archive_file.seek(0)
 

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -162,6 +162,7 @@ class IpfsService:
             data.add_field("path", fileobject)
 
             resp = await session.post(url, data=data)
+            resp.raise_for_status()
             return await resp.json()
 
     async def sub(self, topic: str):

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -2,7 +2,7 @@ import asyncio
 import concurrent
 import json
 import logging
-from typing import IO, Optional, Union, Dict, Self
+from typing import IO, Optional, Union, Dict, Self, BinaryIO
 
 import aiohttp
 import aioipfs
@@ -154,7 +154,7 @@ class IpfsService:
             else:
                 break
 
-    async def add_file(self, fileobject: IO):
+    async def add_file(self, fileobject: BinaryIO):
         url = f"{self.ipfs_client.api_url}add"
 
         async with aiohttp.ClientSession() as session:

--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 from hashlib import sha256
 from io import BytesIO
-from typing import Any, IO, Optional, cast, Final
+from typing import Any, IO, Optional, cast, Final, BinaryIO
 
 from aleph_message.models import ItemType
 
@@ -276,12 +276,13 @@ class StorageService:
         )
 
     async def add_file(
-        self, session: DbSession, fileobject: BytesIO, engine: ItemType = ItemType.ipfs
+        self, session: DbSession, fileobject: BinaryIO, engine: ItemType = ItemType.ipfs
     ) -> str:
         if engine == ItemType.ipfs:
             output = await self.ipfs_service.add_file(fileobject)
             file_hash = output["Hash"]
-            fileobject.seek(0)
+            if fileobject.seekable():
+                fileobject.seek(0)
             file_content = fileobject.read()
 
         elif engine == ItemType.storage:

--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -4,6 +4,7 @@ Basically manages the IPFS storage.
 import asyncio
 import logging
 from hashlib import sha256
+from io import BytesIO
 from typing import Any, IO, Optional, cast, Final
 
 from aleph_message.models import ItemType
@@ -275,7 +276,7 @@ class StorageService:
         )
 
     async def add_file(
-        self, session: DbSession, fileobject: IO, engine: ItemType = ItemType.ipfs
+        self, session: DbSession, fileobject: BytesIO, engine: ItemType = ItemType.ipfs
     ) -> str:
         if engine == ItemType.ipfs:
             output = await self.ipfs_service.add_file(fileobject)


### PR DESCRIPTION
The Chain writer task for Chain.ETH failed with the following stacktrace:

```
aleph-pyaleph-1 | 2024-01-29 14:09:32 [ERROR] aleph.chains.connector: Chain writer task for Chain.ETH failed, relaunching in 10 seconds.
aleph-pyaleph-1 | Traceback (most recent call last):
aleph-pyaleph-1 |   File "/opt/pyaleph/src/aleph/chains/connector.py", line 63, in chain_writer_task
aleph-pyaleph-1 |     await connector.packer(config)
aleph-pyaleph-1 |   File "/opt/pyaleph/src/aleph/chains/ethereum.py", line 351, in packer
aleph-pyaleph-1 |     await self.chain_data_service.prepare_sync_event_payload(
aleph-pyaleph-1 |   File "/opt/pyaleph/src/aleph/chains/chain_data_service.py", line 75, in prepare_sync_event_payload
aleph-pyaleph-1 |     ipfs_cid = await self.storage_service.add_file(
aleph-pyaleph-1 |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
aleph-pyaleph-1 |   File "/opt/pyaleph/src/aleph/storage.py", line 293, in add_file
aleph-pyaleph-1 |     await self.add_file_content_to_local_storage(
aleph-pyaleph-1 |   File "/opt/pyaleph/src/aleph/storage.py", line 269, in add_file_content_to_local_storage
aleph-pyaleph-1 |     await self.storage_engine.write(filename=file_hash, content=file_content)
aleph-pyaleph-1 |   File "/opt/pyaleph/src/aleph/services/storage/fileystem_engine.py", line 26, in write
aleph-pyaleph-1 |     file_path.write_bytes(content)
aleph-pyaleph-1 |   File "/usr/lib/python3.11/pathlib.py", line 1066, in write_bytes
aleph-pyaleph-1 |     view = memoryview(data)
aleph-pyaleph-1 |            ^^^^^^^^^^^^^^^^
aleph-pyaleph-1 | TypeError: memoryview: a bytes-like object is required, not 'str'
```

It appears that a `StringIO` was passed to `aleph.storage.add_file(...)`, resulting in `file_content` being of type `str`, where the underlying function `aleph.services.storage.fileystem_engine.FileSystemStorageEngine.write` expects the type `bytes`.

Solution:
1. Encode the `archive_content` in UTF-8 before adding it in the storage service.
2. Modify the type annotations accordingly
3. Modify the signature of `aleph.storage.StorageService.add_file` to expect `BytesIO` instead of any `IO` type.
