### PR TITLE
Restore nix-shell on Ubuntu

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -30,5 +30,10 @@ jobs:
             # Use channel nixos-23.11 for Linux and nixpkgs-23.11-darwin for macOS
           nix_path: nixpkgs=channel:${{ matrix.os == 'macos-latest' && 'nixpkgs-24.05-darwin' || 'nixos-24.05' }}
 
+      - name: Disable incompatible dependency of `nuls2`
+        run: |
+          sed -i.bak '/py-ed25519-bindings/ s/^[[:space:]]*/# /' pyproject.toml
+          rm pyproject.toml.bak
+
       - name: Run tests
-        run: nix-shell --run "hatch run testing:test -- ./src/ ./test/"
+        run: nix-shell --run "hatch run testing:test"

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -5,14 +5,17 @@ name: Test nix-shell
 on:
   push:
     branches:
-      - 'doesnt_exist'
+      - '*'
 
 
 jobs:
   nix-shell:
+    continue-on-error: true
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
+        # os: [ubuntu-latest, macos-latest]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
   "aleph-message==0.6.1",
   "aleph-nuls2==0.1",
   "aleph-p2p-client @ git+https://github.com/aleph-im/p2p-service-client-python@cbfebb871db94b2ca580e66104a67cd730c5020c",
-  "aleph-pytezos==3.13.4",
   "asyncpg==0.30",
   "base58>=1.0.3",
   "coincurve==20",
@@ -50,6 +49,7 @@ dependencies = [
   "pycryptodome==3.21.0",                                                                                                  # for libp2p-stubs
   "pymultihash==0.8.2",                                                                                                    # for libp2p-stubs
   "pynacl==1.5",
+  "pytezos-crypto==3.13.4.1",
   "python-dateutil==2.8.2",
   "pytz==2023.3",
   "pyyaml==6.0.1",
@@ -62,7 +62,7 @@ dependencies = [
   "sqlalchemy-utils==0.38.3",
   "substrate-interface==1.7.4",
   "types-aiofiles==23.2.0.20240403",
-  "ujson==5.10.0",                                                                                                            # required by aiocache
+  "ujson==5.10.0",                                                                                                         # required by aiocache
   "urllib3==2.3",
   "uvloop==0.21",
   "web3==6.11.2",

--- a/src/aleph/chains/tezos.py
+++ b/src/aleph/chains/tezos.py
@@ -6,9 +6,9 @@ from typing import List
 
 import aiohttp
 from aleph_message.models import Chain
-from aleph_pytezos.crypto.key import Key
 from configmanager import Config
 from nacl.exceptions import BadSignatureError
+from pytezos_crypto.key import Key
 
 import aleph.toolkit.json as aleph_json
 from aleph.chains.abc import ChainReader, Verifier


### PR DESCRIPTION
Some dependency changes broke the `nix-shell` in the past.

This branch fixes the issues and restores a working `nix-shell` on Ubuntu.

Using it on macos did not work, see the error logs: https://github.com/aleph-im/pyaleph/actions/runs/13674053554/job/38230497745

The first commit is from https://github.com/aleph-im/pyaleph/pull/721, which is necessary for this branch to work.
