### PR TITLE
Migrate last Pydantic V1 parsing methods

### DIFF
--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -234,7 +234,9 @@ async def _check_and_add_file(
             raise web.HTTPUnprocessableEntity(reason="Store message content needed")
 
         try:
-            message_content = CostEstimationStoreContent.parse_raw(message.item_content)
+            message_content = CostEstimationStoreContent.model_validate_json(
+                message.item_content
+            )
             message_content.estimated_size_mib = uploaded_file.size / MiB
 
             if message_content.item_hash != file_hash:
@@ -336,7 +338,7 @@ async def storage_add_file(request: web.Request):
                 metadata.file.read() if isinstance(metadata, FileField) else metadata
             )
             try:
-                storage_metadata = StorageMetadata.parse_raw(metadata_bytes)
+                storage_metadata = StorageMetadata.model_validate_json(metadata_bytes)
             except ValidationError as e:
                 raise web.HTTPUnprocessableEntity(
                     reason=f"Could not decode metadata: {e.json()}"

--- a/tests/chains/test_chain_data_service.py
+++ b/tests/chains/test_chain_data_service.py
@@ -45,7 +45,7 @@ async def test_prepare_sync_event_payload(mocker):
         session: DbSession, file_content: bytes, engine: ItemType = ItemType.ipfs
     ) -> str:
         content = file_content
-        archive = OnChainSyncEventPayload.parse_raw(content)
+        archive = OnChainSyncEventPayload.model_validate_json(content)
 
         assert archive.version == 1
         assert len(archive.content.messages) == len(messages)
