### PR TITLE
Implement messages `content` path

### DIFF
--- a/src/aleph/web/controllers/routes.py
+++ b/src/aleph/web/controllers/routes.py
@@ -47,6 +47,9 @@ def register_routes(app: web.Application):
     # of the large amount of code shared with pub_json.
     app.router.add_post("/api/v0/messages", p2p.pub_message)
     app.router.add_get("/api/v0/messages/{item_hash}", messages.view_message)
+    app.router.add_get(
+        "/api/v0/messages/{item_hash}/content", messages.view_message_content
+    )
     app.router.add_get("/api/v0/messages/page/{page}.json", messages.view_messages_list)
     app.router.add_get("/api/ws0/messages", messages.messages_ws)
 


### PR DESCRIPTION
Related tickets : [ALEPH-253](https://aleph-im.atlassian.net/jira/software/c/projects/ALEPH/boards/2?selectedIssue=ALEPH-253)

## Self proofreading checklist

- [X] Is my code clear enough and well documented
- [X] Are my files well typed
- [X] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [X] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Implement a `/api/v0/messages/{item_hash}/content` route path that return directly the `content.content` fields from POST messages.

## How to test

Check that the `/content` path exists and returns the content itself for POST messages, like : https://api3.aleph.im/api/v0/messages/fee8795bb8ac594eeb9624ce169bd5efc52842470da3c95dbc2d3291c3ad8643/content
