### PR TITLE
Fix: Solve EstimatedCostDetail response error.

### DIFF
--- a/src/aleph/schemas/api/costs.py
+++ b/src/aleph/schemas/api/costs.py
@@ -13,7 +13,7 @@ class EstimatedCostDetailResponse(BaseModel):
     cost_hold: str
     cost_stream: str
 
-    @field_validator("cost_hold", "cost_stream")
+    @field_validator("cost_hold", "cost_stream", mode="before")
     def check_format_price(cls, v):
         return format_cost_str(v)
 


### PR DESCRIPTION
When a price of an instance is requested, the CCN was returning that error:

```
Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/aiohttp/web_protocol.py", line 480, in _handle_request
    resp = await request_handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/aiohttp.py", line 157, in sentry_app_handle
    reraise(*_capture_exception())
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/utils.py", line 1718, in reraise
    raise value
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/aiohttp.py", line 140, in sentry_app_handle
    response = await old_handle(self, request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/aiohttp/web_app.py", line 569, in _handle
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pyaleph/src/aleph/web/controllers/prices.py", line 121, in message_price
    response = EstimatedCostsResponse.model_validate(model)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pydantic/main.py", line 703, in model_validate
    return cls.__pydantic_validator__.validate_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 6 validation errors for EstimatedCostsResponse
detail.0.cost_hold
  Input should be a valid string [type=string_type, input_value=Decimal('0E-18'), input_type=Decimal]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type
detail.0.cost_stream
  Input should be a valid string [type=string_type, input_value=Decimal('0.000233333333333333'), input_type=Decimal]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type
detail.1.cost_hold
  Input should be a valid string [type=string_type, input_value=Decimal('0E-18'), input_type=Decimal]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type
detail.1.cost_stream
  Input should be a valid string [type=string_type, input_value=Decimal('0.000094486755555555'), input_type=Decimal]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type
detail.2.cost_hold
  Input should be a valid string [type=string_type, input_value=Decimal('0E-18'), input_type=Decimal]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type
detail.2.cost_stream
  Input should be a valid string [type=string_type, input_value=Decimal('-0.000050022400000000'), input_type=Decimal]
    For further information visit https://errors.pydantic.dev/2.11/v/string_type
```

## Self proofreading checklist

- [X] Is my code clear enough and well documented
- [X] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [X] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Change the validation type to before mode as was used as a type conversion.

## How to test

Check that endpoint: http://51.159.223.120:4024/api/v0/price/d6494eda0950979f9fd554de142d9fc636a455b2c36a769042ba43aae1d204e7