### PR TITLE
feat: cache all metrics data for 10 seconds for performances reasons

### DIFF
--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -39,6 +39,13 @@ def get_defaults():
                     "max_concurrency": 20,
                 },
             },
+            "cache": {
+                "ttl": {
+                    "total_aleph_messages": 120,
+                    "eth_height": 600,
+                    "metrics": 10,
+                },
+            },
         },
         "p2p": {
             # Port used for HTTP communication between nodes.

--- a/src/aleph/web/controllers/metrics.py
+++ b/src/aleph/web/controllers/metrics.py
@@ -23,6 +23,8 @@ from aleph.types.db_session import DbSession
 
 LOGGER = getLogger("WEB.metrics")
 
+config = get_config()
+
 
 def format_dict_for_prometheus(values: Dict) -> str:
     """Format a dict to a Prometheus tags string"""
@@ -101,8 +103,8 @@ pyaleph_build_info = BuildInfo(
 )
 
 
-# Cache Aleph messages count for 2 minutes
-@cached(ttl=120)
+# Cache Aleph messages count for 2 minutes by default
+@cached(ttl=config.aleph.cache.ttl.total_aleph_messages)
 async def fetch_reference_total_messages() -> Optional[int]:
     """Obtain the total number of Aleph messages from another node."""
     LOGGER.debug("Fetching Aleph messages count")
@@ -124,8 +126,8 @@ async def fetch_reference_total_messages() -> Optional[int]:
             return None
 
 
-# Cache ETH height for 10 minutes
-@cached(ttl=600)
+# Cache ETH height for 10 minutes by default
+@cached(ttl=config.aleph.cache.ttl.eth_height)
 async def fetch_eth_height() -> Optional[int]:
     """Obtain the height of the Ethereum blockchain."""
     LOGGER.debug("Fetching ETH height")
@@ -143,7 +145,8 @@ async def fetch_eth_height() -> Optional[int]:
         return -1  # We got a boggus value!
 
 
-@cached(ttl=10)
+# Cache metrics for 10 seconds by default
+@cached(ttl=config.aleph.cache.ttl.metrics)
 async def get_metrics(session: DbSession, node_cache: NodeCache) -> Metrics:
     sync_messages_reference_total = await fetch_reference_total_messages()
     eth_reference_height = await fetch_eth_height()

--- a/src/aleph/web/controllers/metrics.py
+++ b/src/aleph/web/controllers/metrics.py
@@ -143,6 +143,7 @@ async def fetch_eth_height() -> Optional[int]:
         return -1  # We got a boggus value!
 
 
+@cached(ttl=10)
 async def get_metrics(session: DbSession, node_cache: NodeCache) -> Metrics:
     sync_messages_reference_total = await fetch_reference_total_messages()
     eth_reference_height = await fetch_eth_height()


### PR DESCRIPTION
The metrics building ends up taking a lot of performance and we wanted to cache it to reducing the CCN load.

This cache all heavy operations for 10 seconds (arbitrary value to discuss).

Those decisions are based on this line_profiling of the function:

![2025-01-24_03-42](https://github.com/user-attachments/assets/f6271c19-0d30-4a24-a621-32c610f0adf1)

(gosh it tooks so much time to get docker-compose is a PITA)

Related Clickup or Jira tickets : ALEPH-362

## Self proofreading checklist

- [ ] Is my code clear enough and well documented
- [ ] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## How to test

Just launch pyaleph and go on "http://localhost:4024/metrics.json"
