### PR TITLE
fix: avoid exposing messages/posts without channels

### DIFF
--- a/src/aleph/db/accessors/messages.py
+++ b/src/aleph/db/accessors/messages.py
@@ -117,6 +117,8 @@ def make_matching_messages_query(
         )
     if channels:
         select_stmt = select_stmt.where(MessageDb.channel.in_(channels))
+    else:
+        select_stmt = select_stmt.where(MessageDb.channel.is_not(None))
 
     order_by_columns: Tuple = ()  # For mypy to leave us alone until SQLA2
 

--- a/src/aleph/db/accessors/posts.py
+++ b/src/aleph/db/accessors/posts.py
@@ -231,6 +231,8 @@ def filter_post_select_stmt(
         )
     if channels:
         select_stmt = select_stmt.where(literal_column("channel").in_(channels))
+    else:
+        select_stmt = select_stmt.where(literal_column("channel").is_not(None))
     if start_datetime:
         select_stmt = select_stmt.where(last_updated_column >= start_datetime)
     if end_datetime:


### PR DESCRIPTION
We have a bug in production where apparently someone sent messages without a
channel in them and exposing them seems to produce bugs.
