### PR TITLE
ci: avoid running tests twice

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -70,7 +70,6 @@ jobs:
           export OPENSSL_CONF=/etc/ssl/openssl.cnf
           touch config.yml  # Fake config file for alembic
           # TODO: determine why ResourceWarning warnings occur in some tests.
-          hatch run testing:test
 
       - run: |
           hatch run testing:cov


### PR DESCRIPTION
The line just after:

> hatch run testing:cov

Will also launch the tests so we are actually running them twice.
