### PR TITLE
Feature: Add new endpoint to retreive message status

### DIFF
--- a/src/aleph/schemas/api/messages.py
+++ b/src/aleph/schemas/api/messages.py
@@ -204,6 +204,12 @@ class RejectedMessageStatus(BaseMessageStatus):
     details: Any
 
 
+class MessageStatusInfo(BaseMessageStatus):
+    class Config:
+        orm_mode = True
+        fields = {"item_hash": {"exclude": True}}
+
+
 MessageWithStatus = Union[
     PendingMessageStatus,
     ProcessedMessageStatus,

--- a/src/aleph/web/controllers/routes.py
+++ b/src/aleph/web/controllers/routes.py
@@ -50,6 +50,9 @@ def register_routes(app: web.Application):
     app.router.add_get(
         "/api/v0/messages/{item_hash}/content", messages.view_message_content
     )
+    app.router.add_get(
+        "/api/v0/messages/{item_hash}/status", messages.view_message_status
+    )
     app.router.add_get("/api/v0/messages/page/{page}.json", messages.view_messages_list)
     app.router.add_get("/api/ws0/messages", messages.messages_ws)
 


### PR DESCRIPTION
In certain scenarios, we need to determine the status of a message without retrieving all its contents, as this can consume significant memory and time, particularly when the message is large. This PR introduces a fast endpoint that returns only the status field and the reception time, providing the necessary information without unnecessarily loading the system.

## Self proofreading checklist

- [ x] Is my code clear enough and well documented
- [ x] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Add new endpoint to retreive the status info of a specific message

## How to test

https://api.twentysix.testnet.network/api/v0/messages/ae2ae5ee6805c6ba91e1991b6079823a8999254f40837c45248c533624c49527/status

```json
{
  "status": "processed",
  "reception_time": "2024-11-20T15:13:07.404063+00:00"
}
```
