### PR TITLE
Fix: Pending message miss unique constraint

### DIFF
--- a/deployment/migrations/versions/0028_edb195b0ed62_fix_add_unique_constraint_on_pending_.py
+++ b/deployment/migrations/versions/0028_edb195b0ed62_fix_add_unique_constraint_on_pending_.py
@@ -16,7 +16,7 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.create_unique_constraint('uq_pending_message', 'pending_messages', ['sender', 'item_hash', 'signature'])
+    op.create_unique_constraint('uq_pending_message', 'pending_messages', ['item_hash'])
 
 
 def downgrade() -> None:

--- a/deployment/migrations/versions/0028_edb195b0ed62_fix_add_unique_constraint_on_pending_.py
+++ b/deployment/migrations/versions/0028_edb195b0ed62_fix_add_unique_constraint_on_pending_.py
@@ -1,0 +1,24 @@
+"""Fix: add Unique Constraint on pending messsage
+
+Revision ID: edb195b0ed62
+Revises: bafd49315934
+Create Date: 2025-01-14 12:16:10.920697
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'edb195b0ed62'
+down_revision = 'bafd49315934'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint('uq_pending_message', 'pending_messages', ['sender', 'item_hash', 'signature'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('uq_pending_message', 'pending_messages', type_='unique')

--- a/deployment/migrations/versions/0028_edb195b0ed62_fix_add_unique_constraint_on_pending_.py
+++ b/deployment/migrations/versions/0028_edb195b0ed62_fix_add_unique_constraint_on_pending_.py
@@ -6,7 +6,6 @@ Create Date: 2025-01-14 12:16:10.920697
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
   "substrate-interface==1.7.4",
   "types-aiofiles==23.2.0.20240403",
   "ujson==5.4",                                                                                                            # required by aiocache
-  "urllib3==2.3.0",
+  "urllib3==2.3",
   "uvloop==0.21",
   "web3==6.11.2",
 ]

--- a/src/aleph/db/models/pending_messages.py
+++ b/src/aleph/db/models/pending_messages.py
@@ -74,7 +74,7 @@ class PendingMessageDb(Base):
             "signature is not null or not check_message",
             name="signature_not_null_if_check_message",
         ),
-        UniqueConstraint("sender", "item_hash", "signature", name="uq_pending_message"),
+        UniqueConstraint("item_hash", name="uq_pending_message"),
     )
 
     tx: Optional[ChainTxDb] = relationship("ChainTxDb")

--- a/src/aleph/db/models/pending_messages.py
+++ b/src/aleph/db/models/pending_messages.py
@@ -7,12 +7,12 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
-    UniqueConstraint,
     Column,
     ForeignKey,
     Index,
     Integer,
     String,
+    UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship

--- a/src/aleph/db/models/pending_messages.py
+++ b/src/aleph/db/models/pending_messages.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
+    UniqueConstraint,
     Column,
     ForeignKey,
     Index,
@@ -73,6 +74,7 @@ class PendingMessageDb(Base):
             "signature is not null or not check_message",
             name="signature_not_null_if_check_message",
         ),
+        UniqueConstraint("sender", "item_hash", "signature", name="uq_pending_message"),
     )
 
     tx: Optional[ChainTxDb] = relationship("ChainTxDb")

--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Mapping, Optional
 import aio_pika.abc
 import psycopg2
 import sqlalchemy.exc
-
 from aleph_message.models import ItemHash, ItemType, MessageType
 from configmanager import Config
 from pydantic import ValidationError

--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -26,6 +26,13 @@ async def incoming_channel(
             async for message in p2p_client.receive_messages(topic):
                 try:
                     protocol, topic, peer_id = message.routing_key.split(".")
+                    LOGGER.info(
+                        "Received new %s message on topic %s from %s",
+                        protocol,
+                        topic,
+                        peer_id,
+                    )
+                    LOGGER.info("Received new message %r ", message)
                     LOGGER.debug(
                         "Received new %s message on topic %s from %s",
                         protocol,

--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -26,13 +26,6 @@ async def incoming_channel(
             async for message in p2p_client.receive_messages(topic):
                 try:
                     protocol, topic, peer_id = message.routing_key.split(".")
-                    LOGGER.info(
-                        "Received new %s message on topic %s from %s",
-                        protocol,
-                        topic,
-                        peer_id,
-                    )
-                    LOGGER.info("Received new message %r ", message)
                     LOGGER.debug(
                         "Received new %s message on topic %s from %s",
                         protocol,

--- a/tests/message_processing/fixtures/test-data-pending-messaging.json
+++ b/tests/message_processing/fixtures/test-data-pending-messaging.json
@@ -1,0 +1,12 @@
+{
+  "chain": "ETH",
+  "sender": "0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106",
+  "type": "POST",
+  "channel": "INTEGRATION_TESTS",
+  "signature": "0x271939ae35918d0e90877f2319dd0d9737f8334d52539125743caf2460b3896423ca69b1fc85662443cc0bd4ce91e2fb247d7d8291284d8c431e6962c611c4c31c",
+  "time": 1665758931.005458,
+  "item_type": "inline",
+  "item_content": "{\"address\":\"0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106\",\"time\":1665758931.0054002,\"content\":{\"title\":\"My first blog post\",\"body\":\"Ermahgerd, a bleug!\"},\"type\":\"test-post\"}",
+  "item_hash": "9f02e3b5efdbdc0b487359117ae3af40db654892487feae452689a0b84dc1025"
+}
+

--- a/tests/message_processing/load_fixtures.py
+++ b/tests/message_processing/load_fixtures.py
@@ -8,3 +8,10 @@ def load_fixture_messages(fixture: str) -> List[Dict]:
 
     with open(fixture_path) as f:
         return json.load(f)["content"]["messages"]
+
+
+def load_fixture_message(fixture: str) -> Dict:
+    fixture_path = Path(__file__).parent / "fixtures" / fixture
+
+    with open(fixture_path) as f:
+        return json.load(f)

--- a/tests/message_processing/test_process_pending_messages.py
+++ b/tests/message_processing/test_process_pending_messages.py
@@ -1,5 +1,7 @@
 import pytest
 from configmanager import Config
+
+from aleph.db.models import PendingMessageDb
 from aleph.handlers.message_handler import MessagePublisher
 from aleph.storage import StorageService
 from aleph.toolkit.timestamp import utc_now
@@ -16,7 +18,7 @@ async def test_pending_message(
     session_factory: DbSessionFactory,
     test_storage_service: StorageService,
 ):
-    message = load_fixture_message(f"test-data-pending-messaging.json")
+    message = load_fixture_message("test-data-pending-messaging.json")
 
     message_publisher = MessagePublisher(
         session_factory=session_factory,
@@ -30,10 +32,18 @@ async def test_pending_message(
         reception_time=utc_now(),
         origin=MessageOrigin.P2P,
     )
+    assert test1
 
     test2 = await message_publisher.add_pending_message(
         message_dict=message,
         reception_time=utc_now(),
         origin=MessageOrigin.P2P,
     )
+    assert test2
+
+    assert test2.content == test1.content
     assert test2.reception_time == test1.reception_time
+
+    with session_factory() as session:
+        pending_messages = session.query(PendingMessageDb).count()
+        assert pending_messages == 1

--- a/tests/message_processing/test_process_pending_messages.py
+++ b/tests/message_processing/test_process_pending_messages.py
@@ -1,0 +1,39 @@
+import pytest
+from configmanager import Config
+from aleph.handlers.message_handler import MessagePublisher
+from aleph.storage import StorageService
+from aleph.toolkit.timestamp import utc_now
+from aleph.types.db_session import DbSessionFactory
+from aleph.types.message_status import MessageOrigin
+
+from .load_fixtures import load_fixture_message
+
+
+@pytest.mark.asyncio
+async def test_pending_message(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+    test_storage_service: StorageService,
+):
+    message = load_fixture_message(f"test-data-pending-messaging.json")
+
+    message_publisher = MessagePublisher(
+        session_factory=session_factory,
+        storage_service=test_storage_service,
+        config=mock_config,
+        pending_message_exchange=mocker.AsyncMock(),
+    )
+
+    test1 = await message_publisher.add_pending_message(
+        message_dict=message,
+        reception_time=utc_now(),
+        origin=MessageOrigin.P2P,
+    )
+
+    test2 = await message_publisher.add_pending_message(
+        message_dict=message,
+        reception_time=utc_now(),
+        origin=MessageOrigin.P2P,
+    )
+    assert test2.reception_time == test1.reception_time


### PR DESCRIPTION
Even though we use a memory cache, there was a risk of receiving the same pending message twice if the system crashed and reprocessed the message. We now ensure that this is no longer possible

Related Clickup or Jira tickets : ALEPH-NONE

## Self proofreading checklist

- [x] Is my code clear enough and well documented
- [x] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [x] Database migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
This pull request includes changes to add a unique constraint on the `pending_messages` table to ensure data integrity. The changes involve creating a new database migration and updating the SQLAlchemy model for `pending_messages`.

Database migration:

* [`deployment/migrations/versions/0028_edb195b0ed62_fix_add_unique_constraint_on_pending_.py`](diffhunk://#diff-2661d66c0db80abdc821dc2903b8c8fb33112918bedc28b7bdb8a5f0d68126aeR1-R24): Added a new migration script to create a unique constraint on the `pending_messages` table for the columns `sender`, `item_hash`, and `signature`.

Model update:

* [`src/aleph/db/models/pending_messages.py`](diffhunk://#diff-e12fc9f12f46e0b67430c16317a11205c69eb2ae86b1934ffdda872383930cc4R10): Imported `UniqueConstraint` and added a unique constraint to the `PendingMessageDb` class for the columns `sender`, `item_hash`, and `signature`. [[1]](diffhunk://#diff-e12fc9f12f46e0b67430c16317a11205c69eb2ae86b1934ffdda872383930cc4R10) [[2]](diffhunk://#diff-e12fc9f12f46e0b67430c16317a11205c69eb2ae86b1934ffdda872383930cc4R77)

## How to test

Send a message over P2P, restart pyaleph and re send it, it's should be rejected the second time.

## Print screen / video

Upload here print screens or videos showing the changes if relevant.
