### PR TITLE
Fix: Upload Endpoints

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,8 @@ install_requires =
     urllib3==2.0.7
     uvloop==0.19.0
     web3==6.11.2
+    aiofiles==23.2.1
+    types-aiofiles==23.2.0.20240403
 
 dependency_links =
     https://github.com/aleph-im/py-libp2p/tarball/0.1.4-1-use-set#egg=libp2p

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -148,10 +148,10 @@ class UploadedFile:
 
 
 class MultipartUploadedFile(UploadedFile):
-    def __init__(self, file_field: BodyPartReader, max_size: int, file_hash: str = None):
+    def __init__(self, file_field: BodyPartReader, max_size: int):
         self.file_field = file_field
         self.max_size = max_size
-        self.file_hash = file_hash
+        self._hash = None
         try:
             self._temp_file = tempfile.NamedTemporaryFile(delete=False)
             self._file_content = bytearray()
@@ -189,7 +189,7 @@ class MultipartUploadedFile(UploadedFile):
             self._temp_file.write(chunk)
             self._file_content.extend(chunk)
             hash_sha256.update(chunk)
-        self.file_hash = hash_sha256.hexdigest()
+        self._hash = hash_sha256.hexdigest()
         self._temp_file.seek(0)
 
     @property
@@ -206,7 +206,7 @@ class MultipartUploadedFile(UploadedFile):
 
     @property
     def get_hash(self) -> str:
-        return self.file_hash
+        return self._hash
 
 
 class RawUploadedFile(UploadedFile):

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -121,9 +121,9 @@ class StorageMetadata(pydantic.BaseModel):
 class UploadedFile:
     def __init__(self, max_size: int):
         self.max_size = max_size
+        self.hash = ""
+        self.size = 0
         self._hasher = hashlib.sha256()
-        self._hash = ""
-        self._size = 0
         self._temp_file_path = None
         self._temp_file = None
 
@@ -164,19 +164,15 @@ class UploadedFile:
                 self._hasher.update(chunk)  # Update file hash while reading the file
                 await f.write(chunk)
 
-            self._hash = self._hasher.hexdigest()
-            self._size = total_read
+            self.hash = self._hasher.hexdigest()
+            self.size = total_read
             await f.seek(0)
 
     async def _read_chunks(self, chunk_size):
         raise NotImplementedError("Subclasses must implement this method")
 
-    @property
-    def size(self) -> int:
-        return self._size
-
     def get_hash(self) -> str:
-        return self._hash
+        return self._hasher.hexdigest()
 
 
 class MultipartUploadedFile(UploadedFile):

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -338,7 +338,7 @@ async def storage_add_file(request: web.Request):
                 signature_verifier=signature_verifier,
                 storage_service=storage_service,
                 message=message,
-                file=uploaded_file,
+                uploaded_file=uploaded_file,
                 grace_period=grace_period,
             )
             session.commit()

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -246,7 +246,8 @@ async def _check_and_add_file(
     elif isinstance(file_content, str):
         file_bytes = file_content.encode("utf-8")
     else:
-        raise web.HTTPUnprocessableEntity(reason="Invalid file content type")
+        raise web.HTTPUnprocessableEntity(reason=f"Invalid file content type, got {type(file_content)}")
+
     await storage_service.add_file_content_to_local_storage(
         session=session,
         file_content=file_bytes,

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -256,7 +256,7 @@ async def _check_and_add_file(
     await uploaded_file.cleanup()
 
     # For files uploaded without authenticated upload, add a grace period of 1 day.
-    if not message_content:
+    if message_content is None:
         add_grace_period_for_file(
             session=session, file_hash=file_hash, hours=grace_period
         )

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -210,10 +210,10 @@ async def _check_and_add_file(
         signature_verifier: SignatureVerifier,
         storage_service: StorageService,
         message: Optional[PendingStoreMessage],
-        file: UploadedFile,
+        uploaded_file: UploadedFile,
         grace_period: int,
 ) -> str:
-    file_hash = file.get_hash()
+    file_hash = uploaded_file.get_hash()
     # Perform authentication and balance checks
     if message:
         await _verify_message_signature(
@@ -233,12 +233,12 @@ async def _check_and_add_file(
         await _verify_user_balance(
             session=session,
             address=message_content.address,
-            size=file.size,
+            size=uploaded_file.size,
         )
     else:
         message_content = None
 
-    temp_file = await file.open_temp_file()
+    temp_file = await uploaded_file.open_temp_file()
     file_content = await temp_file.read()
 
     if isinstance(file_content, bytes):
@@ -252,7 +252,7 @@ async def _check_and_add_file(
         file_content=file_bytes,
         file_hash=file_hash
     )
-    await file.cleanup()
+    await uploaded_file.cleanup()
 
     # For files uploaded without authenticated upload, add a grace period of 1 day.
     if not message_content:

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -296,6 +296,8 @@ async def storage_add_file(request: web.Request):
             max_size=max_upload_size,
         )
     else:
+        if not isinstance(file_field, (bytes, str)):
+            raise web.HTTPUnprocessableEntity(reason="Invalid file content type.")
         uploaded_file = RawUploadedFile(file_field)
 
     status_code = 200

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -134,13 +134,13 @@ class UploadedFile:
         return self._temp_file
 
     async def close_temp_file(self):
-        if self._temp_file:
+        if self._temp_file is not None:
             await self._temp_file.close()
             self._temp_file = None
 
     async def cleanup(self):
         await self.close_temp_file()
-        if self._temp_file_path:
+        if self._temp_file_path and os.path.exists(self._temp_file_path):
             os.remove(self._temp_file_path)
             self._temp_file_path = None
 

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -148,6 +148,16 @@ class UploadedFile:
         total_read = 0
         chunk_size = 8192
 
+        # From aiofiles changelog:
+        # On Python 3.12, aiofiles.tempfile.NamedTemporaryFile now accepts a
+        # delete_on_close argument, just like the stdlib version.
+        # On Python 3.12, aiofiles.tempfile.NamedTemporaryFile no longer
+        # exposes a delete attribute, just like the stdlib version.
+        #
+        # so we might need to modify this code for python 3.12 at some point
+
+        # it would be ideal to uses aiofiles.tempfile.NamedTemporaryFile but it
+        # doesn't seems to be able to support our current workflow
         temp_file = tempfile.NamedTemporaryFile('w+b', delete=False)
         self._temp_file_path = temp_file.name
         temp_file.close()

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -136,7 +136,6 @@ async def add_file(
 ):
     form_data = aiohttp.FormData()
     form_data.add_field("file", file_content)
-    print(file_content)
 
     post_response = await api_client.post(uri, data=form_data)
     response_text = await post_response.text()


### PR DESCRIPTION
[Issue](https://github.com/aleph-im/pyaleph/issues/564)


Issue Description:
   The current file upload endpoint reads the entire file before checking if it exceeds the maximum allowed size. The size limits are 25 MB for unauthenticated uploads (MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE) and 1000 MB for authenticated uploads (MAX_UPLOAD_FILE_SIZE).

Proposed Solutions:
- Read the file in chunks and check if the size exceeds the maximum allowed size.
- Use a temporary file to handle the data, which helps avoid using too much memory.