### PR TITLE
Allow to connect postgresql in a passwordless mode and with a unix socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/*
 .cache/*
 .*.swp
 */.ipynb_checkpoints/*
+.mypy_cache/*
 
 # data folder
 data*

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/*
 .*.swp
 */.ipynb_checkpoints/*
 .mypy_cache/*
+logfile
 
 # data folder
 data*

--- a/src/aleph/db/connection.py
+++ b/src/aleph/db/connection.py
@@ -28,9 +28,20 @@ def make_db_url(
     password = config.postgres.password.value
     database = config.postgres.database.value
 
-    connection_string = (
-        f"postgresql+{driver}://{user}:{password}@{host}:{port}/{database}"
+    connection_string = f"postgresql+{driver}://{user}:"
+
+    if password is not None:
+        connection_string += f"{password}"
+
+    connection_string += "@"
+
+    if host is not None:
+        connection_string += f"{host}:{port}"
+
+    connection_string += (
+        f"/{database}"
     )
+
     if application_name:
         connection_string += f"?application_name={application_name}"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,17 +100,17 @@ def mock_config(mocker) -> Config:
 
     config_file_path: Path = Path.cwd() / "config.yml"
 
+    # The postgres/redis hosts use Docker network names in the default config.
+    # We always use localhost for tests.
+    config.postgres.host.value = "127.0.0.1"
+    config.redis.host.value = "127.0.0.1"
+
     if config_file_path.exists():
         user_config_raw: str = config_file_path.read_text()
 
         # Little trick to allow empty config files
         if user_config_raw:
             config.yaml.loads(user_config_raw)
-
-    # The postgres/redis hosts use Docker network names in the default config.
-    # We always use localhost for tests.
-    config.postgres.host.value = "127.0.0.1"
-    config.redis.host.value = "127.0.0.1"
 
     # To test handle_new_storage
     config.storage.store_files.value = True


### PR DESCRIPTION
Before that, it was only possible to connect pyaleph to postgresql using an ip/domain and only with a password.

I've also fix a bug in the tests that was overwriting some configuration.

This PR has been extracted from #574 

This PR can be "rebase and merge" since all commits are standalone.