### PR TITLE
Fix: Vm cost view

### DIFF
--- a/deployment/migrations/versions/0026_d3bba5c2bfa0_fix_join_exclude_vm_without_volume.py
+++ b/deployment/migrations/versions/0026_d3bba5c2bfa0_fix_join_exclude_vm_without_volume.py
@@ -1,0 +1,162 @@
+"""Fix join exclude vm without volume
+
+Revision ID: d3bba5c2bfa0
+Revises: 63b767213bfa
+Create Date: 2024-12-06 01:51:53.623781
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd3bba5c2bfa0'
+down_revision = '63b767213bfa'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE OR REPLACE VIEW vm_costs_view AS
+        SELECT vm_versions.vm_hash,
+               vm_versions.owner,
+               vms.resources_vcpus,
+               vms.resources_memory,
+               file_volumes_size.file_volumes_size,
+               other_volumes_size.other_volumes_size,
+               used_disk.required_disk_space,
+               cu.compute_units_required,
+               bcp.base_compute_unit_price,
+               m.compute_unit_price_multiplier,
+               cpm.compute_unit_price,
+               free_disk.included_disk_space,
+               additional_disk.additional_disk_space,
+               adp.disk_price,
+               tp.total_price
+        FROM vm_versions
+                 JOIN vms ON vm_versions.current_version::text = vms.item_hash::text
+                 LEFT JOIN (SELECT volume.vm_hash,
+                              sum(files.size) AS file_volumes_size
+                       FROM vm_volumes_files_view volume
+                                LEFT JOIN files ON volume.volume_to_use::text = files.hash::text
+                       GROUP BY volume.vm_hash) file_volumes_size
+                      ON vm_versions.current_version::text = file_volumes_size.vm_hash::text
+                 LEFT JOIN (SELECT instance_rootfs.instance_hash,
+                                   instance_rootfs.size_mib::bigint * 1024 * 1024 AS rootfs_size
+                            FROM instance_rootfs) rootfs_size ON vm_versions.vm_hash::text = rootfs_size.instance_hash::text
+                 LEFT JOIN (SELECT vm_machine_volumes.vm_hash,
+                              sum(vm_machine_volumes.size_mib) * 1024 * 1024 AS other_volumes_size
+                       FROM vm_machine_volumes
+                       GROUP BY vm_machine_volumes.vm_hash) other_volumes_size
+                      ON vm_versions.current_version::text = other_volumes_size.vm_hash::text,
+             LATERAL ( SELECT file_volumes_size.file_volumes_size +
+                              other_volumes_size.other_volumes_size::numeric AS required_disk_space) used_disk,
+             LATERAL ( SELECT ceil(GREATEST(ceil((vms.resources_vcpus / 1)::double precision),
+                                            (vms.resources_memory / 2048)::double precision)) AS compute_units_required) cu,
+             LATERAL ( SELECT CASE
+                                  WHEN COALESCE(vms.persistent, true)
+                                      THEN '21474836480'::bigint::double precision * cu.compute_units_required
+                                  ELSE '2147483648'::bigint::double precision * cu.compute_units_required
+                                  END AS included_disk_space) free_disk,
+             LATERAL ( SELECT GREATEST((file_volumes_size.file_volumes_size + rootfs_size.rootfs_size::numeric +
+                                        other_volumes_size.other_volumes_size::numeric)::double precision -
+                                       free_disk.included_disk_space,
+                                       0::double precision) AS additional_disk_space) additional_disk,
+             LATERAL ( SELECT CASE
+                                  WHEN vms.payment_type = 'superfluid' THEN 0
+                                  WHEN COALESCE(persistent, true)
+                                    AND environment_trusted_execution_policy IS NOT NULL 
+                                    AND environment_trusted_execution_firmware IS NOT NULL THEN 2000
+                                  WHEN COALESCE(persistent, true) THEN 1000
+                                  ELSE 200
+                                  END AS base_compute_unit_price) bcp,
+             LATERAL ( SELECT CASE
+                                  WHEN COALESCE(vms.persistent, true) THEN 1 + vms.environment_internet::integer
+                                  ELSE 1
+                                  END AS compute_unit_price_multiplier) m,
+             LATERAL ( SELECT cu.compute_units_required * m.compute_unit_price_multiplier::double precision *
+                              bcp.base_compute_unit_price::double precision AS compute_unit_price) cpm,
+             LATERAL ( SELECT CASE
+                        WHEN vms.payment_type = 'superfluid' THEN 0
+                        ELSE additional_disk.additional_disk_space / 20::double precision / (1024 * 1024)::double precision
+                        END AS disk_price
+             ) adp,
+             LATERAL ( SELECT cpm.compute_unit_price + adp.disk_price AS total_price) tp
+        """
+
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        CREATE OR REPLACE VIEW vm_costs_view AS
+        SELECT vm_versions.vm_hash,
+               vm_versions.owner,
+               vms.resources_vcpus,
+               vms.resources_memory,
+               file_volumes_size.file_volumes_size,
+               other_volumes_size.other_volumes_size,
+               used_disk.required_disk_space,
+               cu.compute_units_required,
+               bcp.base_compute_unit_price,
+               m.compute_unit_price_multiplier,
+               cpm.compute_unit_price,
+               free_disk.included_disk_space,
+               additional_disk.additional_disk_space,
+               adp.disk_price,
+               tp.total_price
+        FROM vm_versions
+                 JOIN vms ON vm_versions.current_version::text = vms.item_hash::text
+                 JOIN (SELECT volume.vm_hash,
+                              sum(files.size) AS file_volumes_size
+                       FROM vm_volumes_files_view volume
+                                LEFT JOIN files ON volume.volume_to_use::text = files.hash::text
+                       GROUP BY volume.vm_hash) file_volumes_size
+                      ON vm_versions.current_version::text = file_volumes_size.vm_hash::text
+                 LEFT JOIN (SELECT instance_rootfs.instance_hash,
+                                   instance_rootfs.size_mib::bigint * 1024 * 1024 AS rootfs_size
+                            FROM instance_rootfs) rootfs_size ON vm_versions.vm_hash::text = rootfs_size.instance_hash::text
+                 JOIN (SELECT vm_machine_volumes.vm_hash,
+                              sum(vm_machine_volumes.size_mib) * 1024 * 1024 AS other_volumes_size
+                       FROM vm_machine_volumes
+                       GROUP BY vm_machine_volumes.vm_hash) other_volumes_size
+                      ON vm_versions.current_version::text = other_volumes_size.vm_hash::text,
+             LATERAL ( SELECT file_volumes_size.file_volumes_size +
+                              other_volumes_size.other_volumes_size::numeric AS required_disk_space) used_disk,
+             LATERAL ( SELECT ceil(GREATEST(ceil((vms.resources_vcpus / 1)::double precision),
+                                            (vms.resources_memory / 2048)::double precision)) AS compute_units_required) cu,
+             LATERAL ( SELECT CASE
+                                  WHEN COALESCE(vms.persistent, true)
+                                      THEN '21474836480'::bigint::double precision * cu.compute_units_required
+                                  ELSE '2147483648'::bigint::double precision * cu.compute_units_required
+                                  END AS included_disk_space) free_disk,
+             LATERAL ( SELECT GREATEST((file_volumes_size.file_volumes_size + rootfs_size.rootfs_size::numeric +
+                                        other_volumes_size.other_volumes_size::numeric)::double precision -
+                                       free_disk.included_disk_space,
+                                       0::double precision) AS additional_disk_space) additional_disk,
+             LATERAL ( SELECT CASE
+                                  WHEN vms.payment_type = 'superfluid' THEN 0
+                                  WHEN COALESCE(persistent, true)
+                                    AND environment_trusted_execution_policy IS NOT NULL 
+                                    AND environment_trusted_execution_firmware IS NOT NULL THEN 2000
+                                  WHEN COALESCE(persistent, true) THEN 1000
+                                  ELSE 200
+                                  END AS base_compute_unit_price) bcp,
+             LATERAL ( SELECT CASE
+                                  WHEN COALESCE(vms.persistent, true) THEN 1 + vms.environment_internet::integer
+                                  ELSE 1
+                                  END AS compute_unit_price_multiplier) m,
+             LATERAL ( SELECT cu.compute_units_required * m.compute_unit_price_multiplier::double precision *
+                              bcp.base_compute_unit_price::double precision AS compute_unit_price) cpm,
+             LATERAL ( SELECT CASE
+                        WHEN vms.payment_type = 'superfluid' THEN 0
+                        ELSE additional_disk.additional_disk_space / 20::double precision / (1024 * 1024)::double precision
+                        END AS disk_price
+             ) adp,
+             LATERAL ( SELECT cpm.compute_unit_price + adp.disk_price AS total_price) tp
+        """
+
+    )

--- a/deployment/migrations/versions/0026_d3bba5c2bfa0_fix_join_exclude_vm_without_volume.py
+++ b/deployment/migrations/versions/0026_d3bba5c2bfa0_fix_join_exclude_vm_without_volume.py
@@ -6,7 +6,6 @@ Create Date: 2024-12-06 01:51:53.623781
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -102,10 +102,11 @@ class StoreMessageHandler(ContentHandler):
     ) -> None:
         # TODO: simplify this function, it's overly complicated for no good reason.
 
-        # TODO: this check is useless, remove it
+        # This check is essential to ensure that files are not added to the system
+        # or the current node when the configuration disables storing of files.
         config = get_config()
         if not config.storage.store_files.value:
-            return  # Ignore
+            return  # Ignore if files are not to be stored.
 
         content = message.parsed_content
         assert isinstance(content, StoreContent)

--- a/tests/message_processing/test_process_instances.py
+++ b/tests/message_processing/test_process_instances.py
@@ -656,3 +656,99 @@ async def test_compare_cost_view_with_cost_function_payg(
 
     ## Price Handle
     assert Decimal(str(cost_from_view)) == 0
+
+
+@pytest.fixture
+def fixture_instance_message_only_rootfs(
+    session_factory: DbSessionFactory,
+) -> PendingMessageDb:
+    content = {
+        "address": "0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
+        "allow_amend": False,
+        "variables": {
+            "VM_CUSTOM_VARIABLE": "SOMETHING",
+            "VM_CUSTOM_VARIABLE_2": "32",
+        },
+        "environment": {
+            "reproducible": True,
+            "internet": False,
+            "aleph_api": False,
+            "shared_cache": False,
+        },
+        "resources": {"vcpus": 1, "memory": 2048, "seconds": 30},
+        "requirements": {"cpu": {"architecture": "x86_64"}},
+        "rootfs": {
+            "parent": {
+                "ref": "549ec451d9b099cad112d4aaa2c00ac40fb6729a92ff252ff22eef0b5c3cb613",
+                "use_latest": True,
+            },
+            "persistence": "host",
+            "name": "test-rootfs",
+            "size_mib": 20480,
+        },
+        "authorized_keys": [
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGULT6A41Msmw2KEu0R9MvUjhuWNAsbdeZ0DOwYbt4Qt user@example",
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH0jqdc5dmt75QhTrWqeHDV9xN8vxbgFyOYs2fuQl7CI",
+        ],
+        "volumes": [],
+        "time": 1619017773.8950517,
+    }
+
+    pending_message = PendingMessageDb(
+        item_hash="734a1287a2b7b5be060312ff5b05ad1bcf838950492e3428f2ac6437a1acad26",
+        type=MessageType.instance,
+        chain=Chain.ETH,
+        sender="0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
+        signature=None,
+        item_type=ItemType.inline,
+        item_content=json.dumps(content),
+        time=timestamp_to_datetime(1619017773.8950577),
+        channel=None,
+        reception_time=timestamp_to_datetime(1619017774),
+        fetched=True,
+        check_message=False,
+        retries=0,
+        next_attempt=dt.datetime(2023, 1, 1),
+    )
+    with session_factory() as session:
+
+        session.add(pending_message)
+        session.add(
+            MessageStatusDb(
+                item_hash=pending_message.item_hash,
+                status=MessageStatus.PENDING,
+                reception_time=pending_message.reception_time,
+            )
+        )
+        session.commit()
+
+    return pending_message
+
+
+@pytest.mark.asyncio
+async def test_compare_cost_view_with_cost_function_without_volume(
+    session_factory: DbSessionFactory,
+    message_processor: PendingMessageProcessor,
+    fixture_instance_message_only_rootfs: PendingMessageDb,
+    user_balance: AlephBalanceDb,
+):
+    with session_factory() as session:
+        insert_volume_refs(session, fixture_instance_message_only_rootfs)
+        session.commit()
+
+    pipeline = message_processor.make_pipeline()
+    # Exhaust the iterator
+    _ = [message async for message in pipeline]
+
+    assert fixture_instance_message_only_rootfs.item_content
+    content = InstanceContent.parse_raw(
+        fixture_instance_message_only_rootfs.item_content
+    )
+    with session_factory() as session:
+        cost_from_function: Decimal = compute_cost(session=session, content=content)
+        cost_from_view = session.execute(
+            text("SELECT total_price from vm_costs_view WHERE vm_hash = :vm_hash"),
+            {"vm_hash": fixture_instance_message_only_rootfs.item_hash},
+        ).scalar_one()
+
+    assert Decimal(str(cost_from_view)) == cost_from_function


### PR DESCRIPTION
Related Clickup or Jira tickets : ALEPH-290

## The Problem
The `vm_costs_view` gets data from the `vms` table and joins it with volume data. The issue is with two `JOIN` statements:

1. **File Volumes (`file_volumes_size`)**  
   If a VM doesn't have any file volumes, it gets excluded.

2. **Other Volumes (`other_volumes_size`)**  
   If a VM doesn't have any other volumes, it also gets excluded.

This means VMs with only a `rootfs` (no extra volumes) won't show up in the results.

## The Fix
Change both `JOIN`s to `LEFT JOIN`s. This will include all VMs, even if they don’t have additional volumes.  



## Self proofreading checklist

- [x] Is my code clear enough and well documented
- [x] Are my files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [x] Database migrations file are included
- [x] Are there enough tests
- [] Documentation has been included (for new feature)

## Changes

### Overview
This update addresses an issue where VMs without additional volumes (only `rootfs`) were being excluded from the results in the `vm_costs_view`. The changes ensure that all VMs are included, even if they don't have associated volumes.

### Details
1. **Modified `vm_costs_view`**  
   - Changed the `JOIN` on `file_volumes_size` and `other_volumes_size` to `LEFT JOIN`.  
   - **Reasoning:** This ensures VMs are included in the results, even if they don’t have `file_volumes` or `other_volumes`.

2. **Behavioral Changes**  
   - VMs with only a `rootfs` will now appear in the view.
   - There are no changes to VMs that already had volumes.


## How to test
Just need to send an instance message with only rootfs and no volume.

Also We got a new [Test](https://github.com/aleph-im/pyaleph/pull/664/commits/8dda401ada350728f0b13859918dbe205108f58f) (here was failing at start) that arer now passing.

