### PR TITLE
Aleph-302: fix messages.json start_block and end_block params

### DIFF
--- a/src/aleph/db/accessors/messages.py
+++ b/src/aleph/db/accessors/messages.py
@@ -138,8 +138,7 @@ def make_matching_messages_query(
         if start_block:
             select_stmt = select_stmt.where(
                 select_earliest_confirmation.c.height.is_(None)
-                | select_earliest_confirmation.c.height
-                >= start_block
+                | (select_earliest_confirmation.c.height >= start_block)
             )
         if end_block:
             select_stmt = select_stmt.where(

--- a/src/aleph/db/accessors/messages.py
+++ b/src/aleph/db/accessors/messages.py
@@ -118,7 +118,7 @@ def make_matching_messages_query(
     if channels:
         select_stmt = select_stmt.where(MessageDb.channel.in_(channels))
 
-    order_by_columns: Tuple  # For mypy to leave us alone until SQLA2
+    order_by_columns: Tuple = ()  # For mypy to leave us alone until SQLA2
 
     if sort_by == SortBy.TX_TIME or start_block or end_block:
         select_earliest_confirmation = (

--- a/src/aleph/db/accessors/messages.py
+++ b/src/aleph/db/accessors/messages.py
@@ -125,9 +125,10 @@ def make_matching_messages_query(
             select(
                 message_confirmations.c.item_hash,
                 func.min(ChainTxDb.datetime).label("earliest_confirmation"),
+                ChainTxDb.height,
             )
             .join(ChainTxDb, message_confirmations.c.tx_hash == ChainTxDb.hash)
-            .group_by(message_confirmations.c.item_hash)
+            .group_by(message_confirmations.c.item_hash, ChainTxDb.height)
         ).subquery()
         select_stmt = select_stmt.join(
             select_earliest_confirmation,

--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from collections import deque
-from typing import Deque
+from typing import Any
 
 from aleph_p2p_client import AlephP2PServiceClient
 
@@ -19,8 +19,7 @@ async def incoming_channel(
     LOGGER.debug("incoming channel started...")
 
     await p2p_client.subscribe(topic)
-
-    seen_hashes: Deque[tuple] = deque([], maxlen=200000)
+    seen_hashes: deque[tuple[Any, Any, Any]] = deque([], maxlen=200000)
 
     while True:
         try:


### PR DESCRIPTION
Query like `http://0.0.0.0:4024/api/v0/messages.json?msgType=POST&tags=mainnet&contentTypes=balances-update&pagination=50&sort_order=1&start_block=21135862&addresses=0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10` was broken and generating a 500 error

Related Clickup or Jira tickets : ALEPH-302

## Self proofreading checklist

- [x] Is my code clear enough and well documented
- [x] Are my files well typed

## Changes

So, basically until [this commit](https://github.com/aleph-im/pyaleph/commit/eb3b65369c6daea23616d90e038b02caa837e151) the `start_block/end_block` part of the code was never reached and was not working (except if you call the html query params `StartBlock`)

- first, a select query tried to access the `height` attribute on the table `message_confirmations` that doesn't have any height
- so using a join we grab the transaction `height` value 
- add it to the `GROUP BY`
- then we fix a priority operator because `|` has less precedence than `>=`
- and then we had a default value to `order_by_columns` because in some branches of the `if/elif/else` block it can be uninitialized

## How to test

Launch pyaleph then run this query: `http://0.0.0.0:4024/api/v0/messages.json?msgType=POST&tags=mainnet&contentTypes=balances-update&pagination=50&sort_order=1&start_block=21135862&addresses=0xa1B3bb7d2332383D96b7796B908fB7f7F3c2Be10`

## Notes

I'm not 100% sure that the modification of the `GROUP BY` and of the default value for `order_by_columns` are the behavior we want but this part of the code just never worked before :confused: 

We also probably really want to have some tests here that handle that situation but I understand that this PR is urgent and 301 is also so I'm prioritizing this.