### PR TITLE
Fix: pydantic migrations error handling

### DIFF
--- a/src/aleph/db/accessors/messages.py
+++ b/src/aleph/db/accessors/messages.py
@@ -468,6 +468,19 @@ def mark_pending_message_as_rejected(
         error_code = exception.error_code
         details = exception.details()
         exc_traceback = None
+
+        # Fix for ValueError in details - ensure all values are JSON serializable
+        if details and "errors" in details:
+            for error in details["errors"]:
+                if (
+                    isinstance(error, dict)
+                    and "ctx" in error
+                    and isinstance(error["ctx"], dict)
+                ):
+                    for key, value in list(error["ctx"].items()):
+                        # Convert any ValueError or other exceptions to strings
+                        if isinstance(value, Exception):
+                            error["ctx"][key] = str(value)
     else:
         error_code = ErrorCode.INTERNAL_ERROR
         details = None

--- a/src/aleph/schemas/pending_messages.py
+++ b/src/aleph/schemas/pending_messages.py
@@ -20,6 +20,7 @@ TODO: this module should reasonably be part of aleph message, if only
 import datetime as dt
 from typing import Any, Dict, Generic, Literal, Type
 
+import pydantic_core
 from aleph_message.models import (
     AggregateContent,
     Chain,
@@ -190,5 +191,5 @@ def parse_message(message_dict: Any) -> BasePendingMessage:
 
     try:
         return msg_cls(**message_dict)
-    except ValidationError as e:
+    except (ValidationError, pydantic_core.ValidationError) as e:
         raise InvalidMessageFormat(e.errors()) from e


### PR DESCRIPTION
When re syncing a node some message is not valid anymore,
Those message just getting re try and failing, the goal of this PR is to catch those error and reject 

Related Clickup or Jira tickets : ALEPH-XXX

## Self proofreading checklist

- [x] Is my code clear enough and well documented
- [x] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [ ] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
This pull request addresses error handling improvements and dependency updates in the message processing pipeline. The changes ensure better handling of serialization issues and expand exception handling for validation errors.

### Error Handling Improvements:
* [`src/aleph/db/accessors/messages.py`](diffhunk://#diff-b7d96eb0672e9d9cf9511dc29a0bde42fd4fe0355ef174531b712c69b0a959aaR471-R483): Added a fix to ensure all values in the `details` dictionary are JSON serializable, converting exceptions (e.g., `ValueError`) to strings when necessary. This prevents potential errors during logging or serialization.

### Dependency Updates:
* [`src/aleph/schemas/pending_messages.py`](diffhunk://#diff-8c8f6887a29c96d9e8da2f431201a368c44c2d50f51179ffcd310f31553ffa28R23): Added an import for `pydantic_core` to handle validation exceptions from Pydantic's core library.

### Validation Error Handling:
* [`src/aleph/schemas/pending_messages.py`](diffhunk://#diff-8c8f6887a29c96d9e8da2f431201a368c44c2d50f51179ffcd310f31553ffa28L193-R194): Updated the `parse_message` function to catch both `pydantic.ValidationError` and `pydantic_core.ValidationError`, ensuring broader coverage for validation-related exceptions.

## How to test

Explain how to test your PR.
Re sync a node

## Print screen / video
Some message who got now rejected:
```json
{
   "time":1574117628.065,
   "type":"POST",
   "chain":"NULS2",
   "sender":"NULSd6HgV6PB8e86EGg1LX1dK5zVqwnmHejb7",
   "channel":"MYALEPH",
   "item_hash":"6e887a519187182bd1222de80a9b214d4c6987de85b6836adc98c282fb712df5",
   "item_type":"inline",
   "signature":"G8OumEXfDCubJTFeyBsBRauM//W8MY9EwvJ2j8/OC0yGDixSmYQzJ0ol5rM1t2tf6dja0Wwp0AQfkwf/xDzs/P8=",
   "item_content":"{\"type\":\"amend\",\"address\":\"NULSd6HgV6PB8e86EGg1LX1dK5zVqwnmHejb7\",\"content\":{\"body\":\"\",\"title\":\"\"},\"time\":1574117628.065}"
}
```
Errors:
```json
{
   "errors":[
      {
         "ctx":{
            "error":"A 'ref' is required for POST type 'amend'"
         },
         "loc":[
            "content",
            "type"
         ],
         "msg":"Value error, A 'ref' is required for POST type 'amend'",
         "url":"https://errors.pydantic.dev/2.11/v/value_error",
         "type":"value_error",
         "input":"amend"
      }
   ]
}
```
## Notes

We might need to fully re sync a node and ensure no important message go rejected and shouldn't.
