### PR TITLE
feat: cache aggregates by owner results until they are updated

### DIFF
--- a/src/aleph/cache.py
+++ b/src/aleph/cache.py
@@ -1,0 +1,28 @@
+from collections import defaultdict
+
+
+class Cache:
+    def __init__(self):
+        self._cache = defaultdict(dict)
+
+    def get(self, key, namespace):
+        return self._cache[namespace].get(key)
+
+    def set(self, key, value, namespace):
+        self._cache[namespace][key] = value
+
+    def exists(self, key, namespace):
+        return key in self._cache[namespace]
+
+    def delete_namespace(self, namespace):
+        if namespace in self._cache:
+            self._cache[namespace] = {}
+
+    def delete(self, key, namespace):
+        if self.exists(key, namespace):
+            del self._cache[namespace]
+
+
+# simple in memory cache
+# we can't use aiocache here because most of ORM methods are not async compatible
+cache = Cache()


### PR DESCRIPTION
Optimize aggregates API route using caching

Related Clickup or Jira tickets : ALEPH-363

## Self proofreading checklist

- [x] Is my code clear enough and well documented
- [x] Are my files well typed
- [x] New translations have been added or updated if new strings have been introduced in the frontend
- [x] Database migrations file are included
- [x] Are there enough tests
- [x] Documentation has been included (for new feature)

## Changes

Introduce a small in memory cache based on defaultdict because aiocache requires async and most db related methods aren't async so we can't use it.

We cache on get_aggregates_by_owner call and invalidate the cache on PostgreSQL `after_update` and `after_delete` events to ensure we don't miss any update/delete.

## How to test

Running the tests should be enough, otherwise you just hit the aggregates API endpoint several time to raise the cache and wait for an aggregate to be updated to see if it works.

