### PR TITLE
Feat: new endpoint for estimating the final executable message price before sending it

### DIFF
--- a/src/aleph/web/controllers/routes.py
+++ b/src/aleph/web/controllers/routes.py
@@ -66,6 +66,7 @@ def register_routes(app: web.Application):
     app.router.add_get("/api/v1/posts/page/{page}.json", posts.view_posts_list_v1)
 
     app.router.add_get("/api/v0/price/{item_hash}", prices.message_price)
+    app.router.add_post("/api/v0/price/estimate", prices.message_price_estimate)
 
     app.router.add_get("/api/v0/addresses/stats.json", accounts.addresses_stats_view)
     app.router.add_get(


### PR DESCRIPTION
- [x] Is my code clear enough and well documented
- [x] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

A new endpoint has been added to be able to calculate how much an executable (instance / program) message will cost before actually sending it to the network.

This can be used from the frontend to get an estimation of prices upfront:

`POST /api/v0/price/estimate` with the same body message schema than `POST /api/v0/messages`:
```
{
  "message": {
    "chain": "ETH",
    "sender": "0x...",
    "channel": "ALEPH-CLOUDSOLUTIONS",
    "time": 1738599106.822,
    "item_type": "inline",
    "item_hash": "...",
    "item_content": "...",
    "type": "INSTANCE"
  }
}
```