@@ -113,7 +113,7 @@ async def test_smart_contract_protocol_ipfs_store(
     assert pending_message.channel is None
 
     assert pending_message.item_content
-    message_content = StoreContent.parse_raw(pending_message.item_content)
+    message_content = StoreContent.model_validate_json(pending_message.item_content)
     assert message_content.item_hash == payload.message_content
     assert message_content.item_type == ItemType.ipfs
     assert message_content.address == payload.addr
@@ -173,7 +173,7 @@ async def test_smart_contract_protocol_regular_message(
     assert pending_message.channel is None
 
     assert pending_message.item_content
-    message_content = PostContent.parse_raw(pending_message.item_content)
+    message_content = PostContent.model_validate_json(pending_message.item_content)
     assert message_content.address == content.address
     assert message_content.time == content.time
     assert message_content.ref == content.ref

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -319,7 +319,7 @@ def insert_volume_refs(session: DbSession, message: PendingMessageDb):
     Insert volume references in the DB to make the program processable.
     """
 
-    content = InstanceContent.parse_raw(message.item_content)
+    content = InstanceContent.model_validate_json(message.item_content)
     volumes = get_volume_refs(content)
 
     created = pytz.utc.localize(dt.datetime(2023, 1, 1))

--- a/tests/db/test_cost.py
+++ b/tests/db/test_cost.py
@@ -61,7 +61,7 @@ def insert_volume_refs(session: DbSession, message: MessageDb):
     """
 
     if message.item_content:
-        content = InstanceContent.parse_raw(message.item_content)
+        content = InstanceContent.model_validate_json(message.item_content)
         volumes = get_volume_refs(content)
 
         created = pytz.utc.localize(dt.datetime(2023, 1, 1))
@@ -98,7 +98,7 @@ async def insert_costs(session: DbSession, message: MessageDb):
     """
 
     if message.item_content:
-        content = InstanceContent.parse_raw(message.item_content)
+        content = InstanceContent.model_validate_json(message.item_content)
 
         _, costs = get_total_and_detailed_costs(session, content, message.item_hash)
 

--- a/tests/message_processing/test_process_confidential.py
+++ b/tests/message_processing/test_process_confidential.py
@@ -194,7 +194,7 @@ def get_volume_refs(content: ExecutableContent) -> List[ImmutableVolume]:
 
 def insert_volume_refs(session: DbSession, message: PendingMessageDb):
     item_content = message.item_content if message.item_content is not None else ""
-    content = InstanceContent.parse_raw(item_content)
+    content = InstanceContent.model_validate_json(item_content)
     volumes = get_volume_refs(content)
     created = pytz.utc.localize(dt.datetime(2023, 1, 1))
 

--- a/tests/message_processing/test_process_instances.py
+++ b/tests/message_processing/test_process_instances.py
@@ -338,7 +338,7 @@ def insert_volume_refs(session: DbSession, message: PendingMessageDb):
     """
 
     assert message.item_content
-    content = InstanceContent.parse_raw(message.item_content)
+    content = InstanceContent.model_validate_json(message.item_content)
     volumes = get_volume_refs(content)
 
     created = pytz.utc.localize(dt.datetime(2023, 1, 1))
@@ -488,7 +488,9 @@ async def test_process_instance_missing_volumes(
         assert rejected_message.error_code == ErrorCode.VM_VOLUME_NOT_FOUND
 
         if fixture_instance_message.item_content:
-            content = InstanceContent.parse_raw(fixture_instance_message.item_content)
+            content = InstanceContent.model_validate_json(
+                fixture_instance_message.item_content
+            )
             volume_refs = set(volume.ref for volume in get_volume_refs(content))
             assert isinstance(rejected_message.details, dict)
             assert set(rejected_message.details["errors"]) == volume_refs
@@ -570,7 +572,9 @@ async def test_get_additional_storage_price(
         session.commit()
 
     if fixture_instance_message.item_content:
-        content = InstanceContent.parse_raw(fixture_instance_message.item_content)
+        content = InstanceContent.model_validate_json(
+            fixture_instance_message.item_content
+        )
         with session_factory() as session:
             settings = _get_settings(session)
             pricing = _get_product_price(session, content, settings)
@@ -605,7 +609,9 @@ async def test_get_total_and_detailed_costs_from_db(
     _ = [message async for message in pipeline]
 
     if fixture_instance_message.item_content:
-        content = InstanceContent.parse_raw(fixture_instance_message.item_content)
+        content = InstanceContent.model_validate_json(
+            fixture_instance_message.item_content
+        )
         with session_factory() as session:
             cost, _ = get_total_and_detailed_costs(
                 session=session,
@@ -634,7 +640,7 @@ async def test_compare_account_cost_with_cost_function_hold(
     _ = [message async for message in pipeline]
 
     assert fixture_instance_message.item_content
-    content = InstanceContent.parse_raw(fixture_instance_message.item_content)
+    content = InstanceContent.model_validate_json(fixture_instance_message.item_content)
     with session_factory() as session:
         db_cost, _ = get_total_and_detailed_costs_from_db(
             session=session,
@@ -670,7 +676,7 @@ async def test_compare_account_cost_with_cost_payg_funct(
 
     assert fixture_instance_message_payg.item_content
 
-    content = InstanceContent.parse_raw(
+    content = InstanceContent.model_validate_json(
         fixture_instance_message_payg.item_content
     )  # Parse again
 
@@ -777,7 +783,7 @@ async def test_compare_account_cost_with_cost_function_without_volume(
     _ = [message async for message in pipeline]
 
     assert fixture_instance_message_only_rootfs.item_content
-    content = InstanceContent.parse_raw(
+    content = InstanceContent.model_validate_json(
         fixture_instance_message_only_rootfs.item_content
     )
     with session_factory() as session:

--- a/tests/message_processing/test_process_programs.py
+++ b/tests/message_processing/test_process_programs.py
@@ -117,7 +117,7 @@ def insert_volume_refs(session: DbSession, message: PendingMessageDb):
     """
 
     assert message.item_content
-    content = ProgramContent.parse_raw(message.item_content)
+    content = ProgramContent.model_validate_json(message.item_content)
     volumes = get_volumes_with_ref(content)
 
     created = pytz.utc.localize(dt.datetime(2023, 1, 1))
@@ -302,7 +302,7 @@ async def test_process_program_missing_volumes(
         assert rejected_message.error_code == ErrorCode.VM_VOLUME_NOT_FOUND
 
         assert program_message.item_content
-        content = ProgramContent.parse_raw(program_message.item_content)
+        content = ProgramContent.model_validate_json(program_message.item_content)
         volume_refs = set(volume.ref for volume in get_volumes_with_ref(content))
         assert isinstance(rejected_message.details, dict)
         assert set(rejected_message.details["errors"]) == volume_refs


### PR DESCRIPTION
Fix: Migrate pending pydantic v1 deprecated parsing methods for the pydantic v2

## Self proofreading checklist

- [X] Is my code clear enough and well documented
- [X] Are my files well typed
- [X] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [X] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Fix: Migrate pending pydantic v1 deprecated parsing methods for the pydantic v2
