### PR TITLE
Fix: Store price calculations on small file

### DIFF
--- a/src/aleph/services/cost.py
+++ b/src/aleph/services/cost.py
@@ -243,7 +243,6 @@ def _get_volumes_costs(
     for volume in volumes:
         if isinstance(volume, SizedVolume):
             storage_mib = Decimal(volume.size_mib)
-
         elif isinstance(volume, RefVolume):
             file = _get_file_from_ref(
                 session=session, ref=volume.ref, use_latest=volume.use_latest
@@ -290,7 +289,7 @@ def _get_execution_volumes_costs(
         volumes.append(
             SizedVolume(
                 CostType.EXECUTION_INSTANCE_VOLUME_ROOTFS,
-                content.rootfs.size_mib,
+                Decimal(content.rootfs.size_mib),
                 content.rootfs.parent.ref,
             )
         )
@@ -335,7 +334,7 @@ def _get_execution_volumes_costs(
                 volumes.append(
                     SizedVolume(
                         CostType.EXECUTION_VOLUME_INMUTABLE,
-                        volume.estimated_size_mib,
+                        Decimal(volume.estimated_size_mib),
                         volume.ref,
                         name,
                     ),
@@ -357,7 +356,7 @@ def _get_execution_volumes_costs(
             volumes.append(
                 SizedVolume(
                     CostType.EXECUTION_VOLUME_PERSISTENT,
-                    volume.size_mib,
+                    Decimal(volume.size_mib),
                     None,
                     name,
                 ),
@@ -494,12 +493,12 @@ def _calculate_storage_costs(
     payment_type = get_payment_type(content)
 
     if isinstance(content, CostEstimationStoreContent) and content.estimated_size_mib:
-        storage_mib = content.estimated_size_mib
+        storage_mib = Decimal(content.estimated_size_mib)
     else:
         file = get_file(session, content.item_hash)
         if not file:
             return []
-        storage_mib = int(file.size / MiB)
+        storage_mib = Decimal(file.size / MiB)
 
     volume = SizedVolume(CostType.STORAGE, storage_mib, item_hash)
 

--- a/src/aleph/types/cost.py
+++ b/src/aleph/types/cost.py
@@ -163,7 +163,7 @@ class SizedVolume(VolumeCost):
     def __init__(
         self,
         cost_type: CostType,
-        size_mib: int,
+        size_mib: Decimal,
         ref: Optional[str] = None,
         *args,
     ):

--- a/tests/message_processing/test_process_stores.py
+++ b/tests/message_processing/test_process_stores.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import json
+from decimal import Decimal
 from typing import Mapping, Optional
 
 import pytest
@@ -12,6 +13,7 @@ from aleph.db.models import MessageStatusDb, PendingMessageDb
 from aleph.handlers.content.store import StoreMessageHandler
 from aleph.handlers.message_handler import MessageHandler
 from aleph.jobs.process_pending_messages import PendingMessageProcessor
+from aleph.services.cost import get_total_and_detailed_costs_from_db
 from aleph.services.storage.engine import StorageEngine
 from aleph.storage import StorageService
 from aleph.toolkit.timestamp import timestamp_to_datetime
@@ -89,6 +91,14 @@ async def test_process_store(
             session=session, pending_message=fixture_store_message
         )
         session.commit()
+
+        cost, _ = get_total_and_detailed_costs_from_db(
+            session=session,
+            content=fixture_store_message.content,
+            item_hash=fixture_store_message.item_hash,
+        )
+
+        assert cost == Decimal("0.000004450480138778")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
For store message we used a `SizedVolume` who have `size_mib: int`.
for file of example 14 bytes when it will be converted to mib it's will be really small number and it's will be be round at `0`

## Self proofreading checklist

- [x] Is my code clear enough and well documented
- [x] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
This pull request focuses on improving the precision of volume size calculations by changing the type of `size_mib` from `int` to `Decimal` across various functions and classes in the `aleph` codebase. Additionally, it includes related updates to tests to ensure the new type is handled correctly.

Changes to improve precision:

* [`src/aleph/services/cost.py`](diffhunk://#diff-f183ca14faf6982071b5bc41d4d7cca82183f366bd550d4e2685841a118bb8f7L246): Updated multiple functions (`_get_volumes_costs`, `_get_execution_volumes_costs`, `_calculate_storage_costs`) to convert volume sizes to `Decimal` for more accurate calculations. [[1]](diffhunk://#diff-f183ca14faf6982071b5bc41d4d7cca82183f366bd550d4e2685841a118bb8f7L246) [[2]](diffhunk://#diff-f183ca14faf6982071b5bc41d4d7cca82183f366bd550d4e2685841a118bb8f7L293-R292) [[3]](diffhunk://#diff-f183ca14faf6982071b5bc41d4d7cca82183f366bd550d4e2685841a118bb8f7L338-R337) [[4]](diffhunk://#diff-f183ca14faf6982071b5bc41d4d7cca82183f366bd550d4e2685841a118bb8f7L360-R359) [[5]](diffhunk://#diff-f183ca14faf6982071b5bc41d4d7cca82183f366bd550d4e2685841a118bb8f7L497-R501)

Type change in class definition:

* [`src/aleph/types/cost.py`](diffhunk://#diff-9a4c656148132471ff89e844de9e46f1ec3a23326554132b19a830c593f832d0L166-R166): Modified the `SizedVolume` class to use `Decimal` for `size_mib` instead of `int`.

Updates to tests:

* [`tests/message_processing/test_process_stores.py`](diffhunk://#diff-06e9d035d574f2771892676a508df7eb3dc28def16dfaa0ae29dc795a0312953R3): Added `Decimal` import and updated tests to check the new `Decimal` type for volume sizes. Included a new test to assert the cost calculation using the `Decimal` type. [[1]](diffhunk://#diff-06e9d035d574f2771892676a508df7eb3dc28def16dfaa0ae29dc795a0312953R3) [[2]](diffhunk://#diff-06e9d035d574f2771892676a508df7eb3dc28def16dfaa0ae29dc795a0312953R16) [[3]](diffhunk://#diff-06e9d035d574f2771892676a508df7eb3dc28def16dfaa0ae29dc795a0312953R95-R102)
