### PR TITLE
Fix sortBy/sortOrder on Message/Post queries

### DIFF
--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -57,17 +57,21 @@ DEFAULT_WS_HISTORY = 10
 class BaseMessageQueryParams(BaseModel):
     sort_by: SortBy = Field(
         default=SortBy.TIME,
+        alias="sortBy",
         description="Key to use to sort the messages. "
         "'time' uses the message time field. "
         "'tx-time' uses the first on-chain confirmation time.",
     )
     sort_order: SortOrder = Field(
         default=SortOrder.DESCENDING,
+        alias="sortOrder",
         description="Order in which messages should be listed: "
         "-1 means most recent messages first, 1 means older messages first.",
     )
     message_type: Optional[MessageType] = Field(
-        default=None, alias="msgType", description="Message type. Deprecated: use msgTypes instead"
+        default=None,
+        alias="msgType",
+        description="Message type. Deprecated: use msgTypes instead",
     )
     message_types: Optional[List[MessageType]] = Field(
         default=None, alias="msgTypes", description="Accepted message types."

--- a/src/aleph/web/controllers/posts.py
+++ b/src/aleph/web/controllers/posts.py
@@ -70,12 +70,14 @@ class PostQueryParams(BaseModel):
     )
     sort_by: SortBy = Field(
         default=SortBy.TIME,
+        alias="sortBy",
         description="Key to use to sort the posts. "
         "'time' uses the post creation time field. "
         "'tx-time' uses the first on-chain confirmation time.",
     )
     sort_order: SortOrder = Field(
         default=SortOrder.DESCENDING,
+        alias="sortOrder",
         description="Order in which messages should be listed: "
         "-1 means most recent messages first, 1 means older messages first.",
     )


### PR DESCRIPTION
# Found issues:
- Linked to [issue 95 on SDK](https://github.com/aleph-im/aleph-sdk-python/issues/95) -> Solved here: [PR](https://github.com/aleph-im/aleph-sdk-python/pull/104)
- No sorting when queries request it, even after changing SDK codebase: 

# Proposed solution:
- Added missing aliases on BaseMessageQueryParams & PostQueryParams

@hoh 