### PR TITLE
Migrate Pydantic to new interface

### DIFF
--- a/tests/message_processing/test_process_instances.py
+++ b/tests/message_processing/test_process_instances.py
@@ -294,7 +294,7 @@ def fixture_forget_instance_message(
         sender=fixture_instance_message.sender,
         signature=None,
         item_type=ItemType.inline,
-        item_content=content.json(),
+        item_content=content.model_dump_json(),
         time=fixture_instance_message.time + dt.timedelta(seconds=1),
         channel=None,
         reception_time=fixture_instance_message.reception_time

--- a/tests/message_processing/test_process_pending_txs.py
+++ b/tests/message_processing/test_process_pending_txs.py
@@ -214,7 +214,7 @@ async def test_process_pending_smart_contract_tx_post(
             type="my-type",
             address="KT1VBeLD7hzKpj17aRJ3Kc6QQFeikCEXi7W6",
             time=1000,
-        ).json(),
+        ).model_dump_json(),
     )
 
     await _process_smart_contract_tx(

--- a/tests/schemas/test_pending_messages.py
+++ b/tests/schemas/test_pending_messages.py
@@ -170,7 +170,7 @@ def test_parse_program_message():
     content = json.loads(message_dict["item_content"])
     assert message.content.address == content["address"]
     assert message.content.time == content["time"]
-    assert message.content.code.dict(exclude_none=True) == content["code"]
+    assert message.content.code.model_dump(exclude_none=True) == content["code"]
     assert message.content.type == content["type"]
 
 


### PR DESCRIPTION
## Self proofreading checklist

- [x] Is my code clear enough and well documented
- [x] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
This PR addresses several `PydanticDeprecatedSince20` warnings by updating Pydantic V1 method calls to their V2 equivalents across various test files:

- Replaced `instance.json()` with `instance.model_dump_json()` in:
    - `tests/message_processing/test_process_instances.py`
    - `tests/message_processing/test_process_pending_txs.py`
- Replaced `instance.dict()` with `instance.model_dump()` in `tests/schemas/test_pending_messages.py`.

These changes ensure compatibility with Pydantic V2 and resolve deprecation warnings observed in CI, such as those detailed in the [CI logs](https://github.com/aleph-im/pyaleph/actions/runs/15485681123/job/43599721593#step:11:470).

## How to test
Run the test suite.

## Print screen / video


## Notes

