### PR TITLE
Feature: details and chain filter on balance endpoint

### DIFF
--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -43,12 +43,14 @@ def get_total_balance(
 
 
 def get_total_detailed_balance(
-    session: DbSession, address: str, chain: Optional[str] = None
+    session: DbSession, address: str, chain: Optional[str] = None, include_dapps: bool = False
 ) -> tuple[Decimal, Dict[str, Decimal]]:
     if chain is not None:
         query = (
             select(func.sum(AlephBalanceDb.balance))
-            .where((AlephBalanceDb.address == address) & (AlephBalanceDb.chain == chain))
+            .where((AlephBalanceDb.address == address) & (AlephBalanceDb.chain == chain) &
+                ((AlephBalanceDb.dapp.is_(None)) if not include_dapps else True)
+               )
             .group_by(AlephBalanceDb.address)
         )
 
@@ -57,7 +59,9 @@ def get_total_detailed_balance(
 
     query = (
         select(AlephBalanceDb.chain, func.sum(AlephBalanceDb.balance).label("balance"))
-        .where(AlephBalanceDb.address == address)
+        .where((AlephBalanceDb.address == address) &
+            ((AlephBalanceDb.dapp.is_(None)) if not include_dapps else True)
+        )
         .group_by(AlephBalanceDb.chain)
     )
 
@@ -65,7 +69,9 @@ def get_total_detailed_balance(
 
     query = (
         select(func.sum(AlephBalanceDb.balance))
-        .where(AlephBalanceDb.address == address)
+        .where((AlephBalanceDb.address == address) &
+            ((AlephBalanceDb.dapp.is_(None)) if not include_dapps else True)
+        )
         .group_by(AlephBalanceDb.address)
     )
 

--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -43,14 +43,19 @@ def get_total_balance(
 
 
 def get_total_detailed_balance(
-    session: DbSession, address: str, chain: Optional[str] = None, include_dapps: bool = False
+    session: DbSession,
+    address: str,
+    chain: Optional[str] = None,
+    include_dapps: bool = False,
 ) -> tuple[Decimal, Dict[str, Decimal]]:
     if chain is not None:
         query = (
             select(func.sum(AlephBalanceDb.balance))
-            .where((AlephBalanceDb.address == address) & (AlephBalanceDb.chain == chain) &
-                ((AlephBalanceDb.dapp.is_(None)) if not include_dapps else True)
-               )
+            .where(
+                (AlephBalanceDb.address == address)
+                & (AlephBalanceDb.chain == chain)
+                & ((AlephBalanceDb.dapp.is_(None)) if not include_dapps else True)
+            )
             .group_by(AlephBalanceDb.address)
         )
 
@@ -59,18 +64,23 @@ def get_total_detailed_balance(
 
     query = (
         select(AlephBalanceDb.chain, func.sum(AlephBalanceDb.balance).label("balance"))
-        .where((AlephBalanceDb.address == address) &
-            ((AlephBalanceDb.dapp.is_(None)) if not include_dapps else True)
+        .where(
+            (AlephBalanceDb.address == address)
+            & ((AlephBalanceDb.dapp.is_(None)) if not include_dapps else True)
         )
         .group_by(AlephBalanceDb.chain)
     )
 
-    balances_by_chain = {row.chain: row.balance or Decimal(0) for row in session.execute(query).fetchall()}
+    balances_by_chain = {
+        row.chain: row.balance or Decimal(0)
+        for row in session.execute(query).fetchall()
+    }
 
     query = (
         select(func.sum(AlephBalanceDb.balance))
-        .where((AlephBalanceDb.address == address) &
-            ((AlephBalanceDb.dapp.is_(None)) if not include_dapps else True)
+        .where(
+            (AlephBalanceDb.address == address)
+            & ((AlephBalanceDb.dapp.is_(None)) if not include_dapps else True)
         )
         .group_by(AlephBalanceDb.address)
     )

--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -4,10 +4,10 @@ from typing import Dict, Mapping, Optional, Sequence
 
 from aleph_message.models import Chain
 from sqlalchemy import func, select
+from sqlalchemy.sql import Select
 
 from aleph.db.models import AlephBalanceDb
 from aleph.types.db_session import DbSession
-from aleph.types.sort_order import SortOrder
 
 
 def get_balance_by_chain(
@@ -28,8 +28,7 @@ def make_balances_by_chain_query(
     page: int = 1,
     pagination: int = 100,
     min_balance: int = 0,
-    sort_order: SortOrder = SortOrder.DESCENDING,
-) -> Dict[str, Decimal]:
+) -> Select:
     query = select(AlephBalanceDb.address, AlephBalanceDb.balance, AlephBalanceDb.chain)
 
     if chains:
@@ -38,11 +37,6 @@ def make_balances_by_chain_query(
     if min_balance > 0:
         query = query.filter(AlephBalanceDb.balance >= min_balance)
 
-    if sort_order == SortOrder.DESCENDING:
-        query = query.order_by(AlephBalanceDb.balance.desc())
-    else:
-        query = query.order_by(AlephBalanceDb.balance.asc())
-
     query = query.offset((page - 1) * pagination)
 
     # If pagination == 0, return all matching results
@@ -50,9 +44,6 @@ def make_balances_by_chain_query(
         query = query.limit(pagination)
 
     return query
-
-    # result = session.execute(query).all()
-    # return {row.address: row.balance for row in result}
 
 
 def get_balances_by_chain(session: DbSession, **kwargs):

--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -30,7 +30,7 @@ def make_balances_by_chain_query(
     min_balance: int = 0,
     sort_order: SortOrder = SortOrder.DESCENDING,
 ) -> Dict[str, Decimal]:
-    query = select(AlephBalanceDb.address, AlephBalanceDb.balance)
+    query = select(AlephBalanceDb.address, AlephBalanceDb.balance, AlephBalanceDb.chain)
 
     if chains:
         query = query.where(AlephBalanceDb.chain.in_(chains))

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -1,12 +1,19 @@
 import datetime as dt
 from decimal import Decimal
-from typing import List
+from typing import List, Optional
 
+from aleph_message.models import Chain
 from pydantic import BaseModel, Field
 
 from aleph.types.files import FileType
 from aleph.types.sort_order import SortOrder
 from aleph.web.controllers.utils import DEFAULT_PAGE
+
+
+class GetAccountQueryParams(BaseModel):
+    chain: Optional[Chain] = Field(
+        default=None, description="Get Balance on a specific EVM Chain"
+    )
 
 
 class GetAccountBalanceResponse(BaseModel):

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -19,7 +19,7 @@ class GetAccountQueryParams(BaseModel):
 class GetAccountBalanceResponse(BaseModel):
     address: str
     balance: Decimal
-    details: Optional[Dict[Chain, Decimal]]
+    details: Optional[Dict[str, Decimal]]
     locked_amount: Decimal
 
 

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -1,6 +1,6 @@
 import datetime as dt
 from decimal import Decimal
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from aleph_message.models import Chain
 from pydantic import BaseModel, Field
@@ -19,6 +19,7 @@ class GetAccountQueryParams(BaseModel):
 class GetAccountBalanceResponse(BaseModel):
     address: str
     balance: Decimal
+    details: Optional[Dict[Chain, Decimal]]
     locked_amount: Decimal
 
 

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -51,11 +51,6 @@ class GetBalancesChainsQueryParams(BaseModel):
     page: int = Field(
         default=DEFAULT_PAGE, ge=1, description="Offset in pages. Starts at 1."
     )
-    sort_order: SortOrder = Field(
-        default=SortOrder.DESCENDING,
-        description="Order in which files should be listed: "
-        "-1 means most recent messages first, 1 means older messages first.",
-    )
     min_balance: int = Field(default=0, ge=1, description="Minimum Balance needed")
 
     @validator("chains", pre=True)

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -71,6 +71,7 @@ class AddressBalanceResponse(BaseModel):
 
     address: str
     balance: str
+    chain: Chain
 
 
 class GetAccountFilesResponseItem(BaseModel):

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -3,11 +3,11 @@ from decimal import Decimal
 from typing import Dict, List, Optional
 
 from aleph_message.models import Chain
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
 from aleph.types.files import FileType
 from aleph.types.sort_order import SortOrder
-from aleph.web.controllers.utils import DEFAULT_PAGE
+from aleph.web.controllers.utils import DEFAULT_PAGE, LIST_FIELD_SEPARATOR
 
 
 class GetAccountQueryParams(BaseModel):
@@ -40,6 +40,9 @@ class GetAccountFilesQueryParams(BaseModel):
 
 
 class GetBalancesChainsQueryParams(BaseModel):
+    chains: Optional[List[Chain]] = Field(
+        default=None, description="Accepted values for the 'chain' field."
+    )
     pagination: int = Field(
         default=100,
         ge=0,
@@ -55,14 +58,19 @@ class GetBalancesChainsQueryParams(BaseModel):
     )
     min_balance: int = Field(default=0, ge=1, description="Minimum Balance needed")
 
+    @validator("chains", pre=True)
+    def split_str(cls, v):
+        if isinstance(v, str):
+            return v.split(LIST_FIELD_SEPARATOR)
+        return v
+
 
 class AddressBalanceResponse(BaseModel):
+    class Config:
+        orm_mode = True
+
     address: str
     balance: str
-
-
-class GetChainsBalanceResponse(BaseModel):
-    balances: List[AddressBalanceResponse]
 
 
 class GetAccountFilesResponseItem(BaseModel):

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -39,6 +39,32 @@ class GetAccountFilesQueryParams(BaseModel):
     )
 
 
+class GetBalancesChainsQueryParams(BaseModel):
+    pagination: int = Field(
+        default=100,
+        ge=0,
+        description="Maximum number of files to return. Specifying 0 removes this limit.",
+    )
+    page: int = Field(
+        default=DEFAULT_PAGE, ge=1, description="Offset in pages. Starts at 1."
+    )
+    sort_order: SortOrder = Field(
+        default=SortOrder.DESCENDING,
+        description="Order in which files should be listed: "
+        "-1 means most recent messages first, 1 means older messages first.",
+    )
+    min_balance: int = Field(default=0, ge=1, description="Minimum Balance needed")
+
+
+class AddressBalanceResponse(BaseModel):
+    address: str
+    balance: str
+
+
+class GetChainsBalanceResponse(BaseModel):
+    balances: List[AddressBalanceResponse]
+
+
 class GetAccountFilesResponseItem(BaseModel):
     file_hash: str
     size: int

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -1,5 +1,4 @@
 import json
-from decimal import Decimal
 from itertools import groupby
 from typing import Any, Dict, List
 

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -70,7 +70,9 @@ async def get_account_balance(request: web.Request):
 
     session_factory: DbSessionFactory = get_session_factory_from_request(request)
     with session_factory() as session:
-        balance, details = get_total_detailed_balance(session=session, address=address, chain=query_params.chain)
+        balance, details = get_total_detailed_balance(
+            session=session, address=address, chain=query_params.chain
+        )
         total_cost = get_total_cost_for_address(session=session, address=address)
     return web.json_response(
         text=GetAccountBalanceResponse(

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -71,13 +71,7 @@ async def get_account_balance(request: web.Request):
 
     session_factory: DbSessionFactory = get_session_factory_from_request(request)
     with session_factory() as session:
-        balance_detail = get_total_detailed_balance(session=session, address=address)
-        if query_params.chain is None:
-            balance = Decimal(sum(balance_detail.values()))
-            details = balance_detail
-        else:
-            balance = balance_detail.get(query_params.chain, Decimal(0))
-            details = {}
+        balance, details = get_total_detailed_balance(session=session, address=address, chain=query_params.chain)
         total_cost = get_total_cost_for_address(session=session, address=address)
     return web.json_response(
         text=GetAccountBalanceResponse(

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -120,7 +120,7 @@ async def get_chain_balances(request: web.Request) -> web.Response:
         )
 
     address_balances = [
-        AddressBalanceResponse(address=address, balance=balance)
+        AddressBalanceResponse(address=address, balance=str(balance))
         for address, balance in balances.items()
     ]
 

--- a/src/aleph/web/controllers/routes.py
+++ b/src/aleph/web/controllers/routes.py
@@ -70,7 +70,7 @@ def register_routes(app: web.Application):
     app.router.add_get(
         "/api/v0/addresses/{address}/balance", accounts.get_account_balance
     )
-    app.router.add_get("/api/v0/balances/{chain}", accounts.get_chain_balances)
+    app.router.add_get("/api/v0/balances", accounts.get_chain_balances)
     app.router.add_get("/api/v0/addresses/{address}/files", accounts.get_account_files)
 
     app.router.add_post("/api/v0/ipfs/add_json", storage.add_ipfs_json_controller)

--- a/src/aleph/web/controllers/routes.py
+++ b/src/aleph/web/controllers/routes.py
@@ -70,6 +70,7 @@ def register_routes(app: web.Application):
     app.router.add_get(
         "/api/v0/addresses/{address}/balance", accounts.get_account_balance
     )
+    app.router.add_get("/api/v0/balance/{chain}", accounts.get_chain_balances)
     app.router.add_get("/api/v0/addresses/{address}/files", accounts.get_account_files)
 
     app.router.add_post("/api/v0/ipfs/add_json", storage.add_ipfs_json_controller)

--- a/src/aleph/web/controllers/routes.py
+++ b/src/aleph/web/controllers/routes.py
@@ -70,7 +70,7 @@ def register_routes(app: web.Application):
     app.router.add_get(
         "/api/v0/addresses/{address}/balance", accounts.get_account_balance
     )
-    app.router.add_get("/api/v0/balance/{chain}", accounts.get_chain_balances)
+    app.router.add_get("/api/v0/balances/{chain}", accounts.get_chain_balances)
     app.router.add_get("/api/v0/addresses/{address}/files", accounts.get_account_files)
 
     app.router.add_post("/api/v0/ipfs/add_json", storage.add_ipfs_json_controller)

--- a/tests/api/test_balance.py
+++ b/tests/api/test_balance.py
@@ -27,6 +27,9 @@ async def test_get_balance(
     assert data["balance"] == user_balance.balance
     assert data["locked_amount"] == 2002.4666666666667
 
+    details = data["details"]
+    assert details["ETH"] == user_balance.balance
+
 
 @pytest.mark.asyncio
 async def test_get_balance_with_chain(
@@ -68,6 +71,11 @@ async def test_get_balance_with_chain(
     assert total_data["balance"] == total_expected_balance
     assert total_data["locked_amount"] == expected_locked_amount
 
+    details = total_data["details"]
+    assert details is not None
+    assert details["ETH"] == user_balance_eth_avax.balance
+    assert details["AVAX"] == user_balance_eth_avax.balance
+
 
 @pytest.mark.asyncio
 async def test_get_balance_with_no_balance(
@@ -87,3 +95,5 @@ async def test_get_balance_with_no_balance(
     data = await response.json()
     assert data["balance"] == 0
     assert data["locked_amount"] == 0
+    details = data["details"]
+    assert not details

--- a/tests/api/test_balance.py
+++ b/tests/api/test_balance.py
@@ -1,4 +1,5 @@
 import pytest
+from aleph_message.models import Chain
 
 from aleph.db.models import AlephBalanceDb
 from aleph.jobs.process_pending_messages import PendingMessageProcessor
@@ -25,3 +26,64 @@ async def test_get_balance(
     data = await response.json()
     assert data["balance"] == user_balance.balance
     assert data["locked_amount"] == 2002.4666666666667
+
+
+@pytest.mark.asyncio
+async def test_get_balance_with_chain(
+    ccn_api_client,
+    message_processor: PendingMessageProcessor,
+    instance_message_with_volumes_in_db,
+    fixture_instance_message,
+    user_balance_eth_avax: AlephBalanceDb,
+):
+    pipeline = message_processor.make_pipeline()
+    _ = [message async for message in pipeline]
+
+    assert fixture_instance_message.item_content
+    expected_locked_amount = 2002.4666666666667
+    chain = Chain.AVAX.value
+    # Test Avax
+    avax_response = await ccn_api_client.get(f"{MESSAGES_URI}?chain={chain}")
+
+    assert avax_response.status == 200, await avax_response.text()
+    avax_data = await avax_response.json()
+    avax_expected_balance = user_balance_eth_avax.balance
+    assert avax_data["balance"] == avax_expected_balance
+    assert avax_data["locked_amount"] == expected_locked_amount
+
+    # Verify ETH Value
+    chain = Chain.ETH.value
+    eth_response = await ccn_api_client.get(f"{MESSAGES_URI}?chain={chain}")
+    assert eth_response.status == 200, await eth_response.text()
+    eth_data = await eth_response.json()
+    eth_expected_balance = user_balance_eth_avax.balance
+    assert eth_data["balance"] == eth_expected_balance
+    assert eth_data["locked_amount"] == expected_locked_amount
+
+    # Verify All Chain
+    total_response = await ccn_api_client.get(f"{MESSAGES_URI}")
+    assert total_response.status == 200, await total_response.text()
+    total_data = await total_response.json()
+    total_expected_balance = user_balance_eth_avax.balance * 2
+    assert total_data["balance"] == total_expected_balance
+    assert total_data["locked_amount"] == expected_locked_amount
+
+
+@pytest.mark.asyncio
+async def test_get_balance_with_no_balance(
+    ccn_api_client,
+):
+    response = await ccn_api_client.get(f"{MESSAGES_URI}")
+
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert data["balance"] == 0
+    assert data["locked_amount"] == 0
+
+    # Test Eth Case
+    response = await ccn_api_client.get(f"{MESSAGES_URI}?chain{Chain.ETH.value}")
+
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert data["balance"] == 0
+    assert data["locked_amount"] == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -352,3 +352,27 @@ def user_balance(session_factory: DbSessionFactory) -> AlephBalanceDb:
         session.add(balance)
         session.commit()
     return balance
+
+
+@pytest.fixture
+def user_balance_eth_avax(session_factory: DbSessionFactory) -> AlephBalanceDb:
+    balance_eth = AlephBalanceDb(
+        address="0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
+        chain=Chain.ETH,
+        balance=Decimal(22_192),
+        eth_height=0,
+    )
+
+    balance_avax = AlephBalanceDb(
+        address="0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
+        chain=Chain.AVAX,
+        balance=Decimal(22_192),
+        eth_height=0,
+    )
+
+    with session_factory() as session:
+        session.add(balance_eth)
+        session.add(balance_avax)
+
+        session.commit()
+    return balance_avax


### PR DESCRIPTION
With new chain on aleph, as a user i can't get details of my balance.
The goal of the PR is to allow user filter balance base on chain and get the details.

This PR also introduce an new endpoint : `/api/v0/balances`

Related Clickup or Jira tickets : ALEPH-232

## Self proofreading checklist

- [x] Is my code clear enough and well documented
- [x] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
The /balances do same things as before but
This PR add 2 things
- A new field `details` exemple : `"details": {"AVAX": 447.1290583984875, "ETH": 
4002.070110401869}`
```
http://localhost:4024/api/v0/addresses/0xd463495a6FEaC9921FD0C3a595B81E7B2C02B57d/balance

{"address": "0xd463495a6FEaC9921FD0C3a595B81E7B2C02B57d", "balance": 4784.379935463618, "details": {"AVAX": 447.1290583984875, "BASE": 335.1807666632614, "ETH": 4002.070110401869}, "locked_amount": 0}
```

- A new filter `chain` takings a Chain like (ETH / AVAX / BASE)
```
http://localhost:4024/api/v0/addresses/0xd463495a6FEaC9921FD0C3a595B81E7B2C02B57d/balance?chain=ETH

{"address": "0xd463495a6FEaC9921FD0C3a595B81E7B2C02B57d", "balance": 4002.070110401869, "details": {}, "locked_amount": 0}
```

Fix: /balances when the address didn't has token it's would return ERROR (not found it db cause no balance)
If address not found in db balance is now returning `0`
```
{"address": "0xd463495a6FEaC9921FD0C3a595B81E7B2C02B57", "balance": 0, "details": {}, "locked_amount": 0}
```

- New endpoint to retreive all balances
```
# all balances
http://localhost:4024/api/v0/balances
# filter + pagination
http://localhost:4024/api/v0/balances?chains=SOL,ETH&page=1&pagination=0

# return
{"balances": [{"address": "Dtq5z8dfeCs....YyFKh2cJqh", "balance": "90524.341429", "chain": "SOL"}, {"address": "xfbd5Re5TEA....fhYyxhBCXWyXX", "balance": "90524.341429", "chain": "SOL"}], "pagination_per_page": 2, "pagination_page": 1, "pagination_total": 15336, "pagination_item": "balances"}
```

## How to test
```
http://localhost:4024/api/v0/addresses/0xd463495a6FEaC9921FD0C3a595B81E7B2C02B57d/balance?chain=ETH
```

## Notes

The locked_amount is is for the whole address, we would need some refactor on the view for it or new endpoints.