### PR TITLE
Solve issue with instance messages and `requirements` empty field

### DIFF
--- a/src/aleph/handlers/content/vm.py
+++ b/src/aleph/handlers/content/vm.py
@@ -122,7 +122,11 @@ def _map_content_to_db_model(item_hash, content):
         if content.environment.trusted_execution is not None:
             trusted_execution_policy = content.environment.trusted_execution.policy
             trusted_execution_firmware = content.environment.trusted_execution.firmware
-        if hasattr(content, "requirements") and hasattr(content.requirements.node, 'node_hash'):
+        if (
+                hasattr(content, "requirements")
+                and hasattr(content.requirements, "node")
+                and hasattr(content.requirements.node, "node_hash")
+        ):
             node_hash = content.requirements.node.node_hash
 
     return db_cls(


### PR DESCRIPTION
Problem: When a user send an instance message with the field `requirements` to null, the message is rejected.

Solution: Check if the `requirements` field have something relevant inside.