### PR TITLE
Fix: add origin pending message field

### DIFF
--- a/deployment/migrations/versions/0027_bafd49315934_add_pending_messages_origin.py
+++ b/deployment/migrations/versions/0027_bafd49315934_add_pending_messages_origin.py
@@ -1,0 +1,24 @@
+"""add_pending_messages_origin
+
+Revision ID: bafd49315934
+Revises: d3bba5c2bfa0
+Create Date: 2025-01-13 15:05:05.309960
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'bafd49315934'
+down_revision = 'd3bba5c2bfa0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("pending_messages", sa.Column("origin", sa.String(), nullable=True, default="p2p"))
+
+
+def downgrade() -> None:
+    op.drop_column("pending_messages", "origin")

--- a/src/aleph/db/models/pending_messages.py
+++ b/src/aleph/db/models/pending_messages.py
@@ -85,7 +85,7 @@ class PendingMessageDb(Base):
         tx_hash: Optional[str] = None,
         check_message: bool = True,
         fetched: bool = False,
-        origin: Optional[MessageOrigin] = MessageOrigin.P2P
+        origin: Optional[MessageOrigin] = MessageOrigin.P2P,
     ) -> "PendingMessageDb":
 
         return cls(

--- a/src/aleph/db/models/pending_messages.py
+++ b/src/aleph/db/models/pending_messages.py
@@ -104,7 +104,7 @@ class PendingMessageDb(Base):
             tx_hash=tx_hash,
             reception_time=reception_time,
             fetched=fetched,
-            origin=str(origin),
+            origin=origin,
         )
 
     @classmethod
@@ -142,7 +142,7 @@ class PendingMessageDb(Base):
             retries=0,
             tx_hash=tx_hash,
             reception_time=reception_time,
-            origin=str(origin),
+            origin=origin,
         )
 
 

--- a/src/aleph/db/models/pending_messages.py
+++ b/src/aleph/db/models/pending_messages.py
@@ -66,7 +66,7 @@ class PendingMessageDb(Base):
     retries: int = Column(Integer, nullable=False)
     tx_hash: Optional[str] = Column(ForeignKey("chain_txs.hash"), nullable=True)
     fetched: bool = Column(Boolean, nullable=False)
-    origin: str = Column(String, nullable=True, default=MessageOrigin.P2P)
+    origin: Optional[str] = Column(String, nullable=True, default=MessageOrigin.P2P)
 
     __table_args__ = (
         CheckConstraint(
@@ -104,7 +104,7 @@ class PendingMessageDb(Base):
             tx_hash=tx_hash,
             reception_time=reception_time,
             fetched=fetched,
-            origin=origin,
+            origin=str(origin),
         )
 
     @classmethod
@@ -115,6 +115,7 @@ class PendingMessageDb(Base):
         fetched: bool,
         tx_hash: Optional[str] = None,
         check_message: bool = True,
+        origin: Optional[MessageOrigin] = MessageOrigin.P2P,
     ) -> "PendingMessageDb":
         """
         Utility function to translate Aleph message dictionaries, such as those returned by the API,
@@ -141,6 +142,7 @@ class PendingMessageDb(Base):
             retries=0,
             tx_hash=tx_hash,
             reception_time=reception_time,
+            origin=str(origin),
         )
 
 

--- a/src/aleph/db/models/pending_messages.py
+++ b/src/aleph/db/models/pending_messages.py
@@ -20,6 +20,7 @@ from sqlalchemy_utils.types.choice import ChoiceType
 from aleph.schemas.pending_messages import BasePendingMessage
 from aleph.toolkit.timestamp import timestamp_to_datetime, utc_now
 from aleph.types.channel import Channel
+from aleph.types.message_status import MessageOrigin
 
 from .base import Base
 from .chains import ChainTxDb
@@ -65,6 +66,7 @@ class PendingMessageDb(Base):
     retries: int = Column(Integer, nullable=False)
     tx_hash: Optional[str] = Column(ForeignKey("chain_txs.hash"), nullable=True)
     fetched: bool = Column(Boolean, nullable=False)
+    origin: str = Column(String, nullable=True, default=MessageOrigin.P2P)
 
     __table_args__ = (
         CheckConstraint(

--- a/src/aleph/db/models/pending_messages.py
+++ b/src/aleph/db/models/pending_messages.py
@@ -85,6 +85,7 @@ class PendingMessageDb(Base):
         tx_hash: Optional[str] = None,
         check_message: bool = True,
         fetched: bool = False,
+        origin: Optional[MessageOrigin] = MessageOrigin.P2P
     ) -> "PendingMessageDb":
 
         return cls(
@@ -103,6 +104,7 @@ class PendingMessageDb(Base):
             tx_hash=tx_hash,
             reception_time=reception_time,
             fetched=fetched,
+            origin=origin,
         )
 
     @classmethod

--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -43,7 +43,7 @@ from aleph.types.message_status import (
     InvalidMessageFormat,
     InvalidSignature,
     MessageContentUnavailable,
-    MessageStatus,
+    MessageStatus, MessageOrigin,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -197,6 +197,7 @@ class MessagePublisher(BaseMessageHandler):
         reception_time: dt.datetime,
         tx_hash: Optional[str] = None,
         check_message: bool = True,
+        origin: Optional[str] = MessageOrigin.P2P
     ) -> Optional[PendingMessageDb]:
         # TODO: this implementation is just messy, improve it.
         with self.session_factory() as session:
@@ -394,7 +395,7 @@ class MessageHandler(BaseMessageHandler):
             session=session, pending_message=pending_message, message=message
         )
         await content_handler.process(session=session, messages=[message])
-        return ProcessedMessage(message=message, is_confirmation=False)
+        return ProcessedMessage(message=message, origin=pending_message.origin, is_confirmation=False)
 
     async def check_permissions(self, session: DbSession, message: MessageDb):
         content_handler = self.get_content_handler(message.type)

--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -200,7 +200,7 @@ class MessagePublisher(BaseMessageHandler):
         reception_time: dt.datetime,
         tx_hash: Optional[str] = None,
         check_message: bool = True,
-        origin: Optional[str] = MessageOrigin.P2P,
+        origin: Optional[MessageOrigin] = MessageOrigin.P2P,
     ) -> Optional[PendingMessageDb]:
         # TODO: this implementation is just messy, improve it.
         with self.session_factory() as session:
@@ -400,7 +400,9 @@ class MessageHandler(BaseMessageHandler):
         )
         await content_handler.process(session=session, messages=[message])
         return ProcessedMessage(
-            message=message, origin=pending_message.origin, is_confirmation=False
+            message=message,
+            origin=MessageOrigin(pending_message.origin),
+            is_confirmation=False,
         )
 
     async def check_permissions(self, session: DbSession, message: MessageDb):

--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -187,9 +187,10 @@ class MessagePublisher(BaseMessageHandler):
     async def _publish_pending_message(self, pending_message: PendingMessageDb) -> None:
         mq_message = aio_pika.Message(body=f"{pending_message.id}".encode("utf-8"))
         process_or_fetch = "process" if pending_message.fetched else "fetch"
-        await self.pending_message_exchange.publish(
-            mq_message, routing_key=f"{process_or_fetch}.{pending_message.item_hash}"
-        )
+        if pending_message.origin != MessageOrigin.ONCHAIN:
+            await self.pending_message_exchange.publish(
+                mq_message, routing_key=f"{process_or_fetch}.{pending_message.item_hash}"
+            )
 
     async def add_pending_message(
         self,
@@ -220,6 +221,7 @@ class MessagePublisher(BaseMessageHandler):
                 reception_time=reception_time,
                 tx_hash=tx_hash,
                 check_message=check_message,
+                origin=origin,
             )
 
             try:

--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -401,7 +401,11 @@ class MessageHandler(BaseMessageHandler):
         await content_handler.process(session=session, messages=[message])
         return ProcessedMessage(
             message=message,
-            origin=MessageOrigin(pending_message.origin),
+            origin=(
+                MessageOrigin(pending_message.origin)
+                if pending_message.origin
+                else None
+            ),
             is_confirmation=False,
         )
 

--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -43,7 +43,8 @@ from aleph.types.message_status import (
     InvalidMessageFormat,
     InvalidSignature,
     MessageContentUnavailable,
-    MessageStatus, MessageOrigin,
+    MessageStatus,
+    MessageOrigin,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -189,7 +190,8 @@ class MessagePublisher(BaseMessageHandler):
         process_or_fetch = "process" if pending_message.fetched else "fetch"
         if pending_message.origin != MessageOrigin.ONCHAIN:
             await self.pending_message_exchange.publish(
-                mq_message, routing_key=f"{process_or_fetch}.{pending_message.item_hash}"
+                mq_message,
+                routing_key=f"{process_or_fetch}.{pending_message.item_hash}",
             )
 
     async def add_pending_message(
@@ -198,7 +200,7 @@ class MessagePublisher(BaseMessageHandler):
         reception_time: dt.datetime,
         tx_hash: Optional[str] = None,
         check_message: bool = True,
-        origin: Optional[str] = MessageOrigin.P2P
+        origin: Optional[str] = MessageOrigin.P2P,
     ) -> Optional[PendingMessageDb]:
         # TODO: this implementation is just messy, improve it.
         with self.session_factory() as session:
@@ -397,7 +399,9 @@ class MessageHandler(BaseMessageHandler):
             session=session, pending_message=pending_message, message=message
         )
         await content_handler.process(session=session, messages=[message])
-        return ProcessedMessage(message=message, origin=pending_message.origin, is_confirmation=False)
+        return ProcessedMessage(
+            message=message, origin=pending_message.origin, is_confirmation=False
+        )
 
     async def check_permissions(self, session: DbSession, message: MessageDb):
         content_handler = self.get_content_handler(message.type)

--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -43,8 +43,8 @@ from aleph.types.message_status import (
     InvalidMessageFormat,
     InvalidSignature,
     MessageContentUnavailable,
-    MessageStatus,
     MessageOrigin,
+    MessageStatus,
 )
 
 LOGGER = logging.getLogger(__name__)

--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -25,8 +25,8 @@ from aleph.toolkit.timestamp import utc_now
 from aleph.types.db_session import DbSessionFactory
 from aleph.types.message_processing_result import MessageProcessingResult
 
-from .job_utils import MessageJob, prepare_loop
 from ..types.message_status import MessageOrigin
+from .job_utils import MessageJob, prepare_loop
 
 LOGGER = getLogger(__name__)
 

--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -133,7 +133,9 @@ class PendingMessageProcessor(MessageJob):
         async for processing_results in message_iterator:
             for result in processing_results:
                 if result.origin != MessageOrigin.ONCHAIN:
-                    mq_message = aio_pika.Message(body=aleph_json.dumps(result.to_dict()))
+                    mq_message = aio_pika.Message(
+                        body=aleph_json.dumps(result.to_dict())
+                    )
                     await self.mq_message_exchange.publish(
                         mq_message,
                         routing_key=f"{result.status.value}.{result.item_hash}",

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -69,7 +69,7 @@ class PendingTxProcessor(MqWatcher):
                     reception_time=utc_now(),
                     tx_hash=tx.hash,
                     check_message=tx.protocol != ChainSyncProtocol.SMART_CONTRACT,
-                    origin=MessageOrigin.ONCHAIN
+                    origin=MessageOrigin.ONCHAIN,
                 )
 
             # bogus or handled, we remove it.

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -26,8 +26,8 @@ from aleph.toolkit.timestamp import utc_now
 from aleph.types.chain_sync import ChainSyncProtocol
 from aleph.types.db_session import DbSessionFactory
 
-from .job_utils import MqWatcher, make_pending_tx_queue, prepare_loop
 from ..types.message_status import MessageOrigin
+from .job_utils import MqWatcher, make_pending_tx_queue, prepare_loop
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -27,6 +27,7 @@ from aleph.types.chain_sync import ChainSyncProtocol
 from aleph.types.db_session import DbSessionFactory
 
 from .job_utils import MqWatcher, make_pending_tx_queue, prepare_loop
+from ..types.message_status import MessageOrigin
 
 LOGGER = logging.getLogger(__name__)
 
@@ -68,6 +69,7 @@ class PendingTxProcessor(MqWatcher):
                     reception_time=utc_now(),
                     tx_hash=tx.hash,
                     check_message=tx.protocol != ChainSyncProtocol.SMART_CONTRACT,
+                    origin=MessageOrigin.ONCHAIN
                 )
 
             # bogus or handled, we remove it.

--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -26,6 +26,13 @@ async def incoming_channel(
             async for message in p2p_client.receive_messages(topic):
                 try:
                     protocol, topic, peer_id = message.routing_key.split(".")
+                    LOGGER.info(
+                        "Received new %s message on topic %s from %s",
+                        protocol,
+                        topic,
+                        peer_id,
+                    )
+                    LOGGER.info("Received new message %r ", message)
                     LOGGER.debug(
                         "Received new %s message on topic %s from %s",
                         protocol,

--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -26,13 +26,6 @@ async def incoming_channel(
             async for message in p2p_client.receive_messages(topic):
                 try:
                     protocol, topic, peer_id = message.routing_key.split(".")
-                    LOGGER.info(
-                        "Received new %s message on topic %s from %s",
-                        protocol,
-                        topic,
-                        peer_id,
-                    )
-                    LOGGER.info("Received new message %r ", message)
                     LOGGER.debug(
                         "Received new %s message on topic %s from %s",
                         protocol,

--- a/src/aleph/types/message_processing_result.py
+++ b/src/aleph/types/message_processing_result.py
@@ -1,12 +1,13 @@
-from typing import Any, Dict, Protocol
+from typing import Any, Dict, Protocol, Optional
 
 from aleph.db.models import MessageDb, PendingMessageDb
 from aleph.schemas.api.messages import format_message
-from aleph.types.message_status import ErrorCode, MessageProcessingStatus
+from aleph.types.message_status import ErrorCode, MessageProcessingStatus, MessageOrigin
 
 
 class MessageProcessingResult(Protocol):
     status: MessageProcessingStatus
+    origin: MessageOrigin
 
     @property
     def item_hash(self) -> str:
@@ -17,13 +18,14 @@ class MessageProcessingResult(Protocol):
 
 
 class ProcessedMessage(MessageProcessingResult):
-    def __init__(self, message: MessageDb, is_confirmation: bool = False):
+    def __init__(self, message: MessageDb, is_confirmation: bool = False, origin: Optional[MessageOrigin] = MessageOrigin.P2P):
         self.message = message
         self.status = (
             MessageProcessingStatus.PROCESSED_CONFIRMATION
             if is_confirmation
             else MessageProcessingStatus.PROCESSED_NEW_MESSAGE
         )
+        self.origin = origin
 
     @property
     def item_hash(self) -> str:

--- a/src/aleph/types/message_processing_result.py
+++ b/src/aleph/types/message_processing_result.py
@@ -18,7 +18,12 @@ class MessageProcessingResult(Protocol):
 
 
 class ProcessedMessage(MessageProcessingResult):
-    def __init__(self, message: MessageDb, is_confirmation: bool = False, origin: Optional[MessageOrigin] = MessageOrigin.P2P):
+    def __init__(
+        self,
+        message: MessageDb,
+        is_confirmation: bool = False,
+        origin: Optional[MessageOrigin] = MessageOrigin.P2P,
+    ):
         self.message = message
         self.status = (
             MessageProcessingStatus.PROCESSED_CONFIRMATION

--- a/src/aleph/types/message_processing_result.py
+++ b/src/aleph/types/message_processing_result.py
@@ -1,8 +1,8 @@
-from typing import Any, Dict, Protocol, Optional
+from typing import Any, Dict, Optional, Protocol
 
 from aleph.db.models import MessageDb, PendingMessageDb
 from aleph.schemas.api.messages import format_message
-from aleph.types.message_status import ErrorCode, MessageProcessingStatus, MessageOrigin
+from aleph.types.message_status import ErrorCode, MessageOrigin, MessageProcessingStatus
 
 
 class MessageProcessingResult(Protocol):

--- a/src/aleph/types/message_processing_result.py
+++ b/src/aleph/types/message_processing_result.py
@@ -7,7 +7,7 @@ from aleph.types.message_status import ErrorCode, MessageOrigin, MessageProcessi
 
 class MessageProcessingResult(Protocol):
     status: MessageProcessingStatus
-    origin: MessageOrigin
+    origin: Optional[MessageOrigin] = None
 
     @property
     def item_hash(self) -> str:
@@ -22,7 +22,7 @@ class ProcessedMessage(MessageProcessingResult):
         self,
         message: MessageDb,
         is_confirmation: bool = False,
-        origin: Optional[MessageOrigin] = MessageOrigin.P2P,
+        origin: Optional[MessageOrigin] = None,
     ):
         self.message = message
         self.status = (

--- a/src/aleph/types/message_status.py
+++ b/src/aleph/types/message_status.py
@@ -3,6 +3,11 @@ from enum import Enum, IntEnum
 from typing import Any, Dict, Optional, Sequence, Union
 
 
+class MessageOrigin:
+    ONCHAIN = "onchain"
+    P2P = "p2p"
+    IPFS = "ipfs"
+
 class MessageStatus(str, Enum):
     PENDING = "pending"
     PROCESSED = "processed"

--- a/src/aleph/types/message_status.py
+++ b/src/aleph/types/message_status.py
@@ -8,6 +8,7 @@ class MessageOrigin:
     P2P = "p2p"
     IPFS = "ipfs"
 
+
 class MessageStatus(str, Enum):
     PENDING = "pending"
     PROCESSED = "processed"

--- a/src/aleph/types/message_status.py
+++ b/src/aleph/types/message_status.py
@@ -3,7 +3,7 @@ from enum import Enum, IntEnum
 from typing import Any, Dict, Optional, Sequence, Union
 
 
-class MessageOrigin:
+class MessageOrigin(str, Enum):
     ONCHAIN = "onchain"
     P2P = "p2p"
     IPFS = "ipfs"


### PR DESCRIPTION
This PR should solve P2P issue, over the network

Related Clickup or Jira tickets : ALEPH-XXX

## Self proofreading checklist

- [ ] Is my code clear enough and well documented
- [x] Are my files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [x] Database migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

This pull request introduces the `origin` field to the `pending_messages` table and updates relevant parts of the codebase to handle this new field. The changes ensure that the origin of each pending message is tracked and processed appropriately.

### Database Migration:
* Added a new column `origin` to the `pending_messages` table with a default value of "p2p".

### Model Updates:
* Imported `MessageOrigin` in `src/aleph/db/models/pending_messages.py` and added the `origin` field to the `PendingMessageDb` class. [[1]](diffhunk://#diff-e12fc9f12f46e0b67430c16317a11205c69eb2ae86b1934ffdda872383930cc4R23) [[2]](diffhunk://#diff-e12fc9f12f46e0b67430c16317a11205c69eb2ae86b1934ffdda872383930cc4R69)
* Updated the `from_obj` method in `PendingMessageDb` to include the `origin` parameter. [[1]](diffhunk://#diff-e12fc9f12f46e0b67430c16317a11205c69eb2ae86b1934ffdda872383930cc4R88) [[2]](diffhunk://#diff-e12fc9f12f46e0b67430c16317a11205c69eb2ae86b1934ffdda872383930cc4R107)

### Handler and Job Updates:
* Updated the `message_handler.py` to handle the `origin` field in various methods, including `_publish_pending_message`, `add_pending_message`, and `process`. [[1]](diffhunk://#diff-731bb2c60ea622c661d2209f530cd986ae65df377dda58166cbd085df924fe8aL46-R46) [[2]](diffhunk://#diff-731bb2c60ea622c661d2209f530cd986ae65df377dda58166cbd085df924fe8aR190) [[3]](diffhunk://#diff-731bb2c60ea622c661d2209f530cd986ae65df377dda58166cbd085df924fe8aR201) [[4]](diffhunk://#diff-731bb2c60ea622c661d2209f530cd986ae65df377dda58166cbd085df924fe8aR224) [[5]](diffhunk://#diff-731bb2c60ea622c661d2209f530cd986ae65df377dda58166cbd085df924fe8aL397-R400)
* Updated `process_pending_messages.py` and `process_pending_txs.py` to handle the `origin` field when publishing messages to the message queue. [[1]](diffhunk://#diff-4f872a560aea6c65eb490e37443bc461e7693709f29d2fcc61c3ed105d5f6340R29) [[2]](diffhunk://#diff-4f872a560aea6c65eb490e37443bc461e7693709f29d2fcc61c3ed105d5f6340R135) [[3]](diffhunk://#diff-ab6abdcba55100b7402c43e933e1506e48bee91f30190975a8d1588d5067de06R30) [[4]](diffhunk://#diff-ab6abdcba55100b7402c43e933e1506e48bee91f30190975a8d1588d5067de06R72)

### Type and Status Updates:
* Added `origin` to the `MessageProcessingResult` protocol and updated the `ProcessedMessage` class to handle the `origin` field. [[1]](diffhunk://#diff-6d7ac61f99ee0b843cde403d0e6174da72c0de660796a233b152d00db848591bL1-R10) [[2]](diffhunk://#diff-6d7ac61f99ee0b843cde403d0e6174da72c0de660796a233b152d00db848591bL20-R28)
* Introduced the `MessageOrigin` class in `message_status.py` to define possible origins of messages.