### PR TITLE
chore: prevent pyproject-fmt from being annoying with trailing .0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,10 @@ git-only = [
 ]
 default-ignore = true
 
+[tool.pyproject-fmt]
+# if false will remove unnecessary trailing ``.0``'s from version specifiers
+keep_full_version = true
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 pythonpath = [ "src" ]


### PR DESCRIPTION
This avoid pyproject-fmt from breaking dependabot PR when a dependency number
ends with ".0" because we have better things to do.
