### PR TITLE
Fix: nix-shell raised 'pop_var_context'

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -60,9 +60,6 @@ pkgs.mkShell {
     # Install the required Python packages
     ./venv/bin/pip install -e .\[testing\]
 
-    # Activate the virtual environment
-    source venv/bin/activate
-
     # If config.yml does not exist, create it with the port specified in this shell. 
     [ -e config.yml ] || echo -e "postgres:\n  port: $PG_PORT" > config.yml
 
@@ -78,5 +75,8 @@ pkgs.mkShell {
     echo "PostgreSQL started. Data directory is $PGDATA, Socket directory is $PG_SOCKET_DIR" | sed 's/./=/g'
     echo -e "\033[0m"
     set +eu
+
+    # Activate the virtual environment
+    source venv/bin/activate
   '';
 }


### PR DESCRIPTION
Using nix-shell with the latest version of Nixpkgs raised the following
error:

```
bash: pop_var_context: head of shell_variables not a function context
```

Changing the order of the instructions fixed this.
