### PR TITLE
fix(api): correctly name types paramters of /posts.json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
-  "aio-pika==9.5.0",
+  "aio-pika==9.5",
   "aiocache==0.12.2",
   "aiofiles==23.2.1",
   "aiohttp==3.9.5",
@@ -62,7 +62,7 @@ dependencies = [
   "sqlalchemy-utils==0.38.3",
   "substrate-interface==1.7.4",
   "types-aiofiles==23.2.0.20240403",
-  "ujson==5.4.0",                                                                                                            # required by aiocache
+  "ujson==5.4",                                                                                                            # required by aiocache
   "urllib3==2.2.2",
   "uvloop==0.21",
   "web3==6.11.2",

--- a/src/aleph/web/controllers/posts.py
+++ b/src/aleph/web/controllers/posts.py
@@ -37,7 +37,7 @@ class PostQueryParams(BaseModel):
     )
     post_types: Optional[List[str]] = Field(
         default=None,
-        alias="types",
+        alias="types[]",
         description="Accepted values for the 'content.type' field.",
     )
     tags: Optional[List[str]] = Field(


### PR DESCRIPTION
The types parameters for queries on /posts.json was not taken into account because it was badly named.

Related Clickup or Jira tickets : ALEPH-301

## Self proofreading checklist

- [x] Is my code clear enough and well documented
- [x] Are my files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [x] Database migrations file are included
- [x] Are there enough tests
- [x] Documentation has been included (for new feature)

## Changes

Just correctly name it.

## How to test

Simply do a query on posts.json with the `types[]=...` query parameters like so:

```
curl 'http://localhost:4024/api/v0/posts.json?types[]=corechan-operation' | python -m json.tool | grep '"type":'
```

## Print screen / video

![image](https://github.com/user-attachments/assets/b881de82-a630-4761-bba5-28017c5e1a48)
