### PR TITLE
config: Add a timeout option for the ethereum client

### DIFF
--- a/src/aleph/chains/ethereum.py
+++ b/src/aleph/chains/ethereum.py
@@ -36,7 +36,12 @@ CHAIN_NAME = "ETH"
 
 
 def get_web3(config) -> Web3:
-    web3 = Web3(Web3.HTTPProvider(config.ethereum.api_url.value))
+    web3 = Web3(
+        Web3.HTTPProvider(
+            config.ethereum.api_url.value,
+            request_kwargs={"timeout": config.ethereum.client_timeout.value},
+        )
+    )
     if config.ethereum.chain_id.value == 4:  # rinkeby
         web3.middleware_onion.inject(geth_poa_middleware, layer=0)
     web3.middleware_onion.add(local_filter_middleware)

--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -126,6 +126,8 @@ def get_defaults():
             "archive_delay": 30,
             # Delay in seconds between blockchain message checks.
             "message_delay": 30,
+            # http client timeout, default 60s
+            "client_timeout": 60,
         },
         "tezos": {
             # Whether to fetch transactions from Tezos.


### PR DESCRIPTION
This PR solves a timeout problem on some Ethereum RPCs, as the default timeout is set to 30s by the web3 client,

this PR allows the node operator to configure the timeout according to the rpc and network parameters. 


## Self proofreading checklist

- [x] Is my code clear enough and well documented
- [x] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

