### PR TITLE
ALEPH-408 Storage on a CCN should be an option

### DIFF
--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -173,25 +173,26 @@ class StoreMessageHandler(ContentHandler):
                 )
                 do_standard_lookup = True
 
-        if config.storage.store_files.value and do_standard_lookup:
-            try:
-                file_content = await self.storage_service.get_hash_content(
-                    item_hash,
-                    engine=engine,
-                    tries=4,
-                    timeout=15,  # We only end up here for files < 1MB, a short timeout is okay
-                    use_network=True,
-                    use_ipfs=True,
-                    store_value=True,
-                )
-            except AlephStorageException:
-                raise FileUnavailable(
-                    "Could not retrieve file from storage at this time"
-                )
+        if do_standard_lookup:
+            if config.storage.store_files.value:
+                try:
+                    file_content = await self.storage_service.get_hash_content(
+                        item_hash,
+                        engine=engine,
+                        tries=4,
+                        timeout=15,  # We only end up here for files < 1MB, a short timeout is okay
+                        use_network=True,
+                        use_ipfs=True,
+                        store_value=True,
+                    )
+                except AlephStorageException:
+                    raise FileUnavailable(
+                        "Could not retrieve file from storage at this time"
+                    )
 
-            size = len(file_content)
-        elif not config.storage.store_files.value and do_standard_lookup:
-            size = -1
+                size = len(file_content)
+            else:
+                size = -1
 
         upsert_file(
             session=session,


### PR DESCRIPTION
Related Clickup or Jira tickets : [ALEPH-408](https://aleph-im.atlassian.net/browse/ALEPH-408)

## Self proofreading checklist

- [x] Is my code clear enough and well documented
- [x] Are my files well typed
- [x] Are there enough tests

## Changes

I'm not 100% sure about this approach but I've changed the behavior from doing
nothing to pretending we are storing a file in the database with a size of -1
while not doing the standard lookup nor talking to IPFS.

I'm wondering if we still shouldn't talk to IPFS but prevent it from pinning
the file?  It's unclear to me if we actually want to pin the file here.

## How to test

The tests should take care of it but I haven't been able to find how to
simulate a new message asking to store a file yet.
