### PR TITLE
doc(README): we don't use mongodb anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This will provide you with a shell with PostgreSQL, Redis, and IPFS running.
 
 The Aleph CCN is written in Python and requires Python v3.8+. It will not work with older versions of Python.
 
-It also relies on [MongoDB](https://www.mongodb.com/) and [IPFS](https://ipfs.io/).
+It also relies on [IPFS](https://ipfs.io/).
 
 ## License
 


### PR DESCRIPTION
There are still a lot of other MongoDB references still present that we probably want to get ride off but they are in the documentation and I think this need a whole rewrite?

```
❯ rg -i mongo
CHANGELOG.rst
135:- Decommissioned the support for RocksDB. The only supported storage engine is now MongoDB.

deployment/samples/docker-monitoring/sample-config.yml
20:mongodb:
21:  uri: "mongodb://mongodb:27017"

docs/figures/architecture-stack.pdf
679:(MongoDB) Tj

docs/figures/PyAleph architecture.graphml
487:						<y:Label.Text>MongoDB</y:Label.Text>

docs/guides/install.rst
132:Download the Docker Compose file that defines how to run PyAleph, MongoDB and IPFS together.
176:    * - nfuser_mongodb_1
177:      - docker-entrypoint.sh mongo ...
212:Check PyAleph data via MongoDB
215:MongoDB message counts
219:    docker exec -ti --user mongodb debian_mongodb_1 bash
220:    $ mongo

tests/api/test_list_messages.py
29:    like MongoDB object IDs.

src/aleph/db/accessors/chains.py
112:    #       replace it with the range/multirange operations of PostgreSQL 14+ once the MongoDB

deployment/docker-build/README.md
25:To run the local dev environment, you will need to set the P2P daemon, IPFS and MongoDB hosts to `127.0.0.1`.
44:This will instantiate the services for MongoDB, IPFS and the P2P daemon.
```