### PR TITLE
Added balance pre-check on file pins

### DIFF
--- a/src/aleph/handlers/content/content_handler.py
+++ b/src/aleph/handlers/content/content_handler.py
@@ -1,7 +1,7 @@
 import abc
 from typing import List, Set
 
-from aleph.db.models import MessageDb
+from aleph.db.models import MessageDb, PendingMessageDb
 from aleph.db.models.account_costs import AccountCostsDb
 from aleph.permissions import check_sender_authorization
 from aleph.types.db_session import DbSession
@@ -45,6 +45,19 @@ class ContentHandler(abc.ABC):
         This function is in charge of:
         * checking permissions
         * applying DB updates.
+        """
+        pass
+
+    async def pre_check_balance(
+            self, session: DbSession, message: PendingMessageDb
+    ) -> None:
+        """
+        Checks whether the user has enough Aleph tokens before processing the message.
+
+        Raises InsufficientBalanceException if the balance of the user is too low.
+
+        :param session: DB session.
+        :param message: Pending Message being processed.
         """
         pass
 

--- a/src/aleph/handlers/content/content_handler.py
+++ b/src/aleph/handlers/content/content_handler.py
@@ -1,7 +1,7 @@
 import abc
 from typing import List, Set
 
-from aleph.db.models import MessageDb, PendingMessageDb
+from aleph.db.models import MessageDb
 from aleph.db.models.account_costs import AccountCostsDb
 from aleph.permissions import check_sender_authorization
 from aleph.types.db_session import DbSession
@@ -48,9 +48,7 @@ class ContentHandler(abc.ABC):
         """
         pass
 
