### PR TITLE
fix: mock.called_once doesn't exist

### DIFF
--- a/tests/api/test_p2p.py
+++ b/tests/api/test_p2p.py
@@ -97,4 +97,4 @@ async def test_post_message_sync(ccn_api_client, mocker):
     assert pub_status["failed"] == []
 
     # Check that we cleaned up the queue
-    assert mocked_queue.delete.called_once
+    assert mocked_queue.delete.assert_called_once()


### PR DESCRIPTION
This is to debug the mess in #602 and #574 