### PR TITLE
fix(test_store_message): mock 'not called' was not tested correctly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,10 @@ git-only = [
 ]
 default-ignore = true
 
+[tool.pyproject-fmt]
+# if false will remove unnecessary trailing ``.0``'s from version specifiers
+keep_full_version = true
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 pythonpath = [ "src" ]

--- a/tests/storage/test_store_message.py
+++ b/tests/storage/test_store_message.py
@@ -153,4 +153,4 @@ async def test_handle_new_storage_directory(
     assert stored_file.size == ipfs_stats["CumulativeSize"]
     assert stored_file.type == FileType.DIRECTORY
 
-    assert not storage_engine.called
+    storage_engine.assert_not_called()


### PR DESCRIPTION
In mock the `.called` attribute doesn't mean anything, you need to use
`.assert_called` or `.assert_not_called` or the other methods.
