### PR TITLE
doc: remove references to MongoDB

### DIFF
--- a/deployment/docker-build/README.md
+++ b/deployment/docker-build/README.md
@@ -22,7 +22,7 @@ which you will want to customize for your system.
 
 Change the Ethereum API URL to the endpoint you want the CCN to use.
 
-To run the local dev environment, you will need to set the P2P daemon, IPFS and MongoDB hosts to `127.0.0.1`.
+To run the local dev environment, you will need to set the P2P daemon and IPFS hosts to `127.0.0.1`.
 
 ### Generate your node's private key
 
@@ -41,7 +41,7 @@ Run the Docker Compose file to start all the required services:
 docker-compose -f deployment/docker-build/docker-compose.yml up -d
 ```
 
-This will instantiate the services for MongoDB, IPFS and the P2P daemon.
+This will instantiate the services for IPFS and the P2P daemon.
 
 You can now start the Core Channel Node locally using the `pyaleph` command or by running the `aleph.commands` module,
 for example from PyCharm.

--- a/deployment/samples/docker-monitoring/sample-config.yml
+++ b/deployment/samples/docker-monitoring/sample-config.yml
@@ -17,10 +17,6 @@ ethereum:
   token_contract: "0x27702a26126e0B3702af63Ee09aC4d1A084EF628"
   token_start_height: 10939074
 
-mongodb:
-  uri: "mongodb://mongodb:27017"
-  database: aleph
-
 storage:
   store_files: true
   engine: filesystem

--- a/docs/guides/install.rst
+++ b/docs/guides/install.rst
@@ -129,7 +129,7 @@ To check that the generation of the keys succeeded, check the content of your ke
 3. Run the node with Docker Compose
 ===================================
 
-Download the Docker Compose file that defines how to run PyAleph, MongoDB and IPFS together.
+Download the Docker Compose file that defines how to run PyAleph and IPFS together.
 
 .. parsed-literal::
 
@@ -173,11 +173,6 @@ You should see the following three containers with a State of "Up":
       - Up
       - 0.0.0.0:4001->4001/tcp, 0.0.0.0:4001->4001/udp, 5001/tcp, 8080/tcp, 8081/tcp
 
-    * - nfuser_mongodb_1
-      - docker-entrypoint.sh mongo ...
-      - Up
-      - 27017/tcp
-
     * - nfuser_pyaleph_1
       - pyaleph --config /opt/pyal ...
       - Up
@@ -208,24 +203,6 @@ IPFS Web UI: http://127.0.0.1:5001/webui
     This web interface is only accessible on localhost in the default Docker Compose configuration.
     The API running on port 5001 gives complete control over the IPFS daemon without authentication.
     Never expose this port on the Internet!
-
-Check PyAleph data via MongoDB
-------------------------------
-
-MongoDB message counts
-
-.. code-block:: bash
-
-    docker exec -ti --user mongodb debian_mongodb_1 bash
-    $ mongo
-    > use aleph
-    > show collections
-    > db.messages.count()
-    1468900
-    > db.pending_messages.count()
-    63
-    > db.pending_messages.count()
-    4
 
 5. Register your node
 =====================

--- a/tests/api/test_list_messages.py
+++ b/tests/api/test_list_messages.py
@@ -25,8 +25,7 @@ MESSAGES_PAGE_URI = "/api/v0/messages/page/{page}.json"
 
 def check_message_fields(messages: Iterable[Dict]):
     """
-    Basic checks on fields. For example, check that we do not expose internal data
-    like MongoDB object IDs.
+    Basic checks on fields. For example, check that we do not expose internal data.
     """
     for message in messages:
         assert "_id" not in message


### PR DESCRIPTION
We still have reference to MongoDB here which is not that great and professional https://pyaleph.readthedocs.io/en/latest/guides/install.html since it's linked here https://account.aleph.im/earn/ccn/