### PR TITLE
chore(nix-shell/fix): ensure at least a default config.yml exist otherwise tests won't run

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -65,5 +65,7 @@ pkgs.mkShell {
 
     # Activate the virtual environment
     source venv/bin/activate
+
+    [ -e config.yml ] || touch config.yml
   '';
 }


### PR DESCRIPTION
This also need the PR #570 to be merged, otherwise just running:

```shell
nix-shell --run "pytest"
```

Simply won't work.

I'll also add a PR to handle the situation where postgresql port can colide
with an existing locally running postgresql database because this can often be
the case.
