### PR TITLE
Fix: Remove references to slow server api1.aleph.im

### DIFF
--- a/deployment/samples/docker-compose/sample-config.yml
+++ b/deployment/samples/docker-compose/sample-config.yml
@@ -49,8 +49,8 @@ p2p:
   listen_port: 4031
   reconnect_delay: 60
   peers:
-    - /dns/api1.aleph.im/tcp/4025/p2p/Qmaxufiqdyt5uVWcy1Xh2nh3Rs3382ArnSP2umjCiNG2Vs
     - /dns/api2.aleph.im/tcp/4025/p2p/QmZkurbY2G2hWay59yiTgQNaQxHSNzKZFt2jbnwJhQcKgV
+    - /dns/api3.aleph.im/tcp/4025/p2p/Qmb5b2ZwJm9pVWrppf3D3iMF1bXbjZhbJTwGvKEBMZNxa2
 
 
 rabbitmq:

--- a/deployment/scripts/sync_initial_messages.py
+++ b/deployment/scripts/sync_initial_messages.py
@@ -17,7 +17,7 @@ initial_messages_list = [
     "bd79839bf96e595a06da5ac0b6ba51dea6f7e2591bb913deccded04d831d29f4",  # Legacy Diag VM runtime volume
 ]
 
-FROM_CCN = "http://api1.aleph.im"
+FROM_CCN = "http://api3.aleph.im"
 TO_CCN = "http://api2.aleph.im"
 PUB_SUB_TOPIC = "ALEPH-TEST"
 item_hashes_to_sync = ",".join(initial_messages_list)

--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -66,8 +66,8 @@ def get_defaults():
             "clients": ["http"],
             # Bootstrap peers for the P2P service.
             "peers": [
-                "/dns/api1.aleph.im/tcp/4025/p2p/Qmaxufiqdyt5uVWcy1Xh2nh3Rs3382ArnSP2umjCiNG2Vs",
                 "/dns/api2.aleph.im/tcp/4025/p2p/QmZkurbY2G2hWay59yiTgQNaQxHSNzKZFt2jbnwJhQcKgV",
+                "/dns/api3.aleph.im/tcp/4025/p2p/Qmb5b2ZwJm9pVWrppf3D3iMF1bXbjZhbJTwGvKEBMZNxa2",
             ],
             # Topics to listen to by default on the P2P service.
             "topics": ["ALIVE", "ALEPH-TEST"],
@@ -171,7 +171,6 @@ def get_defaults():
             "reconnect_delay": 60,
             # Bootstrap peers for IPFS.
             "peers": [
-                "/dnsaddr/api1.aleph.im/ipfs/12D3KooWNgogVS6o8fVsPdzh2FJpCdJJLVSgJT38XGE1BJoCerHx",
                 "/ip4/51.159.57.71/tcp/4001/p2p/12D3KooWBH3JVSBwHLNzxv7EzniBP3tDmjJaoa3EJBF9wyhZtHt2",
                 "/ip4/62.210.93.220/tcp/4001/p2p/12D3KooWLcmvqojHzUnR7rr8YhFKGDD8z7fmsPyBfAm2rT3sFGAF",
             ],

--- a/tests/services/test_node_cache.py
+++ b/tests/services/test_node_cache.py
@@ -33,8 +33,8 @@ async def test_api_servers_cache(node_cache: NodeCache):
 
     assert await node_cache.get_api_servers() == set()
 
-    api_server_1 = "https://api1.aleph.im"
-    api_server_2 = "https://api2.aleph.im"
+    api_server_1 = "https://api2.aleph.im"
+    api_server_2 = "https://api3.aleph.im"
 
     await node_cache.add_api_server(api_server_2)
     assert await node_cache.get_api_servers() == {api_server_2}


### PR DESCRIPTION
Server api1.aleph.im is very slow and outdated
(Core i7 from 2018, up to 40 seconds to respond
to `/metrics` in the monitoring).

We suspect that this causes issues in the
monitoring and performance of the network.

This branch removes all references to api1 and
replaces them with api3 where relevant.
