### PR TITLE
Remove `datetime` field from message confirmations response

### DIFF
--- a/src/aleph/schemas/api/messages.py
+++ b/src/aleph/schemas/api/messages.py
@@ -42,11 +42,13 @@ class MessageConfirmation(BaseModel):
     chain: Chain
     height: int
     hash: str
-    datetime: dt.datetime
 
-    @field_serializer("datetime")
-    def serialize_time(self, dt: dt.datetime, _info) -> float:
-        return dt.timestamp()
+    # Omit this field for now as are not exported with previous Pydantic version. TODO: Review if has to be added
+    # datetime: dt.datetime
+    #
+    # @field_serializer("datetime")
+    # def serialize_time(self, dt: dt.datetime, _info) -> float:
+    #     return dt.timestamp()
 
 
 class BaseMessage(BaseModel, Generic[MType, ContentType]):


### PR DESCRIPTION
Fix: Remove `datetime` field from message confirmations as on the current implementation it is not exported.

## Self proofreading checklist

- [X] Is my code clear enough and well documented
- [X] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [X] Database migrations file are included
- [X] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Remove `datetime` field from message confirmations as on the current implementation it is not exported.

## How to test

Check that url http://51.159.223.120:4024/api/v0/messages/6a2abc608800c6063b93f1a99a9683052015d29830725d5300b0009de0668f4e and ensure that the `datetime` field it's not exported on message confirmations.
