### PR TITLE
Solve integrity error logs on Postgresql

### DIFF
--- a/tests/message_processing/test_process_pending_messages.py
+++ b/tests/message_processing/test_process_pending_messages.py
@@ -12,7 +12,7 @@ from .load_fixtures import load_fixture_message
 
 
 @pytest.mark.asyncio
-async def test_pending_message(
+async def test_duplicated_pending_message(
     mocker,
     mock_config: Config,
     session_factory: DbSessionFactory,


### PR DESCRIPTION
Fix: Instead to raise an integrity issue and try to add the message, check before if exists on the database and return the already existing