-    async def pre_check_balance(
-            self, session: DbSession, message: PendingMessageDb
-    ) -> None:
+    async def pre_check_balance(self, session: DbSession, message: MessageDb) -> None:
         """
         Checks whether the user has enough Aleph tokens before processing the message.
 

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -238,6 +238,9 @@ class StoreMessageHandler(ContentHandler):
                 if storage_mib and storage_mib <= (
                     MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE / MiB
                 ):
+                    LOGGER.debug(
+                        f"Cost for {message.item_hash} supposed to be free as size is {storage_mib}"
+                    )
                     return True
 
                 computable_content_data = {

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -207,17 +207,16 @@ class StoreMessageHandler(ContentHandler):
         )
 
     async def pre_check_balance(
-            self, session: DbSession, message: PendingMessageDb
+            self, session: DbSession, message: MessageDb
     ):
         content = _get_store_content(message)
         assert isinstance(content, StoreContent)
 
-        # TODO: Improve the way to retrieve that state
         if are_store_and_program_free(message):
             return True
 
         # This check is essential to ensure that files are not added to the system
-        # or the current node when the configuration disables storing of files.
+        # on the current node when the configuration disables storing of files.
         config = get_config()
         ipfs_enabled = config.ipfs.enabled.value
 

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -8,11 +8,11 @@ TODO:
 import asyncio
 import datetime as dt
 import logging
+from decimal import Decimal
 from typing import List, Optional, Set
 
 import aioipfs
 from aleph_message.models import ItemHash, ItemType, StoreContent
-from decimal import Decimal
 
 from aleph.config import get_config
 from aleph.db.accessors.balances import get_total_balance
@@ -28,10 +28,11 @@ from aleph.db.accessors.files import (
     upsert_file,
     upsert_file_tag,
 )
-from aleph.db.models import MessageDb, PendingMessageDb
+from aleph.db.models import MessageDb
 from aleph.db.models.account_costs import AccountCostsDb
 from aleph.exceptions import AlephStorageException, UnknownHashError
 from aleph.handlers.content.content_handler import ContentHandler
+from aleph.schemas.cost_estimation_messages import CostEstimationStoreContent
 from aleph.services.cost import calculate_storage_size, get_total_and_detailed_costs
 from aleph.storage import StorageService
 from aleph.toolkit.constants import MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE, MiB
@@ -207,9 +208,7 @@ class StoreMessageHandler(ContentHandler):
             size=size,
         )
 
-    async def pre_check_balance(
-            self, session: DbSession, message: MessageDb
-    ):
+    async def pre_check_balance(self, session: DbSession, message: MessageDb):
         content = _get_store_content(message)
         assert isinstance(content, StoreContent)
 
@@ -229,15 +228,23 @@ class StoreMessageHandler(ContentHandler):
         engine = content.item_type
         # Initially only do that balance pre-check for ipfs files.
         if engine == ItemType.ipfs and ipfs_enabled:
-            ipfs_byte_size = await self.storage_service.ipfs_service.get_ipfs_size(content.item_hash)
-            storage_mib = Decimal(ipfs_byte_size / MiB)
-            message.content.estimated_size_mib = int(storage_mib)
-
-            message_cost, _ = get_total_and_detailed_costs(
-                session, content, message.item_hash
+            ipfs_byte_size = await self.storage_service.ipfs_service.get_ipfs_size(
+                content.item_hash
             )
+            if ipfs_byte_size:
+                storage_mib = Decimal(ipfs_byte_size / MiB)
+                computable_content = CostEstimationStoreContent.model_validate(
+                    **message.content
+                )
+                computable_content.estimated_size_mib = int(storage_mib)
+
+                message_cost, _ = get_total_and_detailed_costs(
+                    session, computable_content, message.item_hash
+                )
+            else:
+                message_cost = Decimal(0)
         else:
-            message_cost = 0
+            message_cost = Decimal(0)
 
         required_balance = current_cost + message_cost
 

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -233,6 +233,13 @@ class StoreMessageHandler(ContentHandler):
             )
             if ipfs_byte_size:
                 storage_mib = Decimal(ipfs_byte_size / MiB)
+
+                # Allow users to pin small files
+                if storage_mib and storage_mib <= (
+                    MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE / MiB
+                ):
+                    return True
+
                 computable_content_data = {
                     **content.model_dump(),
                     "estimated_size_mib": int(storage_mib),

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -233,10 +233,13 @@ class StoreMessageHandler(ContentHandler):
             )
             if ipfs_byte_size:
                 storage_mib = Decimal(ipfs_byte_size / MiB)
+                computable_content_data = {
+                    **content.model_dump(),
+                    "estimated_size_mib": int(storage_mib),
+                }
                 computable_content = CostEstimationStoreContent.model_validate(
-                    **message.content
+                    computable_content_data
                 )
-                computable_content.estimated_size_mib = int(storage_mib)
 
                 message_cost, _ = get_total_and_detailed_costs(
                     session, computable_content, message.item_hash

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -213,7 +213,7 @@ class StoreMessageHandler(ContentHandler):
         assert isinstance(content, StoreContent)
 
         if are_store_and_program_free(message):
-            return True
+            return None
 
         # This check is essential to ensure that files are not added to the system
         # on the current node when the configuration disables storing of files.
@@ -241,7 +241,7 @@ class StoreMessageHandler(ContentHandler):
                     LOGGER.debug(
                         f"Cost for {message.item_hash} supposed to be free as size is {storage_mib}"
                     )
-                    return True
+                    return None
 
                 computable_content_data = {
                     **content.model_dump(),
@@ -267,7 +267,7 @@ class StoreMessageHandler(ContentHandler):
                 required_balance=required_balance,
             )
 
-        return True
+        return None
 
     async def check_balance(
         self, session: DbSession, message: MessageDb

--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -376,9 +376,7 @@ class MessageHandler(BaseMessageHandler):
             insert_stmt = make_costs_upsert_query(costs)
             session.execute(insert_stmt)
 
-    async def verify_message(
-        self, pending_message: PendingMessageDb
-    ) -> MessageDb:
+    async def verify_message(self, pending_message: PendingMessageDb) -> MessageDb:
         await self.verify_signature(pending_message=pending_message)
         validated_message = await self.fetch_pending_message(
             pending_message=pending_message
@@ -431,9 +429,7 @@ class MessageHandler(BaseMessageHandler):
             )
 
         # First check the message content and verify it
-        message = await self.verify_message(
-            pending_message=pending_message
-        )
+        message = await self.verify_message(pending_message=pending_message)
 
         # Do a balance pre-check to avoid saving related data
         content_handler = self.get_content_handler(message.type)

--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -430,11 +430,16 @@ class MessageHandler(BaseMessageHandler):
                 error_code=ErrorCode.FORGOTTEN_DUPLICATE,
             )
 
+        # Before starting the real process of the message, do a balance pre-check to avoid saving un-needed files
+        # specially for IPFS service
+        pending_content_handler = self.get_content_handler(pending_message.type)
+        await pending_content_handler.pre_check_balance(session=session, message=pending_message)
+
         message = await self.verify_and_fetch(
             session=session, pending_message=pending_message
         )
 
-        content_handler = self.get_content_handler(message.type)
+        content_handler = self.get_content_handler(pending_message.type)
         await content_handler.check_dependencies(session=session, message=message)
         await content_handler.check_permissions(session=session, message=message)
         costs = await content_handler.check_balance(session=session, message=message)

--- a/src/aleph/jobs/fetch_pending_messages.py
+++ b/src/aleph/jobs/fetch_pending_messages.py
@@ -55,8 +55,8 @@ class PendingMessageFetcher(MessageJob):
     async def fetch_pending_message(self, pending_message: PendingMessageDb):
         with self.session_factory() as session:
             try:
-                message = await self.message_handler.verify_and_fetch(
-                    session=session, pending_message=pending_message
+                message = await self.message_handler.verify_message(
+                    pending_message=pending_message
                 )
                 session.execute(
                     make_pending_message_fetched_statement(

--- a/src/aleph/services/cost.py
+++ b/src/aleph/services/cost.py
@@ -344,22 +344,21 @@ def _get_execution_volumes_costs(
                 isinstance(content, CostEstimationProgramContent)
                 and content.data.estimated_size_mib
             ):
-                if content.data.estimated_size_mib:
-                    volumes.append(
-                        SizedVolume(
-                            CostType.EXECUTION_PROGRAM_VOLUME_DATA,
-                            Decimal(content.data.estimated_size_mib),
-                            content.data.ref,
-                        )
+                volumes.append(
+                    SizedVolume(
+                        CostType.EXECUTION_PROGRAM_VOLUME_DATA,
+                        Decimal(content.data.estimated_size_mib),
+                        content.data.ref,
                     )
-                else:
-                    volumes.append(
-                        RefVolume(
-                            CostType.EXECUTION_PROGRAM_VOLUME_DATA,
-                            content.data.ref,
-                            content.data.use_latest,
-                        ),
-                    )
+                )
+            else:
+                volumes.append(
+                    RefVolume(
+                        CostType.EXECUTION_PROGRAM_VOLUME_DATA,
+                        content.data.ref,
+                        content.data.use_latest,
+                    ),
+                )
 
     for i, volume in enumerate(content.volumes):
         # NOTE: There are legacy volumes with no "mount" property set

--- a/src/aleph/services/cost.py
+++ b/src/aleph/services/cost.py
@@ -299,7 +299,10 @@ def _get_execution_volumes_costs(
         )
 
     elif isinstance(content, (ProgramContent, CostEstimationProgramContent)):
-        if content.code.estimated_size_mib:
+        if (
+            isinstance(content, CostEstimationProgramContent)
+            and content.code.estimated_size_mib
+        ):
             volumes.append(
                 SizedVolume(
                     CostType.EXECUTION_PROGRAM_VOLUME_CODE,
@@ -316,7 +319,10 @@ def _get_execution_volumes_costs(
                 )
             )
 
-        if content.runtime.estimated_size_mib:
+        if (
+            isinstance(content, CostEstimationProgramContent)
+            and content.runtime.estimated_size_mib
+        ):
             volumes.append(
                 SizedVolume(
                     CostType.EXECUTION_PROGRAM_VOLUME_RUNTIME,
@@ -334,22 +340,26 @@ def _get_execution_volumes_costs(
             )
 
         if content.data:
-            if content.data.estimated_size_mib:
-                volumes.append(
-                    SizedVolume(
-                        CostType.EXECUTION_PROGRAM_VOLUME_DATA,
-                        Decimal(content.data.estimated_size_mib),
-                        content.data.ref,
+            if (
+                isinstance(content, CostEstimationProgramContent)
+                and content.data.estimated_size_mib
+            ):
+                if content.data.estimated_size_mib:
+                    volumes.append(
+                        SizedVolume(
+                            CostType.EXECUTION_PROGRAM_VOLUME_DATA,
+                            Decimal(content.data.estimated_size_mib),
+                            content.data.ref,
+                        )
                     )
-                )
-            else:
-                volumes.append(
-                    RefVolume(
-                        CostType.EXECUTION_PROGRAM_VOLUME_DATA,
-                        content.data.ref,
-                        content.data.use_latest,
-                    ),
-                )
+                else:
+                    volumes.append(
+                        RefVolume(
+                            CostType.EXECUTION_PROGRAM_VOLUME_DATA,
+                            content.data.ref,
+                            content.data.use_latest,
+                        ),
+                    )
 
     for i, volume in enumerate(content.volumes):
         # NOTE: There are legacy volumes with no "mount" property set
@@ -361,7 +371,10 @@ def _get_execution_volumes_costs(
                 f"{name_prefix}:{volume.mount or CostType.EXECUTION_VOLUME_INMUTABLE}"
             )
 
-            if volume.estimated_size_mib:
+            if (
+                isinstance(volume, CostEstimationImmutableVolume)
+                and volume.estimated_size_mib
+            ):
                 volumes.append(
                     SizedVolume(
                         CostType.EXECUTION_VOLUME_INMUTABLE,

--- a/src/aleph/services/cost.py
+++ b/src/aleph/services/cost.py
@@ -152,10 +152,10 @@ def _get_product_price_type(
     settings: Settings,
     price_aggregate: Union[AggregateDb, dict],
 ) -> ProductPriceType:
-    if isinstance(content, StoreContent):
+    if isinstance(content, (StoreContent, CostEstimationStoreContent)):
         return ProductPriceType.STORAGE
 
-    if isinstance(content, ProgramContent):
+    if isinstance(content, (ProgramContent, CostEstimationProgramContent)):
         is_on_demand = not content.on.persistent
         return (
             ProductPriceType.PROGRAM
@@ -225,7 +225,7 @@ def _get_nb_compute_units(
 def _get_compute_unit_multiplier(content: CostComputableContent) -> int:
     compute_unit_multiplier = 1
     if (
-        isinstance(content, ProgramContent)
+        isinstance(content, (ProgramContent, CostEstimationProgramContent))
         and not content.on.persistent
         and content.environment.internet
     ):
@@ -289,7 +289,7 @@ def _get_execution_volumes_costs(
 ) -> List[AccountCostsDb]:
     volumes: List[RefVolume | SizedVolume] = []
 
-    if isinstance(content, InstanceContent):
+    if isinstance(content, (InstanceContent, CostEstimationInstanceContent)):
         volumes.append(
             SizedVolume(
                 CostType.EXECUTION_INSTANCE_VOLUME_ROOTFS,
@@ -298,11 +298,8 @@ def _get_execution_volumes_costs(
             )
         )
 
-    elif isinstance(content, ProgramContent):
-        if (
-            isinstance(content, CostEstimationProgramContent)
-            and content.code.estimated_size_mib
-        ):
+    elif isinstance(content, (ProgramContent, CostEstimationProgramContent)):
+        if content.code.estimated_size_mib:
             volumes.append(
                 SizedVolume(
                     CostType.EXECUTION_PROGRAM_VOLUME_CODE,
@@ -319,10 +316,7 @@ def _get_execution_volumes_costs(
                 )
             )
 
-        if (
-            isinstance(content, CostEstimationProgramContent)
-            and content.runtime.estimated_size_mib
-        ):
+        if content.runtime.estimated_size_mib:
             volumes.append(
                 SizedVolume(
                     CostType.EXECUTION_PROGRAM_VOLUME_RUNTIME,
@@ -340,10 +334,7 @@ def _get_execution_volumes_costs(
             )
 
         if content.data:
-            if (
-                isinstance(content, CostEstimationProgramContent)
-                and content.data.estimated_size_mib
-            ):
+            if content.data.estimated_size_mib:
                 volumes.append(
                     SizedVolume(
                         CostType.EXECUTION_PROGRAM_VOLUME_DATA,
@@ -365,15 +356,12 @@ def _get_execution_volumes_costs(
         # or with same values for different volumes causing unique key constraint errors
         name_prefix = f"#{i}"
 
-        if isinstance(volume, ImmutableVolume):
+        if isinstance(volume, (ImmutableVolume, CostEstimationImmutableVolume)):
             name = (
                 f"{name_prefix}:{volume.mount or CostType.EXECUTION_VOLUME_INMUTABLE}"
             )
 
-            if (
-                isinstance(volume, CostEstimationImmutableVolume)
-                and volume.estimated_size_mib
-            ):
+            if volume.estimated_size_mib:
                 volumes.append(
                     SizedVolume(
                         CostType.EXECUTION_VOLUME_INMUTABLE,
@@ -582,7 +570,7 @@ def get_detailed_costs(
     settings = settings or _get_settings(session)
     pricing = pricing or _get_product_price(session, content, settings)
 
-    if isinstance(content, StoreContent):
+    if isinstance(content, (StoreContent, CostEstimationStoreContent)):
         return _calculate_storage_costs(session, content, pricing, item_hash)
     else:
         return _calculate_executable_costs(session, content, pricing, item_hash)

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -57,8 +57,63 @@ class IpfsService:
             if "127.0.0.1" in address and "/tcp" in address and "/p2p" in address:
                 return address.replace("127.0.0.1", public_ip)
 
+    async def get_ipfs_size(self, hash: str, timeout: int = 1, tries: int = 1) -> Optional[int]:
+        try_count = 0
+        result = None
+        while (result is None) and (try_count < tries):
+            try_count += 1
+            try:
+                dag_node = await asyncio.wait_for(
+                    self.ipfs_client.dag.get(hash), timeout=timeout
+                )
+                if isinstance(dag_node, dict):
+                    if 'Data' in dag_node and isinstance(dag_node['Data'], dict):
+                        # This is the common structure for UnixFS nodes after aioipfs parsing
+                        if 'filesize' in dag_node['Data']:
+                            result = dag_node['Data']['filesize']
+                        elif 'Tsize' in dag_node['Data']:  # Less common, but good to check
+                            result = dag_node['Data']['Tsize']
+                        elif 'Tsize' in dag_node:  # Sometimes it might be at the top level directly
+                            result = dag_node['Tsize']
+                    elif 'Links' in dag_node and isinstance(dag_node['Links'], list):
+                        total_size = 0
+                        for link in dag_node['Links']:
+                            # In case it's a link list, get the Tsize property if exists
+                            if 'Tsize' in link and isinstance(link['Tsize'], int):
+                                total_size += link['Tsize']
+                            else:
+                                LOGGER.error(f"Error: CID {hash} did not return a list structure. Type: {type(link)}")
+                        result = total_size
+
+                    elif 'Size' in dag_node:  # Occasionally, 'Size' might refer to total size, but often it's block
+                        # size
+                        result = dag_node['Size']
+                else:
+                    # For raw blocks, dag_node might be bytes. block.stat is better for those.
+                    # For other codecs, the structure will vary.
+                    LOGGER.info(f"Warning: CID {hash} did not return a dictionary structure. Type: {type(dag_node)}")
+                    block_stat = await asyncio.wait_for(
+                        self.ipfs_client.block.stat(hash), timeout=timeout
+                    )
+                    result = block_stat['Size']
+            except aioipfs.APIError:
+                result = None
+                await asyncio.sleep(0.5)
+                continue
+            except asyncio.TimeoutError:
+                result = None
+                await asyncio.sleep(0.5)
+            except (
+                    concurrent.futures.CancelledError,
+                    aiohttp.client_exceptions.ClientConnectorError,
+            ):
+                try_count -= 1  # do not count as a try.
+                await asyncio.sleep(0.1)
+
+            return result
+
     async def get_ipfs_content(
-        self, hash: str, timeout: int = 1, tries: int = 1
+            self, hash: str, timeout: int = 1, tries: int = 1
     ) -> Optional[bytes]:
         try_count = 0
         result = None
@@ -79,8 +134,8 @@ class IpfsService:
                 result = None
                 await asyncio.sleep(0.5)
             except (
-                concurrent.futures.CancelledError,
-                aiohttp.client_exceptions.ClientConnectorError,
+                    concurrent.futures.CancelledError,
+                    aiohttp.client_exceptions.ClientConnectorError,
             ):
                 try_count -= 1  # do not count as a try.
                 await asyncio.sleep(0.1)

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -57,7 +57,9 @@ class IpfsService:
             if "127.0.0.1" in address and "/tcp" in address and "/p2p" in address:
                 return address.replace("127.0.0.1", public_ip)
 
-    async def get_ipfs_size(self, hash: str, timeout: int = 1, tries: int = 1) -> Optional[int]:
+    async def get_ipfs_size(
+        self, hash: str, timeout: int = 1, tries: int = 1
+    ) -> Optional[int]:
         try_count = 0
         result = None
         while (result is None) and (try_count < tries):
@@ -67,35 +69,45 @@ class IpfsService:
                     self.ipfs_client.dag.get(hash), timeout=timeout
                 )
                 if isinstance(dag_node, dict):
-                    if 'Data' in dag_node and isinstance(dag_node['Data'], dict):
+                    if "Data" in dag_node and isinstance(dag_node["Data"], dict):
                         # This is the common structure for UnixFS nodes after aioipfs parsing
-                        if 'filesize' in dag_node['Data']:
-                            result = dag_node['Data']['filesize']
-                        elif 'Tsize' in dag_node['Data']:  # Less common, but good to check
-                            result = dag_node['Data']['Tsize']
-                        elif 'Tsize' in dag_node:  # Sometimes it might be at the top level directly
-                            result = dag_node['Tsize']
-                    elif 'Links' in dag_node and isinstance(dag_node['Links'], list):
+                        if "filesize" in dag_node["Data"]:
+                            result = dag_node["Data"]["filesize"]
+                        elif (
+                            "Tsize" in dag_node["Data"]
+                        ):  # Less common, but good to check
+                            result = dag_node["Data"]["Tsize"]
+                        elif (
+                            "Tsize" in dag_node
+                        ):  # Sometimes it might be at the top level directly
+                            result = dag_node["Tsize"]
+                    elif "Links" in dag_node and isinstance(dag_node["Links"], list):
                         total_size = 0
-                        for link in dag_node['Links']:
+                        for link in dag_node["Links"]:
                             # In case it's a link list, get the Tsize property if exists
-                            if 'Tsize' in link and isinstance(link['Tsize'], int):
-                                total_size += link['Tsize']
+                            if "Tsize" in link and isinstance(link["Tsize"], int):
+                                total_size += link["Tsize"]
                             else:
-                                LOGGER.error(f"Error: CID {hash} did not return a list structure. Type: {type(link)}")
+                                LOGGER.error(
+                                    f"Error: CID {hash} did not return a list structure. Type: {type(link)}"
+                                )
                         result = total_size
 
-                    elif 'Size' in dag_node:  # Occasionally, 'Size' might refer to total size, but often it's block
+                    elif (
+                        "Size" in dag_node
+                    ):  # Occasionally, 'Size' might refer to total size, but often it's block
                         # size
-                        result = dag_node['Size']
+                        result = dag_node["Size"]
                 else:
                     # For raw blocks, dag_node might be bytes. block.stat is better for those.
                     # For other codecs, the structure will vary.
-                    LOGGER.info(f"Warning: CID {hash} did not return a dictionary structure. Type: {type(dag_node)}")
+                    LOGGER.info(
+                        f"Warning: CID {hash} did not return a dictionary structure. Type: {type(dag_node)}"
+                    )
                     block_stat = await asyncio.wait_for(
                         self.ipfs_client.block.stat(hash), timeout=timeout
                     )
-                    result = block_stat['Size']
+                    result = block_stat["Size"]
             except aioipfs.APIError:
                 result = None
                 await asyncio.sleep(0.5)
@@ -104,16 +116,16 @@ class IpfsService:
                 result = None
                 await asyncio.sleep(0.5)
             except (
-                    concurrent.futures.CancelledError,
-                    aiohttp.client_exceptions.ClientConnectorError,
+                concurrent.futures.CancelledError,
+                aiohttp.client_exceptions.ClientConnectorError,
             ):
                 try_count -= 1  # do not count as a try.
                 await asyncio.sleep(0.1)
 
-            return result
+        return result
 
     async def get_ipfs_content(
-            self, hash: str, timeout: int = 1, tries: int = 1
+        self, hash: str, timeout: int = 1, tries: int = 1
     ) -> Optional[bytes]:
         try_count = 0
         result = None
@@ -134,8 +146,8 @@ class IpfsService:
                 result = None
                 await asyncio.sleep(0.5)
             except (
-                    concurrent.futures.CancelledError,
-                    aiohttp.client_exceptions.ClientConnectorError,
+                concurrent.futures.CancelledError,
+                aiohttp.client_exceptions.ClientConnectorError,
             ):
                 try_count -= 1  # do not count as a try.
                 await asyncio.sleep(0.1)

--- a/tests/message_processing/test_process_stores.py
+++ b/tests/message_processing/test_process_stores.py
@@ -2,21 +2,26 @@ import datetime as dt
 import json
 from decimal import Decimal
 from typing import Mapping, Optional
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from aleph_message.models import Chain, ItemHash, ItemType, MessageType
+from aleph_message.models import Chain, ItemHash, ItemType, MessageType, StoreContent
 from configmanager import Config
 
 from aleph.db.accessors.files import get_message_file_pin
 from aleph.db.accessors.messages import get_message_by_item_hash
-from aleph.db.models import MessageStatusDb, PendingMessageDb
+from aleph.db.models import AlephBalanceDb, MessageDb, MessageStatusDb, PendingMessageDb
+from aleph.db.models.account_costs import AccountCostsDb
 from aleph.handlers.content.store import StoreMessageHandler
 from aleph.handlers.message_handler import MessageHandler
 from aleph.jobs.process_pending_messages import PendingMessageProcessor
 from aleph.services.cost import get_total_and_detailed_costs_from_db
 from aleph.services.storage.engine import StorageEngine
 from aleph.storage import StorageService
-from aleph.toolkit.constants import STORE_AND_PROGRAM_COST_DEADLINE_TIMESTAMP
+from aleph.toolkit.constants import (
+    MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE,
+    STORE_AND_PROGRAM_COST_DEADLINE_TIMESTAMP,
+)
 from aleph.toolkit.timestamp import timestamp_to_datetime
 from aleph.types.channel import Channel
 from aleph.types.db_session import DbSessionFactory
@@ -63,6 +68,39 @@ def fixture_store_message_with_cost() -> PendingMessageDb:
             STORE_AND_PROGRAM_COST_DEADLINE_TIMESTAMP + 1
         ),
     )
+
+
+@pytest.fixture
+def create_message_db(mocker):
+    def _create_message(
+        item_hash="test-hash",
+        address="0xABCD1234",
+        time=STORE_AND_PROGRAM_COST_DEADLINE_TIMESTAMP + 1,
+        item_type=ItemType.ipfs,
+        item_content_hash="ipfs-content-hash",
+    ):
+        content = StoreContent(
+            address=address,
+            time=time,
+            item_type=item_type,
+            item_hash=item_content_hash,
+        )
+
+        message = mocker.MagicMock(spec=MessageDb)
+        message.item_hash = item_hash
+        message.type = MessageType.store
+        message.chain = Chain.ETH
+        message.sender = address
+        message.signature = "0xsignature"
+        message.item_type = ItemType.inline
+        message.item_content = json.dumps(content.model_dump())
+        message.parsed_content = content
+        message.time = timestamp_to_datetime(time)
+        message.channel = Channel("TEST")
+
+        return message
+
+    return _create_message
 
 
 # TODO: remove duplication of this class
@@ -281,3 +319,371 @@ async def test_process_store_small_file_no_balance_required(
             item_hash=ItemHash(fixture_store_message_with_cost.item_hash),
         )
         assert file_pin is not None
+
+
+# Tests specifically for the pre_check_balance method
+
+
+@pytest.mark.asyncio
+async def test_pre_check_balance_free_store_message(
+    mocker, session_factory, mock_config
+):
+    """Test that messages sent before the cost deadline are free."""
+    ipfs_service = mocker.AsyncMock()
+    storage_service = StorageService(
+        storage_engine=mocker.AsyncMock(),
+        ipfs_service=ipfs_service,
+        node_cache=mocker.AsyncMock(),
+    )
+    store_handler = StoreMessageHandler(
+        storage_service=storage_service,
+        grace_period=24,
+    )
+
+    with session_factory() as session:
+        # Create a message with timestamp before the deadline
+        message = mocker.MagicMock(spec=MessageDb)
+        content = StoreContent(
+            address="0xABCD1234",
+            time=STORE_AND_PROGRAM_COST_DEADLINE_TIMESTAMP - 1,
+            item_type=ItemType.ipfs,
+            item_hash="ipfs-content-hash",
+        )
+        message.parsed_content = content
+
+        # Should return None without checking balance
+        result = await store_handler.pre_check_balance(session, message)
+        assert result is None
+
+        # Verify that get_ipfs_size was not called
+        assert not ipfs_service.get_ipfs_size.called
+
+
+@pytest.mark.asyncio
+async def test_pre_check_balance_small_ipfs_file(mocker, session_factory, mock_config):
+    """Test that small IPFS files (<=25MiB) don't require balance."""
+    small_file_size = int(
+        MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE * 0.9
+    )  # 90% of max free size
+
+    ipfs_service = mocker.AsyncMock()
+    ipfs_service.get_ipfs_size = AsyncMock(return_value=small_file_size)
+
+    storage_service = StorageService(
+        storage_engine=mocker.AsyncMock(),
+        ipfs_service=ipfs_service,
+        node_cache=mocker.AsyncMock(),
+    )
+
+    store_handler = StoreMessageHandler(
+        storage_service=storage_service,
+        grace_period=24,
+    )
+
+    with session_factory() as session:
+        message = mocker.MagicMock(spec=MessageDb)
+        content = StoreContent(
+            address="0xABCD1234",
+            time=STORE_AND_PROGRAM_COST_DEADLINE_TIMESTAMP + 1,
+            item_type=ItemType.ipfs,
+            item_hash="ipfs-content-hash",
+        )
+        message.parsed_content = content
+
+        # Should return None without checking balance
+        result = await store_handler.pre_check_balance(session, message)
+        assert result is None
+
+        # Verify that get_ipfs_size was called with correct hash
+        ipfs_service.get_ipfs_size.assert_called_once_with("ipfs-content-hash")
+
+
+@pytest.mark.asyncio
+async def test_pre_check_balance_large_ipfs_file_insufficient_balance(
+    mocker,
+    session_factory,
+    mock_config,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """Test that large IPFS files (>25MiB) require sufficient balance."""
+    large_file_size = int(MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE * 2)  # 2x max free size
+
+    ipfs_service = mocker.AsyncMock()
+    ipfs_service.get_ipfs_size = AsyncMock(return_value=large_file_size)
+
+    storage_service = StorageService(
+        storage_engine=mocker.AsyncMock(),
+        ipfs_service=ipfs_service,
+        node_cache=mocker.AsyncMock(),
+    )
+
+    store_handler = StoreMessageHandler(
+        storage_service=storage_service,
+        grace_period=24,
+    )
+
+    with session_factory() as session:
+        message = mocker.MagicMock(spec=MessageDb)
+        content = StoreContent(
+            address="0xABCD1234",
+            time=STORE_AND_PROGRAM_COST_DEADLINE_TIMESTAMP + 1,
+            item_type=ItemType.ipfs,
+            item_hash="ipfs-content-hash",
+        )
+        message.parsed_content = content
+
+        # No balance in the account
+        with pytest.raises(InsufficientBalanceException) as exc_info:
+            await store_handler.pre_check_balance(session, message)
+
+        # Verify exception contains correct balance information
+        assert exc_info.value.balance == Decimal(0)
+        assert exc_info.value.required_balance > Decimal(0)
+
+        # Verify that get_ipfs_size was called with correct hash
+        ipfs_service.get_ipfs_size.assert_called_once_with("ipfs-content-hash")
+
+
+@pytest.mark.asyncio
+async def test_pre_check_balance_large_ipfs_file_sufficient_balance(
+    mocker,
+    session_factory,
+    mock_config,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """Test that large IPFS files (>25MiB) with sufficient balance pass the check."""
+    large_file_size = int(MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE * 2)  # 2x max free size
+
+    ipfs_service = mocker.AsyncMock()
+    ipfs_service.get_ipfs_size = AsyncMock(return_value=large_file_size)
+
+    storage_service = StorageService(
+        storage_engine=mocker.AsyncMock(),
+        ipfs_service=ipfs_service,
+        node_cache=mocker.AsyncMock(),
+    )
+
+    store_handler = StoreMessageHandler(
+        storage_service=storage_service,
+        grace_period=24,
+    )
+
+    with session_factory() as session:
+        # Create a message with a large file
+        address = "0xABCD1234"
+        message = mocker.MagicMock(spec=MessageDb)
+        content = StoreContent(
+            address=address,
+            time=STORE_AND_PROGRAM_COST_DEADLINE_TIMESTAMP + 1,
+            item_type=ItemType.ipfs,
+            item_hash="ipfs-content-hash",
+        )
+        message.parsed_content = content
+
+        # Add sufficient balance for the sender
+        session.add(
+            AlephBalanceDb(
+                address=address,
+                chain=Chain.ETH,
+                balance=Decimal(1000),  # Large enough to cover any costs
+                eth_height=100,
+            )
+        )
+        session.commit()
+
+        # Should pass the balance check
+        result = await store_handler.pre_check_balance(session, message)
+        assert result is None
+
+        # Verify that get_ipfs_size was called with correct hash
+        ipfs_service.get_ipfs_size.assert_called_once_with("ipfs-content-hash")
+
+
+@pytest.mark.asyncio
+async def test_pre_check_balance_non_ipfs_file(mocker, session_factory, mock_config):
+    """Test that non-IPFS files don't require a balance check."""
+    ipfs_service = mocker.AsyncMock()
+    ipfs_service.get_ipfs_size = AsyncMock()
+
+    storage_service = StorageService(
+        storage_engine=mocker.AsyncMock(),
+        ipfs_service=ipfs_service,
+        node_cache=mocker.AsyncMock(),
+    )
+
+    store_handler = StoreMessageHandler(
+        storage_service=storage_service,
+        grace_period=24,
+    )
+
+    with session_factory() as session:
+        # Create a message with a non-IPFS file type
+        message = mocker.MagicMock(spec=MessageDb)
+        content = StoreContent(
+            address="0xABCD1234",
+            time=STORE_AND_PROGRAM_COST_DEADLINE_TIMESTAMP + 1,
+            item_type=ItemType.storage,  # Not IPFS
+            item_hash="storage-content-hash",
+        )
+        message.parsed_content = content
+
+        # Should return None without checking balance
+        result = await store_handler.pre_check_balance(session, message)
+        assert result is None
+
+        # Verify that get_ipfs_size was not called
+        assert not ipfs_service.get_ipfs_size.called
+
+
+@pytest.mark.asyncio
+async def test_pre_check_balance_ipfs_disabled(mocker, session_factory):
+    """Test that when IPFS is disabled, no balance check is performed."""
+    ipfs_service = mocker.AsyncMock()
+    ipfs_service.get_ipfs_size = AsyncMock()
+
+    storage_service = StorageService(
+        storage_engine=mocker.AsyncMock(),
+        ipfs_service=ipfs_service,
+        node_cache=mocker.AsyncMock(),
+    )
+
+    store_handler = StoreMessageHandler(
+        storage_service=storage_service,
+        grace_period=24,
+    )
+
+    # Create a mock config with IPFS disabled
+    mock_config = mocker.MagicMock(spec=Config)
+    ipfs_config = mocker.MagicMock()
+    ipfs_config.enabled.value = False
+    mock_config.ipfs = ipfs_config
+
+    # Patch the get_config function to return our mock config
+    with patch("aleph.handlers.content.store.get_config", return_value=mock_config):
+        with session_factory() as session:
+            message = mocker.MagicMock(spec=MessageDb)
+            content = StoreContent(
+                address="0xABCD1234",
+                time=STORE_AND_PROGRAM_COST_DEADLINE_TIMESTAMP + 1,
+                item_type=ItemType.ipfs,
+                item_hash="ipfs-content-hash",
+            )
+            message.parsed_content = content
+
+            # Should return None without checking balance
+            result = await store_handler.pre_check_balance(session, message)
+            assert result is None
+
+            # Verify that get_ipfs_size was not called
+            assert not ipfs_service.get_ipfs_size.called
+
+
+@pytest.mark.asyncio
+async def test_pre_check_balance_ipfs_size_none(mocker, session_factory, mock_config):
+    """Test handling when get_ipfs_size returns None (file not found)."""
+    ipfs_service = mocker.AsyncMock()
+    ipfs_service.get_ipfs_size = AsyncMock(return_value=None)
+
+    storage_service = StorageService(
+        storage_engine=mocker.AsyncMock(),
+        ipfs_service=ipfs_service,
+        node_cache=mocker.AsyncMock(),
+    )
+
+    store_handler = StoreMessageHandler(
+        storage_service=storage_service,
+        grace_period=24,
+    )
+
+    with session_factory() as session:
+        message = mocker.MagicMock(spec=MessageDb)
+        content = StoreContent(
+            address="0xABCD1234",
+            time=STORE_AND_PROGRAM_COST_DEADLINE_TIMESTAMP + 1,
+            item_type=ItemType.ipfs,
+            item_hash="ipfs-content-hash",
+        )
+        message.parsed_content = content
+
+        # Should return None as no size means no cost
+        result = await store_handler.pre_check_balance(session, message)
+        assert result is None
+
+        # Verify that get_ipfs_size was called with correct hash
+        ipfs_service.get_ipfs_size.assert_called_once_with("ipfs-content-hash")
+
+
+@pytest.mark.asyncio
+async def test_pre_check_balance_with_existing_costs(
+    mocker,
+    session_factory,
+    mock_config,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """Test that existing costs for an address are considered."""
+    large_file_size = int(MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE * 2)  # 2x max free size
+
+    ipfs_service = mocker.AsyncMock()
+    ipfs_service.get_ipfs_size = AsyncMock(return_value=large_file_size)
+
+    storage_service = StorageService(
+        storage_engine=mocker.AsyncMock(),
+        ipfs_service=ipfs_service,
+        node_cache=mocker.AsyncMock(),
+    )
+
+    store_handler = StoreMessageHandler(
+        storage_service=storage_service,
+        grace_period=24,
+    )
+
+    with session_factory() as session:
+        # Create a message with a large file
+        address = "0xABCD1234"
+        message = mocker.MagicMock(spec=MessageDb)
+        content = StoreContent(
+            address=address,
+            time=STORE_AND_PROGRAM_COST_DEADLINE_TIMESTAMP + 1,
+            item_type=ItemType.ipfs,
+            item_hash="ipfs-content-hash",
+        )
+        message.parsed_content = content
+        message.item_hash = "test-message-hash"
+
+        # Add some existing costs for the address
+        session.add(
+            AccountCostsDb(
+                address=address,
+                message_type=MessageType.store,
+                cost=Decimal("10.0"),
+                file_size=1024,
+                volume_size=0,
+                vm_cost=Decimal("0"),
+                message_hash="previous-message-hash",
+            )
+        )
+
+        # Add balance that's enough for the new file but not for both
+        session.add(
+            AlephBalanceDb(
+                address=address,
+                chain=Chain.ETH,
+                balance=Decimal("15.0"),  # Not enough for existing + new
+                eth_height=100,
+            )
+        )
+        session.commit()
+
+        # Should fail the balance check
+        with pytest.raises(InsufficientBalanceException) as exc_info:
+            await store_handler.pre_check_balance(session, message)
+
+        # Verify exception contains correct balance information
+        assert exc_info.value.balance == Decimal("15.0")
+        assert exc_info.value.required_balance > Decimal("15.0")
+
+        # Verify that get_ipfs_size was called with correct hash
+        ipfs_service.get_ipfs_size.assert_called_once_with("ipfs-content-hash")

--- a/tests/services/test_ipfs_service.py
+++ b/tests/services/test_ipfs_service.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import aioipfs
 import pytest
@@ -198,40 +198,16 @@ async def test_get_ipfs_size_cancelled_error():
 
     service = IpfsService(ipfs_client=ipfs_client)
 
-    # Mock asyncio.sleep to not actually sleep during test
-    with patch("asyncio.sleep", new_callable=AsyncMock):
-        # Execute
-        result = await service.get_ipfs_size("test_hash", tries=2)
+    with pytest.raises(asyncio.CancelledError):
+        # Mock asyncio.sleep to not actually sleep during test
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            # Execute
+            result = await service.get_ipfs_size("test_hash", tries=2)
 
-    # Assert
-    assert result is None
-    # Should be called twice since CancelledError doesn't count as a try
-    assert ipfs_client.dag.get.call_count == 2
-
-
-@pytest.mark.asyncio
-async def test_get_ipfs_size_client_connection_error():
-    """Test handling of ClientConnectorError"""
-    # Setup
-    from aiohttp.client_exceptions import ClientConnectorError
-
-    ipfs_client = AsyncMock()
-    # Using side_effect to simulate connection error
-    ipfs_client.dag.get = AsyncMock(
-        side_effect=ClientConnectorError(MagicMock(), MagicMock())
-    )
-
-    service = IpfsService(ipfs_client=ipfs_client)
-
-    # Mock asyncio.sleep to not actually sleep during test
-    with patch("asyncio.sleep", new_callable=AsyncMock):
-        # Execute
-        result = await service.get_ipfs_size("test_hash", tries=2)
-
-    # Assert
-    assert result is None
-    # Should be called twice since ClientConnectorError doesn't count as a try
-    assert ipfs_client.dag.get.call_count == 2
+        # Assert
+        assert result is None
+        # Should be called twice since CancelledError doesn't count as a try
+        assert ipfs_client.dag.get.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_ipfs_service.py
+++ b/tests/services/test_ipfs_service.py
@@ -1,0 +1,256 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aioipfs
+import pytest
+
+from aleph.services.ipfs.service import IpfsService
+
+
+@pytest.mark.asyncio
+async def test_get_ipfs_size_data_filesize():
+    """Test when dag.get returns a dict with Data.filesize"""
+    # Setup
+    ipfs_client = AsyncMock()
+    ipfs_client.dag.get = AsyncMock(return_value={"Data": {"filesize": 1234}})
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    # Execute
+    result = await service.get_ipfs_size("test_hash")
+
+    # Assert
+    assert result == 1234
+    ipfs_client.dag.get.assert_called_once_with("test_hash")
+
+
+@pytest.mark.asyncio
+async def test_get_ipfs_size_data_tsize():
+    """Test when dag.get returns a dict with Data.Tsize"""
+    # Setup
+    ipfs_client = AsyncMock()
+    ipfs_client.dag.get = AsyncMock(return_value={"Data": {"Tsize": 2345}})
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    # Execute
+    result = await service.get_ipfs_size("test_hash")
+
+    # Assert
+    assert result == 2345
+    ipfs_client.dag.get.assert_called_once_with("test_hash")
+
+
+@pytest.mark.asyncio
+async def test_get_ipfs_size_tsize():
+    """Test when dag.get returns a dict with top level Tsize"""
+    # Setup
+    ipfs_client = AsyncMock()
+    ipfs_client.dag.get = AsyncMock(return_value={"Data": {}, "Tsize": 3456})
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    # Execute
+    result = await service.get_ipfs_size("test_hash")
+
+    # Assert
+    assert result == 3456
+    ipfs_client.dag.get.assert_called_once_with("test_hash")
+
+
+@pytest.mark.asyncio
+async def test_get_ipfs_size_links():
+    """Test when dag.get returns a dict with Links array containing Tsize values"""
+    # Setup
+    ipfs_client = AsyncMock()
+    ipfs_client.dag.get = AsyncMock(
+        return_value={"Links": [{"Tsize": 100}, {"Tsize": 200}, {"Tsize": 300}]}
+    )
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    # Execute
+    result = await service.get_ipfs_size("test_hash")
+
+    # Assert
+    assert result == 600  # Sum of all Tsize values
+    ipfs_client.dag.get.assert_called_once_with("test_hash")
+
+
+@pytest.mark.asyncio
+async def test_get_ipfs_size_links_invalid():
+    """Test when dag.get returns a dict with Links containing invalid entries"""
+    # Setup
+    ipfs_client = AsyncMock()
+    ipfs_client.dag.get = AsyncMock(
+        return_value={
+            "Links": [
+                {"Tsize": 100},
+                {"NoTsize": "invalid"},  # Missing Tsize
+                {"Tsize": 300},
+            ]
+        }
+    )
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    # Execute
+    result = await service.get_ipfs_size("test_hash")
+
+    # Assert
+    assert result == 400  # Sum of valid Tsize values
+    ipfs_client.dag.get.assert_called_once_with("test_hash")
+
+
+@pytest.mark.asyncio
+async def test_get_ipfs_size_size():
+    """Test when dag.get returns a dict with Size field"""
+    # Setup
+    ipfs_client = AsyncMock()
+    ipfs_client.dag.get = AsyncMock(return_value={"Size": 4567})
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    # Execute
+    result = await service.get_ipfs_size("test_hash")
+
+    # Assert
+    assert result == 4567
+    ipfs_client.dag.get.assert_called_once_with("test_hash")
+
+
+@pytest.mark.asyncio
+async def test_get_ipfs_size_non_dict():
+    """Test when dag.get returns a non-dictionary (bytes)"""
+    # Setup
+    ipfs_client = AsyncMock()
+    ipfs_client.dag.get = AsyncMock(return_value=b"raw data")
+    ipfs_client.block.stat = AsyncMock(return_value={"Size": 8765})
+
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    # Execute
+    result = await service.get_ipfs_size("test_hash")
+
+    # Assert
+    assert result == 8765
+    ipfs_client.dag.get.assert_called_once_with("test_hash")
+    ipfs_client.block.stat.assert_called_once_with("test_hash")
+
+
+@pytest.mark.asyncio
+async def test_get_ipfs_size_api_error():
+    """Test handling of APIError"""
+    # Setup
+    ipfs_client = AsyncMock()
+    ipfs_client.dag.get = AsyncMock(side_effect=aioipfs.APIError("API Error"))
+
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    # Execute with single try
+    result = await service.get_ipfs_size("test_hash", tries=1)
+
+    # Assert
+    assert result is None
+    ipfs_client.dag.get.assert_called_once_with("test_hash")
+
+
+@pytest.mark.asyncio
+async def test_get_ipfs_size_api_error_multiple_tries():
+    """Test handling of APIError with multiple tries"""
+    # Setup
+    ipfs_client = AsyncMock()
+    ipfs_client.dag.get = AsyncMock(side_effect=aioipfs.APIError("API Error"))
+
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    # Mock asyncio.sleep to not actually sleep during test
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        # Execute with multiple tries
+        result = await service.get_ipfs_size("test_hash", tries=3)
+
+    # Assert
+    assert result is None
+    assert ipfs_client.dag.get.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_get_ipfs_size_timeout_error():
+    """Test handling of TimeoutError"""
+    # Setup
+    ipfs_client = AsyncMock()
+    # Using side_effect to simulate timeout
+    ipfs_client.dag.get = AsyncMock(side_effect=asyncio.TimeoutError())
+
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    # Mock asyncio.sleep to not actually sleep during test
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        # Execute
+        result = await service.get_ipfs_size("test_hash")
+
+    # Assert
+    assert result is None
+    ipfs_client.dag.get.assert_called_once_with("test_hash")
+
+
+@pytest.mark.asyncio
+async def test_get_ipfs_size_cancelled_error():
+    """Test handling of CancelledError"""
+    # Setup
+    ipfs_client = AsyncMock()
+    # Using side_effect to simulate cancellation
+    ipfs_client.dag.get = AsyncMock(side_effect=asyncio.CancelledError())
+
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    # Mock asyncio.sleep to not actually sleep during test
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        # Execute
+        result = await service.get_ipfs_size("test_hash", tries=2)
+
+    # Assert
+    assert result is None
+    # Should be called twice since CancelledError doesn't count as a try
+    assert ipfs_client.dag.get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_ipfs_size_client_connection_error():
+    """Test handling of ClientConnectorError"""
+    # Setup
+    from aiohttp.client_exceptions import ClientConnectorError
+
+    ipfs_client = AsyncMock()
+    # Using side_effect to simulate connection error
+    ipfs_client.dag.get = AsyncMock(
+        side_effect=ClientConnectorError(MagicMock(), MagicMock())
+    )
+
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    # Mock asyncio.sleep to not actually sleep during test
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        # Execute
+        result = await service.get_ipfs_size("test_hash", tries=2)
+
+    # Assert
+    assert result is None
+    # Should be called twice since ClientConnectorError doesn't count as a try
+    assert ipfs_client.dag.get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_ipfs_size_success_after_retry():
+    """Test successful retrieval after initial failures"""
+    # Setup
+    ipfs_client = AsyncMock()
+    # First call fails, second call succeeds
+    ipfs_client.dag.get = AsyncMock(
+        side_effect=[aioipfs.APIError("API Error"), {"Data": {"filesize": 9876}}]
+    )
+
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    # Mock asyncio.sleep to not actually sleep during test
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        # Execute with multiple tries
+        result = await service.get_ipfs_size("test_hash", tries=3)
+
+    # Assert
+    assert result == 9876
+    assert ipfs_client.dag.get.call_count == 2

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -121,7 +121,5 @@ async def test_incoming_inline_content(
         fetched=True,
     )
 
-    message = await message_handler.verify_message(
-        pending_message=pending_message
-    )
+    message = await message_handler.verify_message(pending_message=pending_message)
     assert message is not None

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -121,8 +121,7 @@ async def test_incoming_inline_content(
         fetched=True,
     )
 
-    with session_factory() as session:
-        message = await message_handler.verify_and_fetch(
-            session=session, pending_message=pending_message
-        )
+    message = await message_handler.verify_message(
+        pending_message=pending_message
+    )
     assert message is not None


### PR DESCRIPTION
This PR solves the issue when a user tries to pin a big file on IPFS without having a balance.

## Self proofreading checklist

- [X] Is my code clear enough and well documented
- [X] Are my files well typed
- [X] New translations have been added or updated if new strings have been introduced in the frontend
- [X] Database migrations file are included
- [X] Are there enough tests
- [X] Documentation has been included (for new feature)

## Changes

Added a pre-check balance checking the IPFS file without having to download it. It will work only on unifs type pins, but will save us a lot of useless disk usage.

## How to test

Try to pin a big file on the network with an empty wallet and check that file is not saved either on the database and the message is rejected so faster.