### PR TITLE
Fix: import multihash (caused by aioipfs)

### DIFF
--- a/src/aleph/toolkit/libp2p_stubs/peer/id.py
+++ b/src/aleph/toolkit/libp2p_stubs/peer/id.py
@@ -3,6 +3,7 @@ from typing import Optional, Union
 
 import base58
 import multihash
+import multihash.funcs
 
 from aleph.toolkit.libp2p_stubs.crypto.keys import PublicKey
 
@@ -28,7 +29,7 @@ if ENABLE_INLINING:
         def digest(self) -> bytes:
             return self._digest
 
-    multihash.FuncReg.register(
+    multihash.funcs.FuncReg.register(
         IDENTITY_MULTIHASH_CODE, "identity", hash_new=lambda: IdentityHash()
     )
 
@@ -82,10 +83,10 @@ class ID:
     @classmethod
     def from_pubkey(cls, key: PublicKey) -> "ID":
         serialized_key = key.serialize()
-        algo = multihash.Func.sha2_256
+        algo = multihash.funcs.Func.sha2_256
         if ENABLE_INLINING and len(serialized_key) <= MAX_INLINE_KEY_LENGTH:
             algo = IDENTITY_MULTIHASH_CODE
-        mh_digest = multihash.digest(serialized_key, algo)
+        mh_digest = multihash.Multihash.digest(serialized_key, algo)
         return cls(mh_digest.encode())
 
 


### PR DESCRIPTION
This PR resolves a dependency conflict caused by two libraries, pymultihash and py-multihash, both of which provide a module named multihash. The conflict arises because:

pymultihash is required by pyaleph and is imported as multihash.
py-multihash is now required by aioipfs.

## Self proofreading checklist

- [x] Is my code clear enough and well documented
- [x] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

This pull request includes updates to the `src/aleph/toolkit/libp2p_stubs/peer/id.py` file to improve compatibility with the `multihash` library. The changes mainly involve updating import statements and method calls to reflect the latest structure of the `multihash` library.

Updates to `multihash` library usage:

* Updated import statements to include `multihash.funcs` for better organization and clarity.
* Changed `multihash.FuncReg.register` to `multihash.funcs.FuncReg.register` in the `update` method to align with the new library structure.
* Modified the `from_pubkey` method to use `multihash.funcs.Func.sha2_256` and `multihash.Multihash.digest` to ensure compatibility with the updated `multihash` library.

## How to test

You can try to sync you'r CCN
