### PR TITLE
Add aiohttp-apispec auto generation of OpenAPI docs & specs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,12 +35,13 @@ setup_requires =
 install_requires =
     aio_pika==9.1.3
     aiocache==0.12.2
+    aiohttp==3.8.4
+    aiohttp-apispec==2.2.3
     aiohttp-cors==0.7.0
     aiohttp-jinja2==1.5
-    aiohttp==3.8.4
     aioipfs@git+https://github.com/aleph-im/aioipfs.git@d671c79b2871bb4d6c8877ba1e7f3ffbe7d20b71
     alembic==1.12.1
-    aleph-message==0.4.2
+    aleph-message==0.4.4
     aleph-p2p-client@git+https://github.com/aleph-im/p2p-service-client-python@2c04af39c566217f629fd89505ffc3270fba8676
     aleph-pytezos@git+https://github.com/aleph-im/aleph-pytezos.git@32dd1749a4773da494275709060632cbeba9a51b
     asyncpg==0.28.0

--- a/src/aleph/web/__init__.py
+++ b/src/aleph/web/__init__.py
@@ -7,6 +7,9 @@ import aiohttp_jinja2
 import jinja2
 import pkg_resources
 from aiohttp import web
+from aiohttp_apispec import (
+    setup_aiohttp_apispec,
+)
 
 from aleph.web.controllers.routes import register_routes
 
@@ -59,5 +62,14 @@ def create_aiohttp_app() -> web.Application:
     register_routes(app)
 
     init_cors(app)
+
+    setup_aiohttp_apispec(
+        app=app,
+        title="Aleph",
+        version="v0",
+        url="/api/docs/json",
+        swagger_path="/api/docs",
+        swagger_ui_static_path="/api/docs/ui",
+    )
 
     return app


### PR DESCRIPTION
Docs should be available under `/v0/api/docs`, the OpenAPI spec as JSON in `/v0/api/docs/json`, as far as I understand.

Couldn't test it out myself, as I'm having trouble connecting the rabbitMQ p2p service with Pyaleph while starting it locally.