### PR TITLE
fix docker compose dev allow git to read tags for pyaleph to be able to start

### DIFF
--- a/deployment/docker-build/dev/Dockerfile
+++ b/deployment/docker-build/dev/Dockerfile
@@ -53,7 +53,7 @@ COPY deployment/scripts ./deployment/scripts
 COPY .git ./.git
 COPY src ./src
 
-RUN pip install -e .[linting]
+RUN pip install -e .
 RUN pip install hatch
 
 FROM base

--- a/deployment/docker-build/dev/Dockerfile
+++ b/deployment/docker-build/dev/Dockerfile
@@ -73,6 +73,8 @@ RUN patch /etc/ssl/openssl.cnf /etc/ssl/openssl.cnf.patch
 
 RUN mkdir /var/lib/pyaleph
 
+RUN git config --global --add safe.directory /opt/pyaleph
+
 ENV PATH="/opt/venv/bin:${PATH}"
 WORKDIR /opt/pyaleph
 


### PR DESCRIPTION
- **pyaleph does not provide the lint subdependencies category**
- **fix(docker-compose-dev): allow git to read tags for pyaleph to be able to start"**
