### PR TITLE
Remove double `ack()` method call

### DIFF
--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -32,7 +32,7 @@ async def incoming_channel(
                         peer_id,
                     )
 
-                    # we should check the sender here to avoid spam
+                    # We should check the sender here to avoid spam
                     # and such things...
                     try:
                         message_dict = await decode_pubsub_message(message.body)
@@ -42,7 +42,8 @@ async def incoming_channel(
                             message_dict["item_hash"],
                             message_dict["signature"],
                         ) in seen_hashes:
-                            await message.ack()
+                            # Messages are already ACKed on underlying implementation in p2p_client.receive_messages()
+                            # if the process don't have issues
                             continue
 
                         seen_hashes.append(


### PR DESCRIPTION
## Self proofreading checklist

- [X] Is my code clear enough and well documented
- [X] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [X] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

With the patch done one version `0.5.7` we added a call to ACK the messages already handled before, but indeed it was already done by the `receive_messages()` method, so we end with these kind of errors:
```
2024-11-12 13:55:03 [ERROR] aleph.services.p2p.protocol: Exception in pubsub, reconnecting.
Traceback (most recent call last):
  File "/opt/pyaleph/src/aleph/services/p2p/protocol.py", line 25, in incoming_channel
    async for message in p2p_client.receive_messages(topic):
  File "/opt/venv/lib/python3.12/site-packages/aleph_p2p_client/client.py", line 158, in receive_messages
    async for message in self.mq_client.receive_messages(topic):
  File "/opt/venv/lib/python3.12/site-packages/aleph_p2p_client/client.py", line 73, in receive_messages
    await message.ack()
  File "/opt/venv/lib/python3.12/site-packages/aio_pika/message.py", line 473, in ack
    raise MessageProcessError("Message already processed", self)
aio_pika.exceptions.MessageProcessError: ('Message already processed', IncomingMessage:{'app_id': None,
 'body_size': 942,
 'cluster_id': '',
 'consumer_tag': 'ctag1.4b95afd181cd43579d7ab7384277396a',
 'content_encoding': None,
 'content_type': None,
 'correlation_id': None,
 'delivery_mode': <DeliveryMode.NOT_PERSISTENT: 1>,
 'delivery_tag': 217671,
 'exchange': 'p2p-subscribe',
 'expiration': None,
 'headers': {},
 'message_id': None,
 'routing_key': 'p2p.ALEPH-TEST.QmTqK74SCKQ7EKqPU8Dam43XjiCGLe2GgY6Yv6Ezy9zDvb',
 'timestamp': None,
 'type': 'None',
 'user_id': None})
```
Removing these double `.ack()` method call, we remove the existing error messages.

## How to test

Deploy the version and ensure to not see more `'Message already processed'` errors in the logs.
