### PR TITLE
fix: migration 32 delete confirmations before message

### DIFF
--- a/deployment/migrations/versions/0032_a3ef27f0db81_fix_duplicated_forgotten_messages.py
+++ b/deployment/migrations/versions/0032_a3ef27f0db81_fix_duplicated_forgotten_messages.py
@@ -133,6 +133,15 @@ def do_delete_messages(session: DbSession) -> None:
     session.execute(
         """
         DELETE
+	        FROM message_confirmations mc
+	        using forgotten_messages fm 
+	        WHERE mc.item_hash = fm.item_hash
+        """
+    )
+
+    session.execute(
+        """
+        DELETE
 	        FROM messages m
 	        using forgotten_messages fm 
 	        WHERE m.item_hash = fm.item_hash


### PR DESCRIPTION
Foreign key constraint error on migration 32. `message_confirmations` entries should be removed before `messages` 