### PR TITLE
Solve large int errors

### DIFF
--- a/src/aleph/storage.py
+++ b/src/aleph/storage.py
@@ -2,6 +2,7 @@
 Basically manages the IPFS storage.
 """
 import asyncio
+import json
 import logging
 from hashlib import sha256
 from typing import Any, IO, Optional, cast, Final
@@ -80,6 +81,10 @@ class StorageService:
         try:
             content = aleph_json.loads(item_content)
         except aleph_json.DecodeError as e:
+            error_msg = f"Can't decode JSON: {e}"
+            LOGGER.warning(error_msg)
+            raise InvalidContent(error_msg)
+        except json.decoder.JSONDecodeError as e:
             error_msg = f"Can't decode JSON: {e}"
             LOGGER.warning(error_msg)
             raise InvalidContent(error_msg)

--- a/src/aleph/toolkit/json.py
+++ b/src/aleph/toolkit/json.py
@@ -28,7 +28,7 @@ def load(fp: IO) -> Any:
 def loads(s: Union[bytes, str]) -> Any:
     try:
         return orjson.loads(s)
-    except:
+    except TypeError as e:
         return json.loads(s)
 
 
@@ -39,5 +39,5 @@ def dump(fp: IO, obj: Any) -> None:
 def dumps(obj: Any) -> bytes:
     try:
         return orjson.dumps(obj)
-    except:
+    except TypeError as e:
         return json.dumps(obj).encode()

--- a/src/aleph/toolkit/json.py
+++ b/src/aleph/toolkit/json.py
@@ -28,7 +28,7 @@ def load(fp: IO) -> Any:
 def loads(s: Union[bytes, str]) -> Any:
     try:
         return orjson.loads(s)
-    except TypeError as e:
+    except:
         return json.loads(s)
 
 
@@ -36,8 +36,8 @@ def dump(fp: IO, obj: Any) -> None:
     raise NotImplementedError("orjson does not provide dump")
 
 
-def dumps(obj: Any) -> SerializedJson:
+def dumps(obj: Any) -> bytes:
     try:
         return orjson.dumps(obj)
-    except TypeError as e:
-        return bytes(json.dumps(obj))
+    except:
+        return json.dumps(obj).encode()

--- a/src/aleph/toolkit/json.py
+++ b/src/aleph/toolkit/json.py
@@ -2,7 +2,7 @@
 An abstraction layer for JSON serialization/deserialization.
 Makes swapping between JSON implementations easier.
 """
-
+import json
 
 import orjson
 from typing import Any, IO, Union
@@ -26,7 +26,10 @@ def load(fp: IO) -> Any:
 
 
 def loads(s: Union[bytes, str]) -> Any:
-    return orjson.loads(s)
+    try:
+        return orjson.loads(s)
+    except TypeError as e:
+        return json.loads(s)
 
 
 def dump(fp: IO, obj: Any) -> None:
@@ -34,4 +37,7 @@ def dump(fp: IO, obj: Any) -> None:
 
 
 def dumps(obj: Any) -> SerializedJson:
-    return orjson.dumps(obj)
+    try:
+        return orjson.dumps(obj)
+    except TypeError as e:
+        return bytes(json.dumps(obj))

--- a/tests/toolkit/test_json.py
+++ b/tests/toolkit/test_json.py
@@ -30,7 +30,7 @@ def test_reject_nans():
     """
 
     serialized_json = '{"1": 1, "2": 2, "3": NaN}'
-    with pytest.raises(aleph_json.DecodeError):
+    with pytest.raises(json.decoder.JSONDecodeError):
         _ = aleph_json.loads(serialized_json)
 
 


### PR DESCRIPTION
Problem: On large integer values `orjson` library shows an `TypeError:Integer exceeds 64-bit range` error.

## Self proofreading checklist

- [X] Is my code clear enough and well documented
- [X] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

In case that `orjson` cannot handle the issue and raise a `TypeError` issue, we handle it running a normal `json.XXX` method.

## How to test

Try to run queries with large int numbers.
