### PR TITLE
Allow developers to use nix-shell to get started

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -1,0 +1,18 @@
+  on:
+    push:
+      branches:
+        - '*'
+
+  jobs:
+    nix-shell:
+        runs-on: ubuntu-22.04
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Set up Nix
+              uses: cachix/install-nix-action@v13
+              with:
+                nix_path: nixpkgs=channel:nixos-23.11
+
+            - name: Run tests
+              run: nix-shell --run "pytest"

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -8,7 +8,7 @@
       strategy:
         matrix:
           os: [ macos-latest, ubuntu-latest ]
-          channel: [ nixos-23.11 nixpkgs-23.11-darwin ]
+          channel: [ nixos-23.11, nixpkgs-23.11-darwin ]
       runs-on: ${{ matrix.os }}
 
       steps:

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -11,13 +11,13 @@
       runs-on: ${{ matrix.os }}
 
       steps:
-          - uses: actions/checkout@v2
+          - uses: actions/checkout@v4
             with:
               # Fetch the whole history for all tags and branches (required for aleph.__version__)
               fetch-depth: 0
 
           - name: Set up Nix
-            uses: cachix/install-nix-action@v13
+            uses: cachix/install-nix-action@v25
             with:
               nix_path: nixpkgs=channel:nixos-23.11
 

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -8,7 +8,6 @@
       strategy:
         matrix:
           os: [ macos-latest, ubuntu-latest ]
-          channel: [ nixos-23.11, nixpkgs-23.11-darwin ]
       runs-on: ${{ matrix.os }}
 
       steps:
@@ -23,7 +22,8 @@
           - name: Set up Nix
             uses: cachix/install-nix-action@v25
             with:
-              nix_path: nixpkgs=channel:${{ matrix.channel }}
+              # Use channel nixos-23.11 for Linux and nixpkgs-23.11-darwin for macOS
+              nix_path: nixpkgs=channel:${{ matrix.os == 'macos-latest' && 'nixpkgs-23.11-darwin' || 'nixos-23.11' }}
 
           - name: Run tests
             run: nix-shell --run "pytest"

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -1,29 +1,31 @@
-  on:
-    push:
-      branches:
-        - '*'
+name: Test nix-shell
 
-  jobs:
-    nix-shell:
-      strategy:
-        matrix:
-          os: [ macos-latest, ubuntu-latest ]
-      runs-on: ${{ matrix.os }}
+on:
+  push:
+    branches:
+      - '*'
 
-      steps:
-          - uses: actions/checkout@v4
-            with:
-              # Fetch the whole history for all tags and branches (required for aleph.__version__)
-              fetch-depth: 0
+jobs:
+  nix-shell:
+    strategy:
+      matrix:
+        os: [ macos-latest, ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
 
-          - name: Setup empty config file
-            run: touch config.yml
+    steps:
+        - uses: actions/checkout@v4
+          with:
+            # Fetch the whole history for all tags and branches (required for aleph.__version__)
+            fetch-depth: 0
 
-          - name: Set up Nix
-            uses: cachix/install-nix-action@v25
-            with:
-              # Use channel nixos-23.11 for Linux and nixpkgs-23.11-darwin for macOS
-              nix_path: nixpkgs=channel:${{ matrix.os == 'macos-latest' && 'nixpkgs-23.11-darwin' || 'nixos-23.11' }}
+        - name: Setup empty config file
+          run: touch config.yml
 
-          - name: Run tests
-            run: nix-shell --run "pytest"
+        - name: Set up Nix
+          uses: cachix/install-nix-action@v25
+          with:
+            # Use channel nixos-23.11 for Linux and nixpkgs-23.11-darwin for macOS
+            nix_path: nixpkgs=channel:${{ matrix.os == 'macos-latest' && 'nixpkgs-23.11-darwin' || 'nixos-23.11' }}
+
+        - name: Run tests
+          run: nix-shell --run "pytest"

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -8,6 +8,9 @@
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v2
+              with:
+                # Fetch the whole history for all tags and branches (required for aleph.__version__)
+                fetch-depth: 0
 
             - name: Set up Nix
               uses: cachix/install-nix-action@v13

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -8,6 +8,7 @@
       strategy:
         matrix:
           os: [ macos-latest, ubuntu-latest ]
+          channel: [ nixos-23.11 nixpkgs-23.11-darwin ]
       runs-on: ${{ matrix.os }}
 
       steps:
@@ -16,10 +17,13 @@
               # Fetch the whole history for all tags and branches (required for aleph.__version__)
               fetch-depth: 0
 
+          - name: Setup empty config file
+            run: touch config.yml
+
           - name: Set up Nix
             uses: cachix/install-nix-action@v25
             with:
-              nix_path: nixpkgs=channel:nixos-23.11
+              nix_path: nixpkgs=channel:${{ matrix.channel }}
 
           - name: Run tests
             run: nix-shell --run "pytest"

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -5,17 +5,21 @@
 
   jobs:
     nix-shell:
-        runs-on: ubuntu-22.04
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                # Fetch the whole history for all tags and branches (required for aleph.__version__)
-                fetch-depth: 0
+      strategy:
+        matrix:
+          os: [ macos-latest, ubuntu-latest ]
+      runs-on: ${{ matrix.os }}
 
-            - name: Set up Nix
-              uses: cachix/install-nix-action@v13
-              with:
-                nix_path: nixpkgs=channel:nixos-23.11
+      steps:
+          - uses: actions/checkout@v2
+            with:
+              # Fetch the whole history for all tags and branches (required for aleph.__version__)
+              fetch-depth: 0
 
-            - name: Run tests
-              run: nix-shell --run "pytest"
+          - name: Set up Nix
+            uses: cachix/install-nix-action@v13
+            with:
+              nix_path: nixpkgs=channel:nixos-23.11
+
+          - name: Run tests
+            run: nix-shell --run "pytest"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ pip install -e .[testing,docs]
 
 You're ready to go!
 
+### Developer setup using Nix
+
+We started to add Nix as an easy way to setup a development environment.
+This is still a work in progress and not all dependencies are covered yet.
+
+To use it, you need to have Nix installed on your system. Then you can run:
+
+```bash
+nix-shell
+```
+This will provide you with a shell with PostgreSQL, Redis, and IPFS running.
+
 ## Software used
 
 The Aleph CCN is written in Python and requires Python v3.8+. It will not work with older versions of Python.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You're ready to go!
 We started to add Nix as an easy way to setup a development environment.
 This is still a work in progress and not all dependencies are covered yet.
 
-To use it, you need to have Nix installed on your system. Then you can run:
+To use it, you need to [have Nix installed on your system](https://nixos.org/download.html). Then you can run:
 
 ```bash
 nix-shell

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,7 @@ pkgs.mkShell {
 
     pkgs.python311Packages.secp256k1
     pkgs.python311Packages.fastecdsa
+    pkgs.python311Packages.greenlet
   ];
 
   shellHook = ''

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,39 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = [ pkgs.postgresql pkgs.redis ];
+
+  shellHook = ''
+    echo "Setting up PostgreSQL environment..."
+    export PGDATA=$(mktemp -d)
+    PG_SOCKET_DIR=$(mktemp -d)
+    echo "Initializing database..."
+    initdb $PGDATA
+
+    echo "Starting PostgreSQL with custom socket directory..."
+    pg_ctl -D $PGDATA -o "-k $PG_SOCKET_DIR" -l logfile start
+
+    # Wait a bit for the server to start
+    sleep 1
+
+    # Create the 'aleph' role and a database
+    createuser -h $PG_SOCKET_DIR aleph
+    createdb -h $PG_SOCKET_DIR aleph -O aleph
+
+    # Create a temporary directory for Redis
+    export REDIS_DATA_DIR=$(mktemp -d)
+    redis-server --daemonize yes --dir $REDIS_DATA_DIR --bind 127.0.0.1 --port 6379
+    echo "Redis server started. Data directory is $REDIS_DATA_DIR"
+
+    # Trap the EXIT signal to ensure PostgreSQL is stopped when exiting the shell
+    trap 'echo "Stopping PostgreSQL..."; pg_ctl -D "$PGDATA" stop; echo "Stopping Redis..."; redis-cli -p 6379 shutdown' EXIT
+
+    echo
+    echo "PostgreSQL started. Data directory is $PGDATA, Socket directory is $PG_SOCKET_DIR"
+    echo "Redis started. Data directory is $REDIS_DATA_DIR"
+    echo "Use 'psql -h $PG_SOCKET_DIR' to connect to the database."
+    echo "Use 'redis-cli -p 6379' to connect to the Redis server."
+    echo "To stop PostgreSQL: 'pg_ctl -D $PGDATA stop'"
+    echo "To manually stop Redis: 'redis-cli -p 6379 shutdown'"
+  '';
+}


### PR DESCRIPTION
Solution: Provide a `shell.nix` file so developers can just run `nix-shell` to start temporary PostgreSQL and Redis servers.

The exit signal of the shell is `trap`-ed in order to automatically stop the services on exit.



https://github.com/aleph-im/pyaleph/assets/404665/bb013aec-ca54-4aa7-afad-2febbe1f0f09


