### PR TITLE
a lot of fixes and improvement for running local tests using nix-shell because it was just broken

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -18,9 +18,6 @@ jobs:
             # Fetch the whole history for all tags and branches (required for aleph.__version__)
             fetch-depth: 0
 
-        - name: Setup empty config file
-          run: touch config.yml
-
         - name: Set up Nix
           uses: cachix/install-nix-action@v25
           with:

--- a/deployment/migrations/env.py
+++ b/deployment/migrations/env.py
@@ -27,7 +27,7 @@ target_metadata = Base.metadata
 # ... etc.
 
 
-def get_db_url():
+def get_db_url() -> str:
     cli_args = context.get_x_argument(as_dictionary=True)
     db_url = cli_args.get("db_url")
 
@@ -35,14 +35,22 @@ def get_db_url():
         return db_url
 
     config = get_config()
-    default_config_file = Path.cwd() / "config.yml"
-    config_file = cli_args.get("config_file") or default_config_file
-    if config_file.exists():
-        user_config = config_file.read_text()
+
+    config_file_path: Path
+
+    # intermediat variable to please mypy
+    cli_args_config_file = cli_args.get("config_file")
+    if cli_args_config_file:
+        config_file_path = Path(cli_args_config_file)
+    else:
+        config_file_path = Path.cwd() / "config.yml"
+
+    if config_file_path.exists():
+        user_config_raw: str = config_file_path.read_text()
 
         # Little trick to allow empty config files
-        if user_config:
-            config.yaml.loads(user_config)
+        if user_config_raw:
+            config.yaml.loads(user_config_raw)
 
     return make_db_url(driver="psycopg2", config=config)
 

--- a/deployment/migrations/env.py
+++ b/deployment/migrations/env.py
@@ -37,12 +37,12 @@ def get_db_url():
     config = get_config()
     default_config_file = Path.cwd() / "config.yml"
     config_file = cli_args.get("config_file") or default_config_file
-    with config_file.open() as f:
-        user_config = f.read()
+    if config_file.exists():
+        user_config = config_file.read_text()
 
-    # Little trick to allow empty config files
-    if user_config:
-        config.yaml.loads(user_config)
+        # Little trick to allow empty config files
+        if user_config:
+            config.yaml.loads(user_config)
 
     return make_db_url(driver="psycopg2", config=config)
 

