### PR TITLE
Fix: Chain writer failed due to `TypeError`

### DIFF
--- a/src/aleph/chains/chain_data_service.py
+++ b/src/aleph/chains/chain_data_service.py
@@ -70,10 +70,10 @@ class ChainDataService:
                 messages=[OnChainMessage.from_orm(message) for message in messages]
             ),
         )
-        archive_content = archive.json()
+        archive_content: bytes = archive.json().encode("utf-8")
 
         ipfs_cid = await self.storage_service.add_file(
-            session=session, fileobject=StringIO(archive_content), engine=ItemType.ipfs
+            session=session, file_content=archive_content, engine=ItemType.ipfs
         )
         return OffChainSyncEventPayload(
             protocol=ChainSyncProtocol.OFF_CHAIN_SYNC, version=1, content=ipfs_cid

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -154,12 +154,12 @@ class IpfsService:
             else:
                 break
 
-    async def add_file(self, fileobject: IO):
+    async def add_file(self, file_content: bytes):
         url = f"{self.ipfs_client.api_url}add"
 
         async with aiohttp.ClientSession() as session:
             data = aiohttp.FormData()
-            data.add_field("path", fileobject)
+            data.add_field("path", file_content)
 
             resp = await session.post(url, data=data)
             resp.raise_for_status()

--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -275,16 +275,13 @@ class StorageService:
         )
 
     async def add_file(
-        self, session: DbSession, fileobject: IO, engine: ItemType = ItemType.ipfs
+        self, session: DbSession, file_content: bytes, engine: ItemType = ItemType.ipfs
     ) -> str:
         if engine == ItemType.ipfs:
-            output = await self.ipfs_service.add_file(fileobject)
+            output = await self.ipfs_service.add_file(file_content)
             file_hash = output["Hash"]
-            fileobject.seek(0)
-            file_content = fileobject.read()
 
         elif engine == ItemType.storage:
-            file_content = fileobject.read()
             file_hash = sha256(file_content).hexdigest()
 
         else:

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -104,7 +104,7 @@ async def add_file(
 
     post_response = await api_client.post(uri, data=form_data)
     response_text = await post_response.text()
-    assert post_response.status == 200, await response_text
+    assert post_response.status == 200, response_text
     post_response_json = await post_response.json()
     assert post_response_json["status"] == "success"
     file_hash = post_response_json["hash"]

--- a/tests/chains/test_chain_data_service.py
+++ b/tests/chains/test_chain_data_service.py
@@ -42,9 +42,9 @@ async def test_prepare_sync_event_payload(mocker):
     ]
 
     async def mock_add_file(
-        session: DbSession, fileobject: IO, engine: ItemType = ItemType.ipfs
+        session: DbSession, file_content: bytes, engine: ItemType = ItemType.ipfs
     ) -> str:
-        content = fileobject.read()
+        content = file_content
         archive = OnChainSyncEventPayload.parse_raw(content)
 
         assert archive.version == 1


### PR DESCRIPTION
The Chain writer task for Chain.ETH failed with the following stacktrace:

```
aleph-pyaleph-1 | 2024-01-29 14:09:32 [ERROR] aleph.chains.connector: Chain writer task for Chain.ETH failed, relaunching in 10 seconds.
aleph-pyaleph-1 | Traceback (most recent call last):
aleph-pyaleph-1 |   File "/opt/pyaleph/src/aleph/chains/connector.py", line 63, in chain_writer_task
aleph-pyaleph-1 |     await connector.packer(config)
aleph-pyaleph-1 |   File "/opt/pyaleph/src/aleph/chains/ethereum.py", line 351, in packer
aleph-pyaleph-1 |     await self.chain_data_service.prepare_sync_event_payload(
aleph-pyaleph-1 |   File "/opt/pyaleph/src/aleph/chains/chain_data_service.py", line 75, in prepare_sync_event_payload
aleph-pyaleph-1 |     ipfs_cid = await self.storage_service.add_file(
aleph-pyaleph-1 |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
aleph-pyaleph-1 |   File "/opt/pyaleph/src/aleph/storage.py", line 293, in add_file
aleph-pyaleph-1 |     await self.add_file_content_to_local_storage(
aleph-pyaleph-1 |   File "/opt/pyaleph/src/aleph/storage.py", line 269, in add_file_content_to_local_storage
aleph-pyaleph-1 |     await self.storage_engine.write(filename=file_hash, content=file_content)
aleph-pyaleph-1 |   File "/opt/pyaleph/src/aleph/services/storage/fileystem_engine.py", line 26, in write
aleph-pyaleph-1 |     file_path.write_bytes(content)
aleph-pyaleph-1 |   File "/usr/lib/python3.11/pathlib.py", line 1066, in write_bytes
aleph-pyaleph-1 |     view = memoryview(data)
aleph-pyaleph-1 |            ^^^^^^^^^^^^^^^^
aleph-pyaleph-1 | TypeError: memoryview: a bytes-like object is required, not 'str'
```

It appears that a `StringIO` was passed to `aleph.storage.add_file(...)`, resulting in `file_content` being of type `str`, where the underlying function `aleph.services.storage.fileystem_engine.FileSystemStorageEngine.write` expects the type `bytes`.

Solution:
1. Encode the `archive_content` in UTF-8 before adding it in the storage service.
2. Modify the type annotations accordingly
3. Modify the signature of `aleph.storage.StorageService.add_file` to expect `BytesIO` instead of any `IO` type.

