### PR TITLE
Fix: pending_messages constraints 

### DIFF
--- a/deployment/migrations/versions/0029_46f7e55ff55c_fix_uniqueconstraint_should_have_sender_.py
+++ b/deployment/migrations/versions/0029_46f7e55ff55c_fix_uniqueconstraint_should_have_sender_.py
@@ -6,7 +6,6 @@ Create Date: 2025-01-14 17:51:43.357255
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.

--- a/deployment/migrations/versions/0029_46f7e55ff55c_fix_uniqueconstraint_should_have_sender_.py
+++ b/deployment/migrations/versions/0029_46f7e55ff55c_fix_uniqueconstraint_should_have_sender_.py
@@ -1,0 +1,26 @@
+"""Fix: UniqueCOnstraint should have sender item_hash and signature
+
+Revision ID: 46f7e55ff55c
+Revises: edb195b0ed62
+Create Date: 2025-01-14 17:51:43.357255
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '46f7e55ff55c'
+down_revision = 'edb195b0ed62'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint('uq_pending_message', 'pending_messages', type_='unique')
+    op.create_unique_constraint('uq_pending_message', 'pending_messages', ['sender', 'item_hash', 'signature'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('uq_pending_message', 'pending_messages', type_='unique')
+    op.create_unique_constraint('uq_pending_message', 'pending_messages', ['item_hash'])

--- a/src/aleph/db/models/pending_messages.py
+++ b/src/aleph/db/models/pending_messages.py
@@ -74,7 +74,7 @@ class PendingMessageDb(Base):
             "signature is not null or not check_message",
             name="signature_not_null_if_check_message",
         ),
-        UniqueConstraint("item_hash", name="uq_pending_message"),
+        UniqueConstraint("sender", "item_hash", "signature", name="uq_pending_message"),
     )
 
     tx: Optional[ChainTxDb] = relationship("ChainTxDb")


### PR DESCRIPTION
Fix unique constraint `uq_pending_message`,

There is now constraints on:
`sender`
`item_hash`
`signature`