--- a/shell.nix
+++ b/shell.nix
@@ -46,14 +46,6 @@ pkgs.mkShell {
     ipfs daemon &
     echo "IPFS Kubo started. Data directory is $IPFS_PATH"
 
-    echo
-    echo "PostgreSQL started. Data directory is $PGDATA, Socket directory is $PG_SOCKET_DIR"
-    echo "Redis started. Data directory is $REDIS_DATA_DIR"
-    echo "Use 'psql -h $PG_SOCKET_DIR' to connect to the database."
-    echo "Use 'redis-cli -p 6379' to connect to the Redis server."
-    echo "To stop PostgreSQL: 'pg_ctl -D $PGDATA stop'"
-    echo "To manually stop Redis: 'redis-cli -p 6379 shutdown'"
-
     # Trap the EXIT signal to stop services when exiting the shell
     trap 'echo "Stopping PostgreSQL..."; pg_ctl -D "$PGDATA" stop; echo "Stopping Redis..."; redis-cli -p 6379 shutdown; echo "Stopping IPFS Kubo..."; ipfs shutdown; deactivate' EXIT
 
@@ -69,5 +61,16 @@ pkgs.mkShell {
     source venv/bin/activate
 
     [ -e config.yml ] || touch config.yml
+
+    echo
+    echo "PostgreSQL started. Data directory is $PGDATA, Socket directory is $PG_SOCKET_DIR" | sed 's/./=/g'
+    echo "PostgreSQL started. Data directory is $PGDATA, Socket directory is $PG_SOCKET_DIR"
+    echo "Redis started. Data directory is $REDIS_DATA_DIR"
+    echo "Use 'psql -h $PG_SOCKET_DIR' to connect to the database."
+    echo "Use 'redis-cli -p 6379' to connect to the Redis server."
+    echo "To stop PostgreSQL: 'pg_ctl -D $PGDATA stop'"
+    echo "To manually stop Redis: 'redis-cli -p 6379 shutdown'"
+    echo "PostgreSQL started. Data directory is $PGDATA, Socket directory is $PG_SOCKET_DIR" | sed 's/./=/g'
+    echo
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -67,5 +67,7 @@ pkgs.mkShell {
 
     # Activate the virtual environment
     source venv/bin/activate
+
+    [ -e config.yml ] || touch config.yml
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,8 @@
 
 pkgs.mkShell {
   buildInputs = [
+    pkgs.glibcLocales
+
     pkgs.postgresql
     pkgs.redis
     pkgs.kubo

--- a/shell.nix
+++ b/shell.nix
@@ -62,7 +62,8 @@ pkgs.mkShell {
 
     [ -e config.yml ] || touch config.yml
 
-    echo
+    # bold
+    echo -e "\e[1m"
     echo "PostgreSQL started. Data directory is $PGDATA, Socket directory is $PG_SOCKET_DIR" | sed 's/./=/g'
     echo "PostgreSQL started. Data directory is $PGDATA, Socket directory is $PG_SOCKET_DIR"
     echo "Redis started. Data directory is $REDIS_DATA_DIR"
@@ -71,6 +72,6 @@ pkgs.mkShell {
     echo "To stop PostgreSQL: 'pg_ctl -D $PGDATA stop'"
     echo "To manually stop Redis: 'redis-cli -p 6379 shutdown'"
     echo "PostgreSQL started. Data directory is $PGDATA, Socket directory is $PG_SOCKET_DIR" | sed 's/./=/g'
-    echo
+    echo -e "\033[0m"
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -19,6 +19,7 @@ pkgs.mkShell {
   ];
 
   shellHook = ''
+    set -eu
     echo "Setting up PostgreSQL environment..."
     export PGDATA=$(mktemp -d)
     PG_SOCKET_DIR=$(mktemp -d)
@@ -73,5 +74,6 @@ pkgs.mkShell {
     echo "To manually stop Redis: 'redis-cli -p 6379 shutdown'"
     echo "PostgreSQL started. Data directory is $PGDATA, Socket directory is $PG_SOCKET_DIR" | sed 's/./=/g'
     echo -e "\033[0m"
+    set +eu
   '';
 }

--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -34,7 +34,6 @@ from aleph.services import p2p
 from aleph.services.cache.materialized_views import refresh_cache_materialized_views
 from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
-from aleph.services.ipfs.common import make_ipfs_client
 from aleph.services.keys import generate_keypair, save_keys
 from aleph.services.storage.fileystem_engine import FileSystemStorageEngine
 from aleph.services.storage.garbage_collector import (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,8 +101,7 @@ def mock_config(mocker):
     config_file = Path.cwd() / "config.yml"
 
     if config_file.exists():
-        with config_file.open() as f:
-            user_config = f.read()
+        user_config = config_file.read_text()
 
         # Little trick to allow empty config files
         if user_config:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,16 @@ def session_factory(mock_config):
 def mock_config(mocker):
     config = Config(aleph.config.get_defaults())
 
+    config_file = Path.cwd() / "config.yml"
+
+    if config_file.exists():
+        with config_file.open() as f:
+            user_config = f.read()
+
+        # Little trick to allow empty config files
+        if user_config:
+            config.yaml.loads(user_config)
+
     # The postgres/redis hosts use Docker network names in the default config.
     # We always use localhost for tests.
     config.postgres.host.value = "127.0.0.1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,17 +95,17 @@ def session_factory(mock_config):
 
 
 @pytest.fixture
-def mock_config(mocker):
-    config = Config(aleph.config.get_defaults())
+def mock_config(mocker) -> Config:
+    config: Config = Config(aleph.config.get_defaults())
 
-    config_file = Path.cwd() / "config.yml"
+    config_file_path: Path = Path.cwd() / "config.yml"
 
-    if config_file.exists():
-        user_config = config_file.read_text()
+    if config_file_path.exists():
+        user_config_raw: str = config_file_path.read_text()
 
         # Little trick to allow empty config files
-        if user_config:
-            config.yaml.loads(user_config)
+        if user_config_raw:
+            config.yaml.loads(user_config_raw)
 
     # The postgres/redis hosts use Docker network names in the default config.
     # We always use localhost for tests.


### PR DESCRIPTION
List of modifications and improvements: 

* add pkgs.glibcLocales because otherwise locales aren't handles and postgresql fails
* ensure that we have at least a default config.yml otherwise tests won't launch
* display information information at the end of the output log of nix-shell and in bold otherwise it's hidden in the logs
* wrap shellHooks in `set -eu` otherwise you can have error, nix won't complain and you'll end up in a broken nix-shell not understanding why
* make tests fixtures take into account config.yml otherwise it's simply ignored and only the default are used
* launch postgresql on port 5434 because users can have postgresql on 5432 (or even 5433) and nix-shell will just fails 
* and remove an unused import