### PR TITLE
Fix: remove I/O Blocking code on message processing parts

### DIFF
--- a/src/aleph/api_entrypoint.py
+++ b/src/aleph/api_entrypoint.py
@@ -7,7 +7,7 @@ from configmanager import Config
 
 import aleph.config
 from aleph.chains.signature_verifier import SignatureVerifier
-from aleph.db.connection import make_engine, make_session_factory
+from aleph.db.connection import make_async_engine, make_async_session_factory
 from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
 from aleph.services.p2p import init_p2p_client
@@ -34,12 +34,12 @@ async def configure_aiohttp_app(
     with sentry_sdk.start_transaction(name="init-api-server"):
         p2p_client = await init_p2p_client(config, service_name="api-server-aiohttp")
 
-        engine = make_engine(
+        engine = make_async_engine(
             config,
             echo=config.logging.level.value == logging.DEBUG,
             application_name="aleph-api",
         )
-        session_factory = make_session_factory(engine)
+        session_factory = make_async_session_factory(engine)
 
         node_cache = NodeCache(
             redis_host=config.redis.host.value, redis_port=config.redis.port.value

--- a/src/aleph/chains/bsc.py
+++ b/src/aleph/chains/bsc.py
@@ -5,13 +5,13 @@ from aleph.chains.abc import ChainReader
 from aleph.chains.chain_data_service import PendingTxPublisher
 from aleph.chains.indexer_reader import AlephIndexerReader
 from aleph.types.chain_sync import ChainEventType
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 
 class BscConnector(ChainReader):
     def __init__(
         self,
-        session_factory: DbSessionFactory,
+        session_factory: AsyncDbSessionFactory,
         pending_tx_publisher: PendingTxPublisher,
     ):
         self.indexer_reader = AlephIndexerReader(

--- a/src/aleph/chains/connector.py
+++ b/src/aleph/chains/connector.py
@@ -5,7 +5,7 @@ from typing import Dict, Union
 from aleph_message.models import Chain
 from configmanager import Config
 
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 from .abc import ChainReader, ChainWriter
 from .bsc import BscConnector
@@ -29,7 +29,7 @@ class ChainConnector:
 
     def __init__(
         self,
-        session_factory: DbSessionFactory,
+        session_factory: AsyncDbSessionFactory,
         pending_tx_publisher: PendingTxPublisher,
         chain_data_service: ChainDataService,
     ):

--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -26,7 +26,11 @@ import aleph.config
 from aleph.chains.chain_data_service import ChainDataService, PendingTxPublisher
 from aleph.chains.connector import ChainConnector
 from aleph.cli.args import parse_args
-from aleph.db.connection import make_db_url, make_engine, make_session_factory
+from aleph.db.connection import (
+    make_async_engine,
+    make_async_session_factory,
+    make_db_url,
+)
 from aleph.exceptions import InvalidConfigException, KeyNotFoundException
 from aleph.jobs import start_jobs
 from aleph.jobs.cron.balance_job import BalanceCronJob
@@ -124,12 +128,12 @@ async def main(args: List[str]) -> None:
         run_db_migrations(config)
     LOGGER.info("Database initialized.")
 
-    engine = make_engine(
+    engine = make_async_engine(
         config,
         echo=args.loglevel == logging.DEBUG,
         application_name="aleph-conn-manager",
     )
-    session_factory = make_session_factory(engine)
+    session_factory = make_async_session_factory(engine)
 
     setup_logging(args.loglevel)
 

--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -154,7 +154,6 @@ async def update_balances(
     )
 
     # Convert floats to str to avoid having issue with float to decimal conversion
-
     records = [
         (address, chain.value, dapp or "", str(balance), eth_height, last_update)
         for address, balance in balances.items()

--- a/src/aleph/db/accessors/cron_jobs.py
+++ b/src/aleph/db/accessors/cron_jobs.py
@@ -4,28 +4,30 @@ from typing import List, Optional
 from sqlalchemy import delete, select, update
 
 from aleph.db.models.cron_jobs import CronJobDb
-from aleph.types.db_session import DbSession
+from aleph.types.db_session import AsyncDbSession
 
 
-def get_cron_jobs(session: DbSession) -> List[CronJobDb]:
+async def get_cron_jobs(session: AsyncDbSession) -> List[CronJobDb]:
     select_stmt = select(CronJobDb)
 
-    return (session.execute(select_stmt)).scalars().all()
+    return (await session.execute(select_stmt)).scalars().all()
 
 
-def get_cron_job(session: DbSession, id: str) -> Optional[CronJobDb]:
+async def get_cron_job(session: AsyncDbSession, id: str) -> Optional[CronJobDb]:
     select_stmt = select(CronJobDb).where(CronJobDb.id == id)
 
-    return (session.execute(select_stmt)).scalar_one_or_none()
+    return (await session.execute(select_stmt)).scalar_one_or_none()
 
 
-def update_cron_job(session: DbSession, id: str, last_run: dt.datetime) -> None:
+async def update_cron_job(
+    session: AsyncDbSession, id: str, last_run: dt.datetime
+) -> None:
     update_stmt = update(CronJobDb).values(last_run=last_run).where(CronJobDb.id == id)
 
-    session.execute(update_stmt)
+    await session.execute(update_stmt)
 
 
-def delete_cron_job(session: DbSession, id: str) -> None:
+async def delete_cron_job(session: AsyncDbSession, id: str) -> None:
     delete_stmt = delete(CronJobDb).where(CronJobDb.id == id)
 
-    session.execute(delete_stmt)
+    await session.execute(delete_stmt)

--- a/src/aleph/db/accessors/metrics.py
+++ b/src/aleph/db/accessors/metrics.py
@@ -2,9 +2,8 @@ import time
 from typing import Optional
 
 from sqlalchemy import select, text
-from sqlalchemy.orm.session import Session
 
-from aleph.types.db_session import DbSession
+from aleph.types.db_session import AsyncDbSession
 
 
 def _parse_ccn_result(result):
@@ -60,8 +59,8 @@ def _build_metric_filter(select_stmt, node_id, start_date, end_date, sort_order)
     return select_stmt
 
 
-def query_metric_ccn(
-    session: Session,
+async def query_metric_ccn(
+    session: AsyncDbSession,
     node_id: Optional[str] = None,
     start_date: Optional[float] = None,
     end_date: Optional[float] = None,
@@ -95,13 +94,13 @@ def query_metric_ccn(
         sort_order=sort_order,
     )
 
-    result = session.execute(select_stmt).fetchall()
+    result = (await session.execute(select_stmt)).fetchall()
 
     return _parse_ccn_result(result=result)
 
 
-def query_metric_crn(
-    session: DbSession,
+async def query_metric_crn(
+    session: AsyncDbSession,
     node_id: str,
     start_date: Optional[float] = None,
     end_date: Optional[float] = None,
@@ -132,6 +131,6 @@ def query_metric_crn(
         sort_order=sort_order,
     )
 
-    result = session.execute(select_stmt).fetchall()
+    result = (await session.execute(select_stmt)).fetchall()
 
     return _parse_crn_result(result=result)

--- a/src/aleph/db/accessors/peers.py
+++ b/src/aleph/db/accessors/peers.py
@@ -5,22 +5,22 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 
 from aleph.toolkit.timestamp import utc_now
-from aleph.types.db_session import DbSession
+from aleph.types.db_session import AsyncDbSession
 
 from ..models.peers import PeerDb, PeerType
 
 
-def get_all_addresses_by_peer_type(
-    session: DbSession, peer_type: PeerType
+async def get_all_addresses_by_peer_type(
+    session: AsyncDbSession, peer_type: PeerType
 ) -> Sequence[str]:
     select_peers_stmt = select(PeerDb.address).where(PeerDb.peer_type == peer_type)
 
-    addresses = session.execute(select_peers_stmt)
+    addresses = await session.execute(select_peers_stmt)
     return addresses.scalars().all()
 
 
-def upsert_peer(
-    session: DbSession,
+async def upsert_peer(
+    session: AsyncDbSession,
     peer_id: str,
     peer_type: PeerType,
     address: str,
@@ -43,4 +43,4 @@ def upsert_peer(
             set_={"address": address, "source": source, "last_seen": last_seen},
         )
     )
-    session.execute(upsert_stmt)
+    await session.execute(upsert_stmt)

--- a/src/aleph/db/accessors/pending_txs.py
+++ b/src/aleph/db/accessors/pending_txs.py
@@ -6,19 +6,23 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import selectinload
 
 from aleph.db.models import ChainTxDb, PendingTxDb
-from aleph.types.db_session import DbSession
+from aleph.types.db_session import AsyncDbSession
 
 
-def get_pending_tx(session: DbSession, tx_hash: str) -> Optional[PendingTxDb]:
+async def get_pending_tx(
+    session: AsyncDbSession, tx_hash: str
+) -> Optional[PendingTxDb]:
     select_stmt = (
         select(PendingTxDb)
         .where(PendingTxDb.tx_hash == tx_hash)
         .options(selectinload(PendingTxDb.tx))
     )
-    return (session.execute(select_stmt)).scalar_one_or_none()
+    return (await session.execute(select_stmt)).scalar_one_or_none()
 
 
-def get_pending_txs(session: DbSession, limit: int = 200) -> Iterable[PendingTxDb]:
+async def get_pending_txs(
+    session: AsyncDbSession, limit: int = 200
+) -> Iterable[PendingTxDb]:
     select_stmt = (
         select(PendingTxDb)
         .join(ChainTxDb, PendingTxDb.tx_hash == ChainTxDb.hash)
@@ -26,24 +30,26 @@ def get_pending_txs(session: DbSession, limit: int = 200) -> Iterable[PendingTxD
         .limit(limit)
         .options(selectinload(PendingTxDb.tx))
     )
-    return (session.execute(select_stmt)).scalars()
+    return (await session.execute(select_stmt)).scalars()
 
 
-def count_pending_txs(session: DbSession, chain: Optional[Chain] = None) -> int:
+async def count_pending_txs(
+    session: AsyncDbSession, chain: Optional[Chain] = None
+) -> int:
     select_stmt = select(func.count(PendingTxDb.tx_hash))
     if chain:
         select_stmt = select_stmt.join(
             ChainTxDb, PendingTxDb.tx_hash == ChainTxDb.hash
         ).where(ChainTxDb.chain == chain)
 
-    return (session.execute(select_stmt)).scalar_one()
+    return (await session.execute(select_stmt)).scalar_one()
 
 
-def upsert_pending_tx(session: DbSession, tx_hash: str) -> None:
+async def upsert_pending_tx(session: AsyncDbSession, tx_hash: str) -> None:
     upsert_stmt = insert(PendingTxDb).values(tx_hash=tx_hash).on_conflict_do_nothing()
-    session.execute(upsert_stmt)
+    await session.execute(upsert_stmt)
 
 
-def delete_pending_tx(session: DbSession, tx_hash: str) -> None:
+async def delete_pending_tx(session: AsyncDbSession, tx_hash: str) -> None:
     delete_stmt = delete(PendingTxDb).where(PendingTxDb.tx_hash == tx_hash)
-    session.execute(delete_stmt)
+    await session.execute(delete_stmt)

--- a/src/aleph/db/accessors/vms.py
+++ b/src/aleph/db/accessors/vms.py
@@ -3,11 +3,13 @@ from typing import Iterable, Optional
 
 from sqlalchemy import delete, func, or_, select
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import selectinload, with_polymorphic
 
 from aleph.db.models.vms import (
     CodeVolumeDb,
     DataVolumeDb,
     ImmutableVolumeDb,
+    MachineVolumeBaseDb,
     ProgramDb,
     RootfsVolumeDb,
     RuntimeDb,
@@ -15,54 +17,78 @@ from aleph.db.models.vms import (
     VmInstanceDb,
     VmVersionDb,
 )
-from aleph.types.db_session import DbSession
+from aleph.types.db_session import AsyncDbSession
 from aleph.types.vms import VmVersion
 
-
-def get_instance(session: DbSession, item_hash: str) -> Optional[VmInstanceDb]:
-    select_stmt = select(VmInstanceDb).where(VmInstanceDb.item_hash == item_hash)
-    return session.execute(select_stmt).scalar_one_or_none()
+VolumeWithSubtypes = with_polymorphic(MachineVolumeBaseDb, "*")
 
 
-def get_program(session: DbSession, item_hash: str) -> Optional[ProgramDb]:
-    select_stmt = select(ProgramDb).where(ProgramDb.item_hash == item_hash)
-    return session.execute(select_stmt).scalar_one_or_none()
+async def get_instance(
+    session: AsyncDbSession, item_hash: str
+) -> Optional[VmInstanceDb]:
+    stmt = (
+        select(VmInstanceDb)
+        .options(
+            selectinload(VmInstanceDb.volumes.of_type(VolumeWithSubtypes)),
+            selectinload(VmInstanceDb.rootfs),
+        )
+        .where(VmInstanceDb.item_hash == item_hash)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
 
 
-def is_vm_amend_allowed(session: DbSession, vm_hash: str) -> Optional[bool]:
+async def get_program(session: AsyncDbSession, item_hash: str) -> Optional[ProgramDb]:
+    stmt = (
+        select(ProgramDb)
+        .options(
+            selectinload(ProgramDb.code_volume),
+            selectinload(ProgramDb.runtime),
+            selectinload(ProgramDb.data_volume),
+            selectinload(ProgramDb.volumes.of_type(VolumeWithSubtypes)),
+        )
+        .where(ProgramDb.item_hash == item_hash)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def is_vm_amend_allowed(session: AsyncDbSession, vm_hash: str) -> Optional[bool]:
     select_stmt = (
         select(VmBaseDb.allow_amend)
         .select_from(VmVersionDb)
         .join(VmBaseDb, VmVersionDb.current_version == VmBaseDb.item_hash)
         .where(VmVersionDb.vm_hash == vm_hash)
     )
-    return session.execute(select_stmt).scalar_one_or_none()
+    return (await session.execute(select_stmt)).scalar_one_or_none()
 
 
-def _delete_vm(session: DbSession, where) -> Iterable[str]:
+async def _delete_vm(session: AsyncDbSession, where) -> Iterable[str]:
     # Deletion of volumes is managed automatically by the DB
     # using an "on delete cascade" foreign key.
-    return session.execute(
-        delete(VmBaseDb).where(where).returning(VmBaseDb.item_hash)
+    return (
+        await session.execute(
+            delete(VmBaseDb).where(where).returning(VmBaseDb.item_hash)
+        )
     ).scalars()
 
 
-def delete_vm(session: DbSession, vm_hash: str) -> None:
-    _ = _delete_vm(session=session, where=VmBaseDb.item_hash == vm_hash)
+async def delete_vm(session: AsyncDbSession, vm_hash: str) -> None:
+    _ = await _delete_vm(session=session, where=VmBaseDb.item_hash == vm_hash)
 
 
-def delete_vm_updates(session: DbSession, vm_hash: str) -> Iterable[str]:
-    return _delete_vm(session=session, where=VmBaseDb.replaces == vm_hash)
+async def delete_vm_updates(session: AsyncDbSession, vm_hash: str) -> Iterable[str]:
+    return await _delete_vm(session=session, where=VmBaseDb.replaces == vm_hash)
 
 
-def get_vm_version(session: DbSession, vm_hash: str) -> Optional[VmVersionDb]:
-    return session.execute(
-        select(VmVersionDb).where(VmVersionDb.vm_hash == vm_hash)
+async def get_vm_version(
+    session: AsyncDbSession, vm_hash: str
+) -> Optional[VmVersionDb]:
+    return (
+        await session.execute(select(VmVersionDb).where(VmVersionDb.vm_hash == vm_hash))
     ).scalar_one_or_none()
 
 
-def get_vms_dependent_volumes(
-    session: DbSession, volume_hash: str
+async def get_vms_dependent_volumes(
+    session: AsyncDbSession, volume_hash: str
 ) -> Optional[VmBaseDb]:
     statement = (
         select(VmBaseDb)
@@ -93,11 +119,11 @@ def get_vms_dependent_volumes(
             )
         )
     )
-    return session.execute(statement).scalar_one_or_none()
+    return (await session.execute(statement)).scalar_one_or_none()
 
 
-def upsert_vm_version(
-    session: DbSession,
+async def upsert_vm_version(
+    session: AsyncDbSession,
     vm_hash: str,
     owner: str,
     current_version: VmVersion,
@@ -114,10 +140,10 @@ def upsert_vm_version(
         set_={"current_version": current_version, "last_updated": last_updated},
         where=VmVersionDb.last_updated < last_updated,
     )
-    session.execute(upsert_stmt)
+    await session.execute(upsert_stmt)
 
 
-def refresh_vm_version(session: DbSession, vm_hash: str) -> None:
+async def refresh_vm_version(session: AsyncDbSession, vm_hash: str) -> None:
     coalesced_ref = func.coalesce(VmBaseDb.replaces, VmBaseDb.item_hash)
     select_latest_revision_stmt = (
         select(
@@ -151,5 +177,5 @@ def refresh_vm_version(session: DbSession, vm_hash: str) -> None:
             "last_updated": insert_stmt.excluded.last_updated,
         },
     )
-    session.execute(delete(VmVersionDb).where(VmVersionDb.vm_hash == vm_hash))
-    session.execute(upsert_stmt)
+    await session.execute(delete(VmVersionDb).where(VmVersionDb.vm_hash == vm_hash))
+    await session.execute(upsert_stmt)

--- a/src/aleph/db/connection.py
+++ b/src/aleph/db/connection.py
@@ -69,7 +69,9 @@ def make_async_engine(
     application_name: Optional[str] = None,
 ) -> AsyncEngine:
     return create_async_engine(
-        make_db_url(driver="asyncpg", config=config, application_name=application_name),
+        make_db_url(driver="asyncpg", config=config),
+        connect_args={"server_settings": {"application_name": application_name}},
+
         future=True,
         echo=echo,
     )

--- a/src/aleph/db/connection.py
+++ b/src/aleph/db/connection.py
@@ -71,7 +71,6 @@ def make_async_engine(
     return create_async_engine(
         make_db_url(driver="asyncpg", config=config),
         connect_args={"server_settings": {"application_name": application_name}},
-
         future=True,
         echo=echo,
     )

--- a/src/aleph/handlers/content/content_handler.py
+++ b/src/aleph/handlers/content/content_handler.py
@@ -4,12 +4,12 @@ from typing import List, Set
 from aleph.db.models import MessageDb
 from aleph.db.models.account_costs import AccountCostsDb
 from aleph.permissions import check_sender_authorization
-from aleph.types.db_session import DbSession
+from aleph.types.db_session import AsyncDbSession
 
 
 class ContentHandler(abc.ABC):
     async def fetch_related_content(
-        self, session: DbSession, message: MessageDb
+        self, session: AsyncDbSession, message: MessageDb
     ) -> None:
         """
         Fetch additional content from the network based on the content of a message.
@@ -24,7 +24,7 @@ class ContentHandler(abc.ABC):
         pass
 
     async def is_related_content_fetched(
-        self, session: DbSession, message: MessageDb
+        self, session: AsyncDbSession, message: MessageDb
     ) -> bool:
         """
         Check whether the additional network content mentioned in the message
@@ -38,7 +38,7 @@ class ContentHandler(abc.ABC):
         return True
 
     @abc.abstractmethod
-    async def process(self, session: DbSession, messages: List[MessageDb]) -> None:
+    async def process(self, session: AsyncDbSession, messages: List[MessageDb]) -> None:
         """
         Process several messages of the same type and applies the resulting changes.
 
@@ -48,7 +48,9 @@ class ContentHandler(abc.ABC):
         """
         pass
 
-    async def pre_check_balance(self, session: DbSession, message: MessageDb) -> None:
+    async def pre_check_balance(
+        self, session: AsyncDbSession, message: MessageDb
+    ) -> None:
         """
         Checks whether the user has enough Aleph tokens before processing the message.
 
@@ -60,7 +62,7 @@ class ContentHandler(abc.ABC):
         pass
 
     async def check_balance(
-        self, session: DbSession, message: MessageDb
+        self, session: AsyncDbSession, message: MessageDb
     ) -> List[AccountCostsDb] | None:
         """
         Checks whether the user has enough Aleph tokens to process the message.
@@ -73,7 +75,9 @@ class ContentHandler(abc.ABC):
         """
         pass
 
-    async def check_dependencies(self, session: DbSession, message: MessageDb) -> None:
+    async def check_dependencies(
+        self, session: AsyncDbSession, message: MessageDb
+    ) -> None:
         """
         Check dependencies of a message.
 
@@ -87,7 +91,9 @@ class ContentHandler(abc.ABC):
         """
         pass
 
-    async def check_permissions(self, session: DbSession, message: MessageDb) -> None:
+    async def check_permissions(
+        self, session: AsyncDbSession, message: MessageDb
+    ) -> None:
         """
         Check user permissions.
 
@@ -102,7 +108,9 @@ class ContentHandler(abc.ABC):
         await check_sender_authorization(session=session, message=message)
 
     @abc.abstractmethod
-    async def forget_message(self, session: DbSession, message: MessageDb) -> Set[str]:
+    async def forget_message(
+        self, session: AsyncDbSession, message: MessageDb
+    ) -> Set[str]:
         """
         Clean up message-type specific objects when forgetting a message.
 

--- a/src/aleph/handlers/content/post.py
+++ b/src/aleph/handlers/content/post.py
@@ -49,12 +49,8 @@ async def update_balances(session: AsyncDbSession, content: Mapping[str, Any]) -
     dapp = content.get("dapp")
 
     LOGGER.info("Updating balances for %s (dapp: %s)", chain, dapp)
-    print(f"Chain type: {type(chain)}, Chain value: {chain.value}, Full chain: {chain}")
 
     balances: Dict[str, float] = content["balances"]
-    print(f"Number of balances to update: {len(balances)}")
-    for addr, bal in list(balances.items())[:3]:  # Print first 3 for debug
-        print(f"  {addr}: {bal} bal type {type(bal)}")
 
     await update_balances_db(
         session=session,

--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -8,6 +8,7 @@ import sqlalchemy.exc
 from aleph_message.models import ItemHash, ItemType, MessageType
 from configmanager import Config
 from pydantic import ValidationError
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 
 from aleph.chains.signature_verifier import SignatureVerifier
@@ -39,7 +40,7 @@ from aleph.handlers.content.vm import VmMessageHandler
 from aleph.schemas.pending_messages import parse_message
 from aleph.storage import StorageService
 from aleph.toolkit.timestamp import timestamp_to_datetime
-from aleph.types.db_session import DbSession, DbSessionFactory
+from aleph.types.db_session import AsyncDbSession, AsyncDbSessionFactory
 from aleph.types.files import FileType
 from aleph.types.message_processing_result import ProcessedMessage, RejectedMessage
 from aleph.types.message_status import (
@@ -122,7 +123,7 @@ class BaseMessageHandler:
 
         return validated_message
 
-    async def fetch_related_content(self, session: DbSession, message: MessageDb):
+    async def fetch_related_content(self, session: AsyncDbSession, message: MessageDb):
         content_handler = self.get_content_handler(message.type)
 
         try:
@@ -135,7 +136,7 @@ class BaseMessageHandler:
             ) from e
 
     async def load_fetched_content(
-        self, session: DbSession, pending_message: PendingMessageDb
+        self, session: AsyncDbSession, pending_message: PendingMessageDb
     ) -> PendingMessageDb:
         if pending_message.item_type != ItemType.inline:
             pending_message.fetched = False
@@ -161,7 +162,7 @@ class MessagePublisher(BaseMessageHandler):
 
     def __init__(
         self,
-        session_factory: DbSessionFactory,
+        session_factory: AsyncDbSessionFactory,
         storage_service: StorageService,
         config: Config,
         pending_message_exchange: aio_pika.abc.AbstractExchange,
@@ -191,21 +192,22 @@ class MessagePublisher(BaseMessageHandler):
         origin: Optional[MessageOrigin] = MessageOrigin.P2P,
     ) -> Optional[PendingMessageDb]:
         # TODO: this implementation is just messy, improve it.
-        with self.session_factory() as session:
+        async with self.session_factory() as session:
             try:
                 # we don't check signatures yet.
                 message = parse_message(message_dict)
             except InvalidMessageException as e:
                 LOGGER.warning(e)
-                reject_new_pending_message(
+                await reject_new_pending_message(
                     session=session,
                     pending_message=message_dict,
                     exception=e,
                     tx_hash=tx_hash,
                 )
-                session.commit()
+                await session.commit()
                 return None
 
+            # TODO: fix this pydanticV2 issue
             pending_message = PendingMessageDb.from_obj(
                 message,
                 reception_time=reception_time,
@@ -220,25 +222,24 @@ class MessagePublisher(BaseMessageHandler):
                 )
             except InvalidMessageException as e:
                 LOGGER.warning("Invalid message: %s - %s", message.item_hash, str(e))
-                reject_new_pending_message(
+                await reject_new_pending_message(
                     session=session,
                     pending_message=message_dict,
                     exception=e,
                     tx_hash=tx_hash,
                 )
-                session.commit()
+                await session.commit()
                 return None
 
             # Check if there are an already existing record
-            existing_message = (
-                session.query(PendingMessageDb)
-                .filter_by(
-                    sender=pending_message.sender,
-                    item_hash=pending_message.item_hash,
-                    signature=pending_message.signature,
-                )
-                .one_or_none()
+            stmt = select(PendingMessageDb).filter_by(
+                sender=pending_message.sender,
+                item_hash=pending_message.item_hash,
+                signature=pending_message.signature,
             )
+
+            existing_message = (await session.execute(stmt)).scalars().one_or_none()
+
             if existing_message:
                 return existing_message
 
@@ -255,9 +256,9 @@ class MessagePublisher(BaseMessageHandler):
             )
 
             try:
-                session.execute(upsert_message_status_stmt)
-                session.execute(insert_pending_message_stmt)
-                session.commit()
+                await session.execute(upsert_message_status_stmt)
+                await session.execute(insert_pending_message_stmt)
+                await session.commit()
             except sqlalchemy.exc.IntegrityError:
                 # Handle the unique constraint violation.
                 LOGGER.warning("Duplicate pending message detected trying to save it.")
@@ -269,14 +270,14 @@ class MessagePublisher(BaseMessageHandler):
                     pending_message.item_hash,
                     str(e),
                 )
-                session.rollback()
-                reject_new_pending_message(
+                await session.rollback()
+                await reject_new_pending_message(
                     session=session,
                     pending_message=message_dict,
                     exception=e,
                     tx_hash=tx_hash,
                 )
-                session.commit()
+                await session.commit()
                 return None
 
             await self._publish_pending_message(pending_message)
@@ -307,16 +308,16 @@ class MessageHandler(BaseMessageHandler):
 
     @staticmethod
     async def confirm_existing_message(
-        session: DbSession,
+        session: AsyncDbSession,
         existing_message: MessageDb,
         pending_message: PendingMessageDb,
     ):
         if pending_message.signature != existing_message.signature:
             raise InvalidSignature(f"Invalid signature for {pending_message.item_hash}")
 
-        delete_pending_message(session=session, pending_message=pending_message)
+        await delete_pending_message(session=session, pending_message=pending_message)
         if tx_hash := pending_message.tx_hash:
-            session.execute(
+            await session.execute(
                 make_confirmation_upsert_query(
                     item_hash=pending_message.item_hash, tx_hash=tx_hash
                 )
@@ -324,27 +325,30 @@ class MessageHandler(BaseMessageHandler):
 
     @staticmethod
     async def confirm_existing_forgotten_message(
-        session: DbSession,
+        session: AsyncDbSession,
         forgotten_message: ForgottenMessageDb,
         pending_message: PendingMessageDb,
     ):
         if pending_message.signature != forgotten_message.signature:
             raise InvalidSignature(f"Invalid signature for {pending_message.item_hash}")
 
-        delete_pending_message(session=session, pending_message=pending_message)
+        await delete_pending_message(session=session, pending_message=pending_message)
 
     async def insert_message(
-        self, session: DbSession, pending_message: PendingMessageDb, message: MessageDb
+        self,
+        session: AsyncDbSession,
+        pending_message: PendingMessageDb,
+        message: MessageDb,
     ):
-        session.execute(make_message_upsert_query(message))
+        await session.execute(make_message_upsert_query(message))
         if message.item_type != ItemType.inline:
-            upsert_file(
+            await upsert_file(
                 session=session,
                 file_hash=message.item_hash,
                 size=message.size,
                 file_type=FileType.FILE,
             )
-            insert_content_file_pin(
+            await insert_content_file_pin(
                 session=session,
                 file_hash=message.item_hash,
                 owner=message.sender,
@@ -352,8 +356,8 @@ class MessageHandler(BaseMessageHandler):
                 created=timestamp_to_datetime(message.content["time"]),
             )
 
-        delete_pending_message(session=session, pending_message=pending_message)
-        session.execute(
+        await delete_pending_message(session=session, pending_message=pending_message)
+        await session.execute(
             make_message_status_upsert_query(
                 item_hash=message.item_hash,
                 new_status=MessageStatus.PROCESSED,
@@ -363,18 +367,18 @@ class MessageHandler(BaseMessageHandler):
         )
 
         if tx_hash := pending_message.tx_hash:
-            session.execute(
+            await session.execute(
                 make_confirmation_upsert_query(
                     item_hash=message.item_hash, tx_hash=tx_hash
                 )
             )
 
     async def insert_costs(
-        self, session: DbSession, costs: List[AccountCostsDb], message: MessageDb
+        self, session: AsyncDbSession, costs: List[AccountCostsDb], message: MessageDb
     ):
         if len(costs) > 0:
             insert_stmt = make_costs_upsert_query(costs)
-            session.execute(insert_stmt)
+            await session.execute(insert_stmt)
 
     async def verify_message(self, pending_message: PendingMessageDb) -> MessageDb:
         await self.verify_signature(pending_message=pending_message)
@@ -385,7 +389,7 @@ class MessageHandler(BaseMessageHandler):
         return validated_message
 
     async def process(
-        self, session: DbSession, pending_message: PendingMessageDb
+        self, session: AsyncDbSession, pending_message: PendingMessageDb
     ) -> ProcessedMessage | RejectedMessage:
         """
         Process a pending message.
@@ -401,7 +405,7 @@ class MessageHandler(BaseMessageHandler):
         """
 
         # Note: Check if message already exists (and confirm it)
-        existing_message = get_message_by_item_hash(
+        existing_message = await get_message_by_item_hash(
             session=session, item_hash=ItemHash(pending_message.item_hash)
         )
         if existing_message:
@@ -414,7 +418,7 @@ class MessageHandler(BaseMessageHandler):
 
         # Note: Check if message is already forgotten (and confirm it)
         # this is to avoid race conditions when a confirmation arrives after the FORGET message has been preocessed
-        forgotten_message = get_forgotten_message(
+        forgotten_message = await get_forgotten_message(
             session=session, item_hash=ItemHash(pending_message.item_hash)
         )
         if forgotten_message:

--- a/src/aleph/jobs/__init__.py
+++ b/src/aleph/jobs/__init__.py
@@ -10,14 +10,14 @@ from aleph.jobs.process_pending_messages import (
 from aleph.jobs.process_pending_txs import handle_txs_task, pending_txs_subprocess
 from aleph.jobs.reconnect_ipfs import reconnect_ipfs_job
 from aleph.services.ipfs import IpfsService
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 LOGGER = logging.getLogger("jobs")
 
 
 def start_jobs(
     config,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     ipfs_service: IpfsService,
     use_processes=True,
 ) -> List[Coroutine]:

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -12,7 +12,7 @@ from setproctitle import setproctitle
 
 from aleph.chains.chain_data_service import ChainDataService
 from aleph.db.accessors.pending_txs import delete_pending_tx, get_pending_txs
-from aleph.db.connection import make_engine, make_session_factory
+from aleph.db.connection import make_async_engine, make_async_session_factory
 from aleph.db.models import PendingTxDb
 from aleph.handlers.message_handler import MessagePublisher
 from aleph.services.cache.node_cache import NodeCache
@@ -24,7 +24,7 @@ from aleph.toolkit.monitoring import setup_sentry
 from aleph.toolkit.rabbitmq import make_mq_conn
 from aleph.toolkit.timestamp import utc_now
 from aleph.types.chain_sync import ChainSyncProtocol
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 from ..types.message_status import MessageOrigin
 from .job_utils import MqWatcher, make_pending_tx_queue, prepare_loop
@@ -35,7 +35,7 @@ LOGGER = logging.getLogger(__name__)
 class PendingTxProcessor(MqWatcher):
     def __init__(
         self,
-        session_factory: DbSessionFactory,
+        session_factory: AsyncDbSessionFactory,
         message_publisher: MessagePublisher,
         chain_data_service: ChainDataService,
         pending_tx_queue: aio_pika.abc.AbstractQueue,
@@ -73,9 +73,9 @@ class PendingTxProcessor(MqWatcher):
                 )
 
             # bogus or handled, we remove it.
-            with self.session_factory() as session:
-                delete_pending_tx(session=session, tx_hash=tx.hash)
-                session.commit()
+            async with self.session_factory() as session:
+                await delete_pending_tx(session=session, tx_hash=tx.hash)
+                await session.commit()
 
         else:
             LOGGER.debug("TX contains no message")
@@ -90,8 +90,8 @@ class PendingTxProcessor(MqWatcher):
         seen_offchain_hashes = set()
         seen_ids: Set[str] = set()
         LOGGER.info("handling TXs")
-        with self.session_factory() as session:
-            for pending_tx in get_pending_txs(session):
+        async with self.session_factory() as session:
+            for pending_tx in await get_pending_txs(session):
                 # TODO: remove this feature? It doesn't seem necessary.
                 if pending_tx.tx.protocol == ChainSyncProtocol.OFF_CHAIN_SYNC:
                     if pending_tx.tx.content in seen_offchain_hashes:
@@ -118,8 +118,8 @@ class PendingTxProcessor(MqWatcher):
 async def handle_txs_task(config: Config):
     max_concurrent_tasks = config.aleph.jobs.pending_txs.max_concurrency.value
 
-    engine = make_engine(config=config, application_name="aleph-txs")
-    session_factory = make_session_factory(engine)
+    engine = make_async_engine(config=config, application_name="aleph-txs")
+    session_factory = make_async_session_factory(engine)
 
     mq_conn = await make_mq_conn(config=config)
     mq_channel = await mq_conn.channel()

--- a/src/aleph/jobs/reconnect_ipfs.py
+++ b/src/aleph/jobs/reconnect_ipfs.py
@@ -11,13 +11,13 @@ from configmanager import Config
 from aleph.db.accessors.peers import get_all_addresses_by_peer_type
 from aleph.db.models import PeerType
 from aleph.services.ipfs import IpfsService
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 LOGGER = logging.getLogger("jobs.reconnect_ipfs")
 
 
 async def reconnect_ipfs_job(
-    config: Config, session_factory: DbSessionFactory, ipfs_service: IpfsService
+    config: Config, session_factory: AsyncDbSessionFactory, ipfs_service: IpfsService
 ):
     from aleph.services.utils import get_IP
 
@@ -34,8 +34,8 @@ async def reconnect_ipfs_job(
                 except aioipfs.APIError:
                     LOGGER.warning("Can't reconnect to %s" % peer)
 
-            with session_factory() as session:
-                peers = get_all_addresses_by_peer_type(
+            async with session_factory() as session:
+                peers = await get_all_addresses_by_peer_type(
                     session=session, peer_type=PeerType.IPFS
                 )
 

--- a/src/aleph/network.py
+++ b/src/aleph/network.py
@@ -13,7 +13,7 @@ from aleph.services.ipfs.common import make_ipfs_client
 from aleph.services.ipfs.pubsub import incoming_channel as incoming_ipfs_channel
 from aleph.services.storage.fileystem_engine import FileSystemStorageEngine
 from aleph.storage import StorageService
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 from aleph.types.message_status import InvalidMessageFormat
 
 LOGGER = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ async def decode_pubsub_message(message_data: bytes) -> Dict[str, Any]:
 
 async def listener_tasks(
     config,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     node_cache: NodeCache,
     p2p_client: AlephP2PServiceClient,
     mq_channel: aio_pika.abc.AbstractChannel,

--- a/src/aleph/permissions.py
+++ b/src/aleph/permissions.py
@@ -2,10 +2,12 @@ from aleph_message.models import MessageType
 
 from aleph.db.accessors.aggregates import get_aggregate_by_key
 from aleph.db.models import MessageDb
-from aleph.types.db_session import DbSession
+from aleph.types.db_session import AsyncDbSession
 
 
-async def check_sender_authorization(session: DbSession, message: MessageDb) -> bool:
+async def check_sender_authorization(
+    session: AsyncDbSession, message: MessageDb
+) -> bool:
     """Checks a content against a message to verify if sender is authorized.
 
     TODO: implement "security" aggregate key check.
@@ -20,7 +22,7 @@ async def check_sender_authorization(session: DbSession, message: MessageDb) -> 
     if sender == address:
         return True
 
-    aggregate = get_aggregate_by_key(
+    aggregate = await get_aggregate_by_key(
         session=session, key="security", owner=address
     )  # do we need anything else here?
 

--- a/src/aleph/services/cache/materialized_views.py
+++ b/src/aleph/services/cache/materialized_views.py
@@ -2,12 +2,14 @@ import asyncio
 import logging
 
 from aleph.db.accessors.messages import refresh_address_stats_mat_view
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 LOGGER = logging.getLogger(__name__)
 
 
-async def refresh_cache_materialized_views(session_factory: DbSessionFactory) -> None:
+async def refresh_cache_materialized_views(
+    session_factory: AsyncDbSessionFactory,
+) -> None:
     """
     Refresh DB materialized views used as caches, periodically.
 
@@ -19,9 +21,9 @@ async def refresh_cache_materialized_views(session_factory: DbSessionFactory) ->
 
     while True:
         try:
-            with session_factory() as session:
-                refresh_address_stats_mat_view(session)
-                session.commit()
+            async with session_factory() as session:
+                await refresh_address_stats_mat_view(session)
+                await session.commit()
                 LOGGER.info("Refreshed address stats materialized view")
 
         except Exception:

--- a/src/aleph/services/p2p/__init__.py
+++ b/src/aleph/services/p2p/__init__.py
@@ -4,7 +4,7 @@ from aleph_p2p_client import AlephP2PServiceClient, make_p2p_service_client
 from configmanager import Config
 
 from aleph.services.ipfs import IpfsService
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 from ..cache.node_cache import NodeCache
 from .manager import initialize_host
@@ -28,7 +28,7 @@ async def init_p2p_client(config: Config, service_name: str) -> AlephP2PServiceC
 
 async def init_p2p(
     config: Config,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     service_name: str,
     ipfs_service: IpfsService,
     node_cache: NodeCache,

--- a/src/aleph/services/p2p/http.py
+++ b/src/aleph/services/p2p/http.py
@@ -12,23 +12,14 @@ import aiohttp
 
 LOGGER = logging.getLogger("P2P.HTTP")
 
-SESSIONS = dict()
 
-
-async def api_get_request(base_uri, method, timeout=1):
-    if timeout not in SESSIONS:
-        connector = aiohttp.TCPConnector(limit_per_host=5)
-        SESSIONS[timeout] = aiohttp.ClientSession(
-            read_timeout=timeout, connector=connector
-        )
-
+async def api_get_request(session: aiohttp.ClientSession, base_uri, method, timeout=1):
     uri = f"{base_uri}/api/v0/{method}"
     try:
-        async with SESSIONS[timeout].get(uri) as resp:
+        async with session.get(uri) as resp:
             if resp.status != 200:
-                result = None
-            else:
-                result = await resp.json()
+                return None
+            return await resp.json()
     except (
         TimeoutError,
         asyncio.TimeoutError,
@@ -44,17 +35,32 @@ async def api_get_request(base_uri, method, timeout=1):
 
 
 async def get_peer_hash_content(
-    base_uri: str, item_hash: str, timeout: int = 1
+    session: aiohttp.ClientSession,
+    base_uri: str,
+    item_hash: str,
+    semaphore,
+    timeout: int = 1,
 ) -> Optional[bytes]:
-    result = None
-    item = await api_get_request(base_uri, f"storage/{item_hash}", timeout=timeout)
-    if item is not None and item["status"] == "success" and item["content"] is not None:
-        # TODO: IMPORTANT /!\ verify the hash of received data!
-        return base64.decodebytes(item["content"].encode("utf-8"))
-    else:
-        LOGGER.debug(f"can't get hash {item_hash}")
-
-    return result
+    async with (
+        semaphore
+    ):  # We use semaphore to avoid having too much call at the same time
+        result = None
+        item = await api_get_request(
+            session=session,
+            base_uri=base_uri,
+            method=f"storage/{item_hash}",
+            timeout=timeout,
+        )
+        if (
+            item is not None
+            and item["status"] == "success"
+            and item["content"] is not None
+        ):
+            # TODO: IMPORTANT /!\ verify the hash of received data!
+            return base64.decodebytes(item["content"].encode("utf-8"))
+        else:
+            LOGGER.debug(f"can't get hash {item_hash}")
+        return result
 
 
 async def request_hash(
@@ -62,9 +68,38 @@ async def request_hash(
 ) -> Optional[bytes]:
     uris: List[str] = sample(api_servers, k=len(api_servers))
 
-    for uri in uris:
-        content = await get_peer_hash_content(uri, item_hash, timeout=timeout)
-        if content is not None:
-            return content
+    # Avoid too  much request at the same time
+    semaphore = asyncio.Semaphore(5)
+
+    connector = aiohttp.TCPConnector(limit_per_host=5)
+    timeout_conf = aiohttp.ClientTimeout(total=timeout)
+
+    async with aiohttp.ClientSession(
+        connector=connector, timeout=timeout_conf
+    ) as session:
+        # Use Task instead of
+        tasks = [
+            asyncio.create_task(
+                get_peer_hash_content(
+                    session=session,
+                    base_uri=url,
+                    item_hash=item_hash,
+                    semaphore=semaphore,
+                )
+            )
+            for url in uris
+        ]
+
+        for completed_task in asyncio.as_completed(tasks):
+            try:
+                result = await completed_task
+                if result:
+                    # We cancel other Task
+                    for task in tasks:
+                        if not task.done():
+                            task.cancel()
+                    return result
+            except Exception:
+                continue
 
     return None  # Nothing found...

--- a/src/aleph/services/p2p/jobs.py
+++ b/src/aleph/services/p2p/jobs.py
@@ -8,7 +8,7 @@ from configmanager import Config
 
 from aleph.db.accessors.peers import get_all_addresses_by_peer_type
 from aleph.db.models import PeerType
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 from ..cache.node_cache import NodeCache
 from .http import api_get_request
@@ -26,7 +26,9 @@ LOGGER = logging.getLogger("P2P.jobs")
 
 
 async def reconnect_p2p_job(
-    config: Config, session_factory: DbSessionFactory, p2p_client: AlephP2PServiceClient
+    config: Config,
+    session_factory: AsyncDbSessionFactory,
+    p2p_client: AlephP2PServiceClient,
 ) -> None:
     await asyncio.sleep(2)
 
@@ -34,9 +36,9 @@ async def reconnect_p2p_job(
         try:
             peers = set(config.p2p.peers.value)
 
-            with session_factory() as session:
+            async with session_factory() as session:
                 peers |= set(
-                    get_all_addresses_by_peer_type(
+                    await get_all_addresses_by_peer_type(
                         session=session, peer_type=PeerType.P2P
                     )
                 )
@@ -66,7 +68,7 @@ async def check_peer(peer_uri: str, timeout: int = 1) -> PeerStatus:
 
 
 async def tidy_http_peers_job(
-    config: Config, session_factory: DbSessionFactory, node_cache: NodeCache
+    config: Config, session_factory: AsyncDbSessionFactory, node_cache: NodeCache
 ) -> None:
     """Check that HTTP peers are reachable, else remove them from the list"""
     from aleph.services.utils import get_IP
@@ -78,8 +80,8 @@ async def tidy_http_peers_job(
         jobs = []
 
         try:
-            with session_factory() as session:
-                peers = get_all_addresses_by_peer_type(
+            async with session_factory() as session:
+                peers = await get_all_addresses_by_peer_type(
                     session=session, peer_type=PeerType.HTTP
                 )
 

--- a/src/aleph/services/p2p/manager.py
+++ b/src/aleph/services/p2p/manager.py
@@ -10,14 +10,14 @@ from aleph.services.ipfs import IpfsService
 from aleph.services.peers.monitor import monitor_hosts_ipfs, monitor_hosts_p2p
 from aleph.services.peers.publish import publish_host
 from aleph.services.utils import get_IP
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 LOGGER = logging.getLogger(__name__)
 
 
 async def initialize_host(
     config: Config,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     node_cache: NodeCache,
     p2p_client: AlephP2PServiceClient,
     ipfs_service: IpfsService,
@@ -87,7 +87,7 @@ async def initialize_host(
 
         if config.ipfs.enabled.value:
             tasks.append(
-                monitor_hosts_ipfs(
+                await monitor_hosts_ipfs(
                     ipfs_service=ipfs_service,
                     session_factory=session_factory,
                     alive_topic=config.ipfs.alive_topic.value,

--- a/src/aleph/services/storage/fileystem_engine.py
+++ b/src/aleph/services/storage/fileystem_engine.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 from typing import Optional, Union
 
+import aiofiles
+import aiofiles.ospath
+
 from .engine import StorageEngine
 
 
@@ -16,19 +19,26 @@ class FileSystemStorageEngine(StorageEngine):
     async def read(self, filename: str) -> Optional[bytes]:
         file_path = self.folder / filename
 
-        if not file_path.is_file():
+        if not await aiofiles.ospath.isfile(file_path):
             return None
-
-        return file_path.read_bytes()
+        async with aiofiles.open(file_path, "rb") as f:
+            return await f.read()
 
     async def write(self, filename: str, content: bytes):
         file_path = self.folder / filename
-        file_path.write_bytes(content)
+        async with aiofiles.open(file_path, "wb") as f:
+            await f.write(content)
 
     async def delete(self, filename: str):
         file_path = self.folder / filename
-        file_path.unlink(missing_ok=True)
+        async_unlink = aiofiles.ospath.wrap(
+            Path.unlink
+        )  # We manually warp unlink (not handle by aiofiles)
+
+        await async_unlink(async_unlink(file_path, missing_ok=True))
 
     async def exists(self, filename: str) -> bool:
         file_path = self.folder / filename
-        return file_path.exists()
+        return await aiofiles.ospath.exists(
+            file_path
+        )  # This func warp .exist func into async

--- a/src/aleph/services/storage/fileystem_engine.py
+++ b/src/aleph/services/storage/fileystem_engine.py
@@ -33,9 +33,9 @@ class FileSystemStorageEngine(StorageEngine):
         file_path = self.folder / filename
         async_unlink = aiofiles.ospath.wrap(
             Path.unlink
-        )  # We manually warp unlink (not handle by aiofiles)
+        )  # We manually wrap unlink (not handled by aiofiles)
 
-        await async_unlink(async_unlink(file_path, missing_ok=True))
+        await async_unlink(file_path, missing_ok=True)
 
     async def exists(self, filename: str) -> bool:
         file_path = self.folder / filename

--- a/src/aleph/services/storage/garbage_collector.py
+++ b/src/aleph/services/storage/garbage_collector.py
@@ -21,7 +21,7 @@ from aleph.db.accessors.messages import (
 from aleph.db.models.messages import MessageStatusDb
 from aleph.storage import StorageService
 from aleph.toolkit.timestamp import utc_now
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 from aleph.types.message_status import MessageStatus
 
 LOGGER = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ LOGGER = logging.getLogger(__name__)
 
 class GarbageCollector:
     def __init__(
-        self, session_factory: DbSessionFactory, storage_service: StorageService
+        self, session_factory: AsyncDbSessionFactory, storage_service: StorageService
     ):
         self.session_factory = session_factory
         self.storage_service = storage_service
@@ -61,27 +61,25 @@ class GarbageCollector:
         """
         LOGGER.info("Checking messages with REMOVING status")
 
-        with self.session_factory() as session:
+        async with self.session_factory() as session:
             # Get all messages with REMOVING status
             removing_messages = list(
-                get_matching_hashes(
+                await get_matching_hashes(
                     session=session,
                     status=MessageStatus.REMOVING,
                     hash_only=False,
                     pagination=0,  # Get all matching messages
                 )
             )
-
             LOGGER.info(
                 "Found %d messages with REMOVING status", len(removing_messages)
             )
-
             for message_status in removing_messages:
                 item_hash = message_status.item_hash
                 try:
                     # For STORE messages, check if the file is still pinned
                     # We need to get message details to check its type
-                    message = get_one_message_by_item_hash(
+                    message = await get_one_message_by_item_hash(
                         session=session, item_hash=item_hash
                     )
 
@@ -89,13 +87,13 @@ class GarbageCollector:
 
                     if message and message.type == MessageType.store:
                         # Check if the file is still pinned (by item_hash cause there could be other messages pinning the same file_hash)
-                        if file_pin_exists(session=session, item_hash=item_hash):
+                        if await file_pin_exists(session=session, item_hash=item_hash):
                             resources_deleted = False
 
                     # If all resources have been deleted, update status to REMOVED
                     if resources_deleted:
                         now = utc_now()
-                        session.execute(
+                        await session.execute(
                             make_message_status_upsert_query(
                                 item_hash=item_hash,
                                 new_status=MessageStatus.REMOVED,
@@ -113,39 +111,39 @@ class GarbageCollector:
                         str(err),
                     )
 
-            delete_costs_for_forgotten_and_deleted_messages(session=session)
+            await delete_costs_for_forgotten_and_deleted_messages(session=session)
 
-            session.commit()
+            await session.commit()
 
     async def collect(self, datetime: dt.datetime):
-        with self.session_factory() as session:
+        async with self.session_factory() as session:
             # Delete outdated grace period file pins
-            delete_grace_period_file_pins(session=session, datetime=datetime)
-            session.commit()
+            await delete_grace_period_file_pins(session=session, datetime=datetime)
+            await session.commit()
 
             # Delete files without pins
-            files_to_delete = list(get_unpinned_files(session))
+            files_to_delete = list(await get_unpinned_files(session))
             LOGGER.info("Found %d files to delete", len(files_to_delete))
 
         for file_to_delete in files_to_delete:
-            with self.session_factory() as session:
+            async with self.session_factory() as session:
                 try:
                     file_hash = ItemHash(file_to_delete.hash)
                     LOGGER.info("Deleting %s...", file_hash)
 
-                    delete_file_db(session=session, file_hash=file_hash)
+                    await delete_file_db(session=session, file_hash=file_hash)
 
                     if file_hash.item_type == ItemType.ipfs:
                         await self._delete_from_ipfs(file_hash)
                     elif file_hash.item_type == ItemType.storage:
                         await self._delete_from_local_storage(file_hash)
 
-                    session.commit()
+                    await session.commit()
 
                     LOGGER.info("Deleted %s", file_hash)
                 except Exception as err:
                     LOGGER.error("Failed to delete file %s: %s", file_hash, str(err))
-                    session.rollback()
+                    await session.rollback()
 
         # After collecting garbage, check and update message status
         await self._check_and_update_removing_messages()

--- a/src/aleph/web/controllers/app_state_getters.py
+++ b/src/aleph/web/controllers/app_state_getters.py
@@ -16,7 +16,7 @@ from aleph.chains.signature_verifier import SignatureVerifier
 from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
 from aleph.storage import StorageService
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 APP_STATE_CONFIG = "config"
 APP_STATE_MQ_CONN = "mq_conn"
@@ -99,8 +99,8 @@ def get_p2p_client_from_request(request: web.Request) -> AlephP2PServiceClient:
     return cast(AlephP2PServiceClient, request.app[APP_STATE_P2P_CLIENT])
 
 
-def get_session_factory_from_request(request: web.Request) -> DbSessionFactory:
-    return cast(DbSessionFactory, request.app[APP_STATE_SESSION_FACTORY])
+def get_session_factory_from_request(request: web.Request) -> AsyncDbSessionFactory:
+    return cast(AsyncDbSessionFactory, request.app[APP_STATE_SESSION_FACTORY])
 
 
 def get_storage_service_from_request(request: web.Request) -> StorageService:

--- a/src/aleph/web/controllers/channels.py
+++ b/src/aleph/web/controllers/channels.py
@@ -5,13 +5,13 @@ from aiohttp import web
 
 from aleph.db.accessors.messages import get_distinct_channels
 from aleph.types.channel import Channel
-from aleph.types.db_session import DbSession
+from aleph.types.db_session import AsyncDbSession
 from aleph.web.controllers.app_state_getters import get_session_factory_from_request
 
 
 @cached(ttl=60 * 120, cache=SimpleMemoryCache, timeout=120)
-async def get_channels(session: DbSession) -> List[Channel]:
-    channels = get_distinct_channels(session)
+async def get_channels(session: AsyncDbSession) -> List[Channel]:
+    channels = await get_distinct_channels(session)
     return list(channels)
 
 
@@ -23,7 +23,7 @@ async def used_channels(request: web.Request) -> web.Response:
 
     session_factory = get_session_factory_from_request(request)
 
-    with session_factory() as session:
+    async with session_factory() as session:
         channels = await get_channels(session)
 
     response = web.json_response({"channels": channels})

--- a/src/aleph/web/controllers/ipfs.py
+++ b/src/aleph/web/controllers/ipfs.py
@@ -58,15 +58,17 @@ async def ipfs_add_file(request: web.Request):
     )
     size = stats["Size"]
 
-    with session_factory() as session:
-        upsert_file(
+    async with session_factory() as session:
+        await upsert_file(
             session=session,
             file_hash=cid,
             size=size,
             file_type=FileType.FILE,
         )
-        add_grace_period_for_file(session=session, file_hash=cid, hours=grace_period)
-        session.commit()
+        await add_grace_period_for_file(
+            session=session, file_hash=cid, hours=grace_period
+        )
+        await session.commit()
 
     output = {
         "status": "success",

--- a/src/aleph/web/controllers/main.py
+++ b/src/aleph/web/controllers/main.py
@@ -8,7 +8,7 @@ from aiohttp import web
 from pydantic import BaseModel
 
 from aleph.db.accessors.metrics import query_metric_ccn, query_metric_crn
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 from aleph.web.controllers.app_state_getters import (
     get_node_cache_from_request,
     get_session_factory_from_request,
@@ -22,9 +22,9 @@ logger = logging.getLogger(__name__)
 async def index(request: web.Request) -> Dict:
     """Index of aleph."""
 
-    session_factory: DbSessionFactory = get_session_factory_from_request(request)
+    session_factory: AsyncDbSessionFactory = get_session_factory_from_request(request)
     node_cache = get_node_cache_from_request(request)
-    with session_factory() as session:
+    async with session_factory() as session:
         return asdict(await get_metrics(session=session, node_cache=node_cache))
 
 
@@ -32,12 +32,12 @@ async def status_ws(request: web.Request) -> web.WebSocketResponse:
     ws = web.WebSocketResponse()
     await ws.prepare(request)
 
-    session_factory: DbSessionFactory = get_session_factory_from_request(request)
+    session_factory: AsyncDbSessionFactory = get_session_factory_from_request(request)
     node_cache = get_node_cache_from_request(request)
 
     previous_status = None
     while True:
-        with session_factory() as session:
+        async with session_factory() as session:
             status = await get_metrics(session=session, node_cache=node_cache)
 
         if status != previous_status:
@@ -61,7 +61,7 @@ async def metrics(request: web.Request) -> web.Response:
     session_factory = get_session_factory_from_request(request)
     node_cache = get_node_cache_from_request(request)
 
-    with session_factory() as session:
+    async with session_factory() as session:
         return web.Response(
             text=format_dataclass_for_prometheus(
                 await get_metrics(session=session, node_cache=node_cache)
@@ -71,10 +71,10 @@ async def metrics(request: web.Request) -> web.Response:
 
 async def metrics_json(request: web.Request) -> web.Response:
     """JSON version of the Prometheus metrics."""
-    session_factory: DbSessionFactory = get_session_factory_from_request(request)
+    session_factory: AsyncDbSessionFactory = get_session_factory_from_request(request)
     node_cache = get_node_cache_from_request(request)
 
-    with session_factory() as session:
+    async with session_factory() as session:
         return web.Response(
             text=(await get_metrics(session=session, node_cache=node_cache)).to_json(),
             content_type="application/json",
@@ -97,13 +97,13 @@ def _get_node_id_from_request(request: web.Request) -> str:
 async def ccn_metric(request: web.Request) -> web.Response:
     """Fetch metrics for CCN node id"""
 
-    session_factory: DbSessionFactory = get_session_factory_from_request(request)
+    session_factory: AsyncDbSessionFactory = get_session_factory_from_request(request)
     query_params = Metrics.model_validate(request.query)
 
     node_id = _get_node_id_from_request(request)
 
-    with session_factory() as session:
-        ccn = query_metric_ccn(
+    async with session_factory() as session:
+        ccn = await query_metric_ccn(
             session,
             node_id=node_id,
             start_date=query_params.start_date,
@@ -123,13 +123,13 @@ async def ccn_metric(request: web.Request) -> web.Response:
 async def crn_metric(request: web.Request) -> web.Response:
     """Fetch Metric for crn."""
 
-    session_factory: DbSessionFactory = get_session_factory_from_request(request)
+    session_factory: AsyncDbSessionFactory = get_session_factory_from_request(request)
     query_params = Metrics.model_validate(request.query)
 
     node_id = _get_node_id_from_request(request)
 
-    with session_factory() as session:
-        crn = query_metric_crn(
+    async with session_factory() as session:
+        crn = await query_metric_crn(
             session,
             node_id=node_id,
             start_date=query_params.start_date,

--- a/src/aleph/web/controllers/prices.py
+++ b/src/aleph/web/controllers/prices.py
@@ -23,7 +23,7 @@ from aleph.services.cost import (
     get_total_and_detailed_costs_from_db,
 )
 from aleph.toolkit.costs import format_cost_str
-from aleph.types.db_session import DbSession
+from aleph.types.db_session import AsyncDbSession
 from aleph.types.message_status import MessageStatus
 from aleph.web.controllers.app_state_getters import (
     get_session_factory_from_request,
@@ -60,7 +60,9 @@ class MessagePrice(DataClassJsonMixin):
     required_tokens: Optional[Decimal] = None
 
 
-async def get_executable_message(session: DbSession, item_hash_str: str) -> MessageDb:
+async def get_executable_message(
+    session: AsyncDbSession, item_hash_str: str
+) -> MessageDb:
     """Attempt to get an executable message from the database.
     Raises an HTTP exception if the message is not found, not processed or is not an executable message.
     """
@@ -72,7 +74,7 @@ async def get_executable_message(session: DbSession, item_hash_str: str) -> Mess
         raise web.HTTPBadRequest(body=f"Invalid message hash: {item_hash_str}")
 
     # Get the message status from the database
-    message_status_db = get_message_status(session=session, item_hash=item_hash)
+    message_status_db = await get_message_status(session=session, item_hash=item_hash)
     if not message_status_db:
         raise web.HTTPNotFound(body=f"Message not found with hash: {item_hash}")
     # Loop through the status_exceptions to find a match and raise the corresponding exception
@@ -82,7 +84,7 @@ async def get_executable_message(session: DbSession, item_hash_str: str) -> Mess
     assert message_status_db.status == MessageStatus.PROCESSED
 
     # Get the message from the database
-    message: Optional[MessageDb] = get_message_by_item_hash(session, item_hash)
+    message: Optional[MessageDb] = await get_message_by_item_hash(session, item_hash)
     if not message:
         raise web.HTTPNotFound(body="Message not found, despite appearing as processed")
     if message.type not in (
@@ -101,14 +103,14 @@ async def message_price(request: web.Request):
     """Returns the price of an executable message."""
 
     session_factory = get_session_factory_from_request(request)
-    with session_factory() as session:
+    async with session_factory() as session:
         item_hash = request.match_info["item_hash"]
         message = await get_executable_message(session, item_hash)
         content: ExecutableContent = message.parsed_content
 
         try:
             payment_type = get_payment_type(content)
-            required_tokens, costs = get_total_and_detailed_costs_from_db(
+            required_tokens, costs = await get_total_and_detailed_costs_from_db(
                 session, content, item_hash
             )
 
@@ -137,7 +139,7 @@ async def message_price_estimate(request: web.Request):
     session_factory = get_session_factory_from_request(request)
     storage_service = get_storage_service_from_request(request)
 
-    with session_factory() as session:
+    async with session_factory() as session:
         parsed_body = PubMessageRequest.model_validate(await request.json())
         message = validate_cost_estimation_message_dict(parsed_body.message_dict)
         content = await validate_cost_estimation_message_content(
@@ -147,7 +149,7 @@ async def message_price_estimate(request: web.Request):
 
         try:
             payment_type = get_payment_type(content)
-            required_tokens, costs = get_total_and_detailed_costs(
+            required_tokens, costs = await get_total_and_detailed_costs(
                 session, content, item_hash
             )
 

--- a/src/aleph/web/controllers/programs.py
+++ b/src/aleph/web/controllers/programs.py
@@ -2,7 +2,7 @@ from aiohttp import web
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 from aleph.db.accessors.messages import get_programs_triggered_by_messages
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 from aleph.types.sort_order import SortOrder
 
 
@@ -20,9 +20,9 @@ async def get_programs_on_message(request: web.Request) -> web.Response:
             data=error.json(), status=web.HTTPBadRequest.status_code
         )
 
-    session_factory: DbSessionFactory = request.app["session_factory"]
+    session_factory: AsyncDbSessionFactory = request.app["session_factory"]
 
-    with session_factory() as session:
+    async with session_factory() as session:
         messages = [
             {
                 "item_hash": result.item_hash,
@@ -30,7 +30,7 @@ async def get_programs_on_message(request: web.Request) -> web.Response:
                     "on": {"message": result.message_subscriptions},
                 },
             }
-            for result in get_programs_triggered_by_messages(
+            for result in await get_programs_triggered_by_messages(
                 session=session, sort_order=query.sort_order
             )
         ]

--- a/src/aleph/web/controllers/utils.py
+++ b/src/aleph/web/controllers/utils.py
@@ -22,7 +22,7 @@ from aleph.services.ipfs import IpfsService
 from aleph.services.p2p.pubsub import publish as pub_p2p
 from aleph.toolkit.shield import shielded
 from aleph.toolkit.timestamp import utc_now
-from aleph.types.db_session import DbSession
+from aleph.types.db_session import AsyncDbSession
 from aleph.types.message_status import (
     InvalidMessageException,
     MessageProcessingStatus,
@@ -405,10 +405,12 @@ async def broadcast_and_process_message(
     return status
 
 
-def add_grace_period_for_file(session: DbSession, file_hash: str, hours: int):
+async def add_grace_period_for_file(
+    session: AsyncDbSession, file_hash: str, hours: int
+):
     current_datetime = utc_now()
     delete_by = current_datetime + dt.timedelta(hours=hours)
-    insert_grace_period_file_pin(
+    await insert_grace_period_file_pin(
         session=session,
         file_hash=file_hash,
         created=utc_now(),

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -24,13 +24,13 @@ from aleph.handlers.message_handler import MessageHandler
 from aleph.jobs.process_pending_messages import PendingMessageProcessor
 from aleph.storage import StorageService
 from aleph.toolkit.timestamp import timestamp_to_datetime, utc_now
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 from aleph.types.message_status import MessageStatus
 
 
 # TODO: remove the raw parameter, it's just to avoid larger refactorings
 async def _load_fixtures(
-    session_factory: DbSessionFactory, filename: str, raw: bool = True
+    session_factory: AsyncDbSessionFactory, filename: str, raw: bool = True
 ) -> Sequence[Dict[str, Any]]:
     fixtures_dir = Path(__file__).parent / "fixtures"
     fixtures_file = fixtures_dir / filename
@@ -41,7 +41,7 @@ async def _load_fixtures(
     messages = []
     tx_hashes = set()
 
-    with session_factory() as session:
+    async with session_factory() as session:
         for message_dict in messages_json:
             message_db = MessageDb.from_message_dict(message_dict)
             messages.append(message_db)
@@ -53,8 +53,8 @@ async def _load_fixtures(
                     tx_hashes.add(tx_hash)
                     session.add(chain_tx_db)
 
-                session.flush()
-                session.execute(
+                await session.flush()
+                await session.execute(
                     insert(message_confirmations).values(
                         item_hash=message_db.item_hash, tx_hash=tx_hash
                     )
@@ -67,14 +67,14 @@ async def _load_fixtures(
             )
             session.add(message_status)
 
-        session.commit()
+        await session.commit()
 
     return messages_json if raw else messages
 
 
 @pytest_asyncio.fixture
 async def fixture_messages(
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
 ) -> Sequence[Dict[str, Any]]:
     return await _load_fixtures(session_factory, "fixture_messages.json")
 
@@ -94,23 +94,23 @@ def make_aggregate_element(message: MessageDb) -> AggregateElementDb:
 
 @pytest_asyncio.fixture
 async def fixture_aggregate_messages(
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
 ) -> Sequence[MessageDb]:
     messages = await _load_fixtures(
         session_factory, "fixture_aggregates.json", raw=False
     )
     aggregate_keys = set()
-    with session_factory() as session:
+    async with session_factory() as session:
         for message in messages:
             aggregate_element = make_aggregate_element(message)  # type: ignore
             session.add(aggregate_element)
             aggregate_keys.add((aggregate_element.owner, aggregate_element.key))
-        session.commit()
+        await session.commit()
 
         for owner, key in aggregate_keys:
-            refresh_aggregate(session=session, owner=owner, key=key)
+            await refresh_aggregate(session=session, owner=owner, key=key)
 
-        session.commit()
+        await session.commit()
 
     return messages  # type: ignore
 
@@ -131,14 +131,14 @@ def make_post_db(message: MessageDb) -> PostDb:
 
 @pytest_asyncio.fixture
 async def fixture_posts(
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
 ) -> Sequence[PostDb]:
     messages = await _load_fixtures(session_factory, "fixture_posts.json", raw=False)
     posts = [make_post_db(message) for message in messages]  # type: ignore
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add_all(posts)
-        session.commit()
+        await session.commit()
 
     return posts
 
@@ -222,7 +222,9 @@ def amended_post_with_refs_and_tags(
 
 
 @pytest.fixture
-def message_processor(mocker, mock_config: Config, session_factory: DbSessionFactory):
+def message_processor(
+    mocker, mock_config: Config, session_factory: AsyncDbSessionFactory
+):
     storage_engine = InMemoryStorageEngine(files={})
     storage_service = StorageService(
         storage_engine=storage_engine,

--- a/tests/api/test_get_message.py
+++ b/tests/api/test_get_message.py
@@ -2,6 +2,7 @@ import datetime as dt
 from typing import Any, Mapping, Sequence
 
 import pytest
+import pytest_asyncio
 import pytz
 from aleph_message.models import Chain, ItemType, MessageType
 
@@ -20,7 +21,7 @@ from aleph.schemas.api.messages import (
 )
 from aleph.toolkit.timestamp import timestamp_to_datetime
 from aleph.types.channel import Channel
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 from aleph.types.message_status import ErrorCode, MessageStatus
 
 MESSAGE_URI = "/api/v0/messages/{}"
@@ -30,9 +31,9 @@ MESSAGE_CONTENT_URI = "/api/v0/messages/{}/content"
 RECEPTION_DATETIME = pytz.utc.localize(dt.datetime(2023, 1, 1))
 
 
-@pytest.fixture
-def fixture_messages_with_status(
-    session_factory: DbSessionFactory,
+@pytest_asyncio.fixture
+async def fixture_messages_with_status(
+    session_factory: AsyncDbSessionFactory,
 ) -> Mapping[MessageStatus, Sequence[Any]]:
 
     pending_messages = [
@@ -171,7 +172,7 @@ def fixture_messages_with_status(
         MessageStatus.REJECTED: rejected_messages,
     }
 
-    with session_factory() as session:
+    async with session_factory() as session:
         for status, messages in messages_dict.items():
             for message in messages:
                 session.add(message)
@@ -182,7 +183,7 @@ def fixture_messages_with_status(
                         reception_time=RECEPTION_DATETIME,
                     )
                 )
-        session.commit()
+        await session.commit()
 
     return messages_dict
 

--- a/tests/api/test_new_metric.py
+++ b/tests/api/test_new_metric.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 import pytest_asyncio
 
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 from .conftest import _load_fixtures
 
@@ -15,7 +15,7 @@ def _generate_uri(node_type: str, node_id: str) -> str:
 
 @pytest_asyncio.fixture
 async def fixture_metrics_messages(
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
 ) -> Sequence[Dict[str, Any]]:
     return await _load_fixtures(session_factory, "test-metric.json")
 

--- a/tests/api/test_posts.py
+++ b/tests/api/test_posts.py
@@ -6,7 +6,7 @@ import pytest
 from aleph.db.models import MessageDb
 from aleph.db.models.messages import MessageStatusDb
 from aleph.db.models.posts import PostDb
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 POSTS_URI = "/api/v1/posts.json"
 
@@ -57,16 +57,16 @@ async def test_get_posts(ccn_api_client, fixture_posts: Sequence[PostDb]):
 @pytest.mark.asyncio
 async def test_get_posts_refs(
     ccn_api_client,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     fixture_posts: Sequence[PostDb],
     post_with_refs_and_tags: Tuple[MessageDb, PostDb, MessageStatusDb],
 ):
     message_db, post_db, message_status_db = post_with_refs_and_tags
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add_all(fixture_posts)
         session.add_all([message_db, post_db, message_status_db])
-        session.commit()
+        await session.commit()
 
     # Match the ref
     response = await ccn_api_client.get(
@@ -111,7 +111,7 @@ async def test_get_posts_refs(
 @pytest.mark.asyncio
 async def test_get_amended_posts_refs(
     ccn_api_client,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     fixture_posts: Sequence[PostDb],
     post_with_refs_and_tags: Tuple[MessageDb, PostDb, MessageStatusDb],
     amended_post_with_refs_and_tags: Tuple[MessageDb, PostDb, MessageStatusDb],
@@ -125,13 +125,13 @@ async def test_get_amended_posts_refs(
 
     original_post_db.latest_amend = amend_post_db.item_hash
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add_all(fixture_posts)
         session.add_all(
             [original_message_db, original_post_db, original_message_status_db]
         )
         session.add_all([amend_message_db, amend_post_db, amend_message_status_db])
-        session.commit()
+        await session.commit()
 
     # Match the ref
     response = await ccn_api_client.get(
@@ -176,16 +176,16 @@ async def test_get_amended_posts_refs(
 @pytest.mark.asyncio
 async def test_get_posts_tags(
     ccn_api_client,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     fixture_posts: Sequence[PostDb],
     post_with_refs_and_tags: Tuple[MessageDb, PostDb, MessageStatusDb],
 ):
     message_db, post_db, message_status_db = post_with_refs_and_tags
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add_all(fixture_posts)
         session.add_all([message_db, post_db, message_status_db])
-        session.commit()
+        await session.commit()
 
     # Match one tag
     response = await ccn_api_client.get(
@@ -245,7 +245,7 @@ async def test_get_posts_tags(
 @pytest.mark.asyncio
 async def test_get_amended_posts_tags(
     ccn_api_client,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     fixture_posts: Sequence[PostDb],
     post_with_refs_and_tags: Tuple[MessageDb, PostDb, MessageStatusDb],
     amended_post_with_refs_and_tags: Tuple[MessageDb, PostDb, MessageStatusDb],
@@ -259,13 +259,13 @@ async def test_get_amended_posts_tags(
 
     original_post_db.latest_amend = amend_post_db.item_hash
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add_all(fixture_posts)
         session.add_all(
             [original_message_db, original_post_db, original_message_status_db]
         )
         session.add_all([amend_message_db, amend_post_db, amend_message_status_db])
-        session.commit()
+        await session.commit()
 
     # Match one tag
     response = await ccn_api_client.get("/api/v0/posts.json", params={"tags": "amend"})

--- a/tests/balances/test_balances.py
+++ b/tests/balances/test_balances.py
@@ -7,7 +7,7 @@ from aleph_message.models import Chain
 from aleph.db.accessors.balances import get_balance_by_chain, get_total_balance
 from aleph.db.models import AlephBalanceDb
 from aleph.handlers.content.post import update_balances
-from aleph.types.db_session import DbSession, DbSessionFactory
+from aleph.types.db_session import AsyncDbSession, AsyncDbSessionFactory
 
 BALANCES_CONTENT_SOL: Mapping[str, Any] = {
     "tags": ["SOL", "SPL", "CsZ5LZkDS7h9TDKjrbL7VAwQZ9nsRu8vJLhRYfmGaN8K", "mainnet"],
@@ -63,62 +63,68 @@ BALANCES_CONTENT_SABLIER: Mapping[str, Any] = {
 }
 
 
-def compare_balances(
-    session: DbSession, balances: Mapping[str, float], chain: Chain, dapp: Optional[str]
+async def compare_balances(
+    session: AsyncDbSession,
+    balances: Mapping[str, float],
+    chain: Chain,
+    dapp: Optional[str],
 ):
     for address, expected_balance in balances.items():
-        balance_db = get_balance_by_chain(
+        balance_db = await get_balance_by_chain(
             session, address=address, chain=chain, dapp=dapp
         )
         assert balance_db is not None
-        # Easier to compare decimals and floats as strings
-        assert str(balance_db) == str(expected_balance)
+        assert balance_db == Decimal(
+            str(expected_balance)
+        )  # Force the conversion to str to avoid float to decimal
 
-    nb_balances_db = AlephBalanceDb.count(session)
+    nb_balances_db = await AlephBalanceDb.count(session)
     assert nb_balances_db == len(balances)
 
 
 @pytest.mark.asyncio
-async def test_process_balances_solana(session_factory: DbSessionFactory):
+async def test_process_balances_solana(session_factory: AsyncDbSessionFactory):
     content = BALANCES_CONTENT_SOL
 
-    with session_factory() as session:
-        update_balances(session=session, content=content)
-        session.commit()
+    async with session_factory() as session:
+        await update_balances(session=session, content=content)
+        await session.commit()
 
         balances = content["balances"]
-        compare_balances(session=session, balances=balances, chain=Chain.SOL, dapp=None)
+        await compare_balances(
+            session=session, balances=balances, chain=Chain.SOL, dapp=None
+        )
 
 
 @pytest.mark.asyncio
-async def test_process_balances_sablier(session_factory: DbSessionFactory):
+async def test_process_balances_sablier(session_factory: AsyncDbSessionFactory):
     content = BALANCES_CONTENT_SABLIER
 
-    with session_factory() as session:
-        update_balances(session=session, content=content)
-        session.commit()
+    async with session_factory() as session:
+        await update_balances(session=session, content=content)
+        await session.commit()
 
         balances = content["balances"]
-        compare_balances(
+        await compare_balances(
             session=session, balances=balances, chain=Chain.ETH, dapp="SABLIER"
         )
 
 
 @pytest.mark.asyncio
-async def test_update_balances(session_factory: DbSessionFactory):
+async def test_update_balances(session_factory: AsyncDbSessionFactory):
     content = BALANCES_CONTENT_SOL
 
-    with session_factory() as session:
-        update_balances(session=session, content=content)
-        session.commit()
+    async with session_factory() as session:
+        await update_balances(session=session, content=content)
+        await session.commit()
 
     new_content = BALANCES_CONTENT_SOL_UPDATE
-    with session_factory() as session:
-        update_balances(session=session, content=new_content)
-        session.commit()
+    async with session_factory() as session:
+        await update_balances(session=session, content=new_content)
+        await session.commit()
         session.expire_all()
 
-        compare_balances(
+        await compare_balances(
             session=session,
             balances=new_content["balances"],
             chain=Chain.SOL,
@@ -126,11 +132,12 @@ async def test_update_balances(session_factory: DbSessionFactory):
         )
 
 
-def test_get_total_balance(session_factory: DbSessionFactory):
+@pytest.mark.asyncio
+async def test_get_total_balance(session_factory: AsyncDbSessionFactory):
     address_1 = "my-address"
     address_2 = "your-address"
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add(
             AlephBalanceDb(
                 address=address_1,
@@ -167,25 +174,25 @@ def test_get_total_balance(session_factory: DbSessionFactory):
                 eth_height=0,
             )
         )
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
-        balance_with_dapps = get_total_balance(
+    async with session_factory() as session:
+        balance_with_dapps = await get_total_balance(
             session=session, address=address_1, include_dapps=True
         )
         assert balance_with_dapps == 1_001_100_000
 
-        balance_no_dapps = get_total_balance(
+        balance_no_dapps = await get_total_balance(
             session=session, address=address_1, include_dapps=False
         )
         assert balance_no_dapps == 1_100_000
 
-        balance_address_2 = get_total_balance(
+        balance_address_2 = await get_total_balance(
             session=session, address=address_2, include_dapps=False
         )
         assert balance_address_2 == 3
 
-        balance_unknown_address = get_total_balance(
+        balance_unknown_address = await get_total_balance(
             session=session, address="unknown-address", include_dapps=False
         )
         assert balance_unknown_address == Decimal(0)

--- a/tests/chains/test_chain_data_service.py
+++ b/tests/chains/test_chain_data_service.py
@@ -18,7 +18,7 @@ from aleph.schemas.chains.tezos_indexer_response import MessageEventPayload
 from aleph.schemas.pending_messages import parse_message
 from aleph.toolkit.timestamp import timestamp_to_datetime
 from aleph.types.chain_sync import ChainSyncProtocol
-from aleph.types.db_session import DbSession, DbSessionFactory
+from aleph.types.db_session import AsyncDbSession, AsyncDbSessionFactory
 
 
 @pytest.mark.asyncio
@@ -42,7 +42,7 @@ async def test_prepare_sync_event_payload(mocker):
     ]
 
     async def mock_add_file(
-        session: DbSession, file_content: bytes, engine: ItemType = ItemType.ipfs
+        session: AsyncDbSession, file_content: bytes, engine: ItemType = ItemType.ipfs
     ) -> str:
         content = file_content
         archive = OnChainSyncEventPayload.model_validate_json(content)
@@ -70,7 +70,7 @@ async def test_prepare_sync_event_payload(mocker):
 
 @pytest.mark.asyncio
 async def test_smart_contract_protocol_ipfs_store(
-    mocker, session_factory: DbSessionFactory
+    mocker, session_factory: AsyncDbSessionFactory
 ):
     payload = MessageEventPayload(
         timestamp=1668611900,
@@ -122,7 +122,7 @@ async def test_smart_contract_protocol_ipfs_store(
 
 @pytest.mark.asyncio
 async def test_smart_contract_protocol_regular_message(
-    mocker, session_factory: DbSessionFactory
+    mocker, session_factory: AsyncDbSessionFactory
 ):
     content = PostContent(
         content={"body": "My first post on Tezos"},

--- a/tests/db/test_aggregates.py
+++ b/tests/db/test_aggregates.py
@@ -11,11 +11,11 @@ from aleph.db.accessors.aggregates import (
     refresh_aggregate,
 )
 from aleph.db.models import AggregateDb, AggregateElementDb
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 
 @pytest.mark.asyncio
-async def test_get_aggregate_by_key(session_factory: DbSessionFactory):
+async def test_get_aggregate_by_key(session_factory: AsyncDbSessionFactory):
     key = "key"
     owner = "Me"
     creation_datetime = dt.datetime(2022, 1, 1)
@@ -35,12 +35,12 @@ async def test_get_aggregate_by_key(session_factory: DbSessionFactory):
         ),
     )
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add(aggregate)
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
-        aggregate_db = get_aggregate_by_key(session=session, owner=owner, key=key)
+    async with session_factory() as session:
+        aggregate_db = await get_aggregate_by_key(session=session, owner=owner, key=key)
         assert aggregate_db
         assert aggregate_db.key == key
         assert aggregate_db.owner == owner
@@ -48,8 +48,8 @@ async def test_get_aggregate_by_key(session_factory: DbSessionFactory):
         assert aggregate_db.last_revision_hash == aggregate.last_revision.item_hash
 
     # Try not loading the content
-    with session_factory() as session:
-        aggregate_db = get_aggregate_by_key(
+    async with session_factory() as session:
+        aggregate_db = await get_aggregate_by_key(
             session=session, owner=owner, key=key, with_content=False
         )
 
@@ -59,9 +59,11 @@ async def test_get_aggregate_by_key(session_factory: DbSessionFactory):
 
 
 @pytest.mark.asyncio
-async def test_get_aggregate_by_key_no_data(session_factory: DbSessionFactory):
-    with session_factory() as session:
-        aggregate = get_aggregate_by_key(session=session, owner="owner", key="key")
+async def test_get_aggregate_by_key_no_data(session_factory: AsyncDbSessionFactory):
+    async with session_factory() as session:
+        aggregate = await get_aggregate_by_key(
+            session=session, owner="owner", key="key"
+        )
 
     assert aggregate is None
 
@@ -107,25 +109,26 @@ def aggregate_fixtures() -> Tuple[AggregateDb, Sequence[AggregateElementDb]]:
     ]
 
 
-def _test_refresh_aggregate(
-    session_factory: DbSessionFactory,
+@pytest.mark.asyncio
+async def _test_refresh_aggregate(
+    session_factory: AsyncDbSessionFactory,
     aggregate: Optional[AggregateDb],
     expected_aggregate: AggregateDb,
     elements: Sequence[AggregateElementDb],
 ):
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add_all(elements)
         if aggregate:
             session.add(aggregate)
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
-        refresh_aggregate(
+    async with session_factory() as session:
+        await refresh_aggregate(
             session=session, owner=expected_aggregate.owner, key=expected_aggregate.key
         )
-        session.commit()
+        await session.commit()
 
-        aggregate_db = get_aggregate_by_key(
+        aggregate_db = await get_aggregate_by_key(
             session=session, owner=expected_aggregate.owner, key=expected_aggregate.key
         )
 
@@ -141,11 +144,11 @@ def _test_refresh_aggregate(
 
 @pytest.mark.asyncio
 async def test_refresh_aggregate_insert(
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     aggregate_fixtures: Tuple[AggregateDb, Sequence[AggregateElementDb]],
 ):
     aggregate, elements = aggregate_fixtures
-    _test_refresh_aggregate(
+    await _test_refresh_aggregate(
         session_factory=session_factory,
         aggregate=None,
         expected_aggregate=aggregate,
@@ -155,7 +158,7 @@ async def test_refresh_aggregate_insert(
 
 @pytest.mark.asyncio
 async def test_refresh_aggregate_update(
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     aggregate_fixtures: Tuple[AggregateDb, Sequence[AggregateElementDb]],
 ):
     updated_aggregate, elements = aggregate_fixtures
@@ -167,7 +170,7 @@ async def test_refresh_aggregate_update(
         last_revision_hash=elements[0].item_hash,
         dirty=True,
     )
-    _test_refresh_aggregate(
+    await _test_refresh_aggregate(
         session_factory=session_factory,
         aggregate=aggregate,
         expected_aggregate=updated_aggregate,
@@ -177,11 +180,11 @@ async def test_refresh_aggregate_update(
 
 @pytest.mark.asyncio
 async def test_refresh_aggregate_update_no_op(
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     aggregate_fixtures: Tuple[AggregateDb, Sequence[AggregateElementDb]],
 ):
     aggregate, elements = aggregate_fixtures
-    _test_refresh_aggregate(
+    await _test_refresh_aggregate(
         session_factory=session_factory,
         aggregate=aggregate,
         expected_aggregate=aggregate,
@@ -191,27 +194,29 @@ async def test_refresh_aggregate_update_no_op(
 
 @pytest.mark.asyncio
 async def test_get_content_keys(
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     aggregate_fixtures: Tuple[AggregateDb, Sequence[AggregateElementDb]],
 ):
     aggregate, elements = aggregate_fixtures
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add_all(elements)
         session.add(aggregate)
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
+    async with session_factory() as session:
         keys = set(
-            get_aggregate_content_keys(
+            await get_aggregate_content_keys(
                 session=session, key=aggregate.key, owner=aggregate.owner
             )
         )
         assert keys == set(aggregate.content.keys())
 
     # Test no match
-    with session_factory() as session:
+    async with session_factory() as session:
         keys = set(
-            get_aggregate_content_keys(session=session, key="not-a-key", owner="no-one")
+            await get_aggregate_content_keys(
+                session=session, key="not-a-key", owner="no-one"
+            )
         )
         assert keys == set()

--- a/tests/db/test_chains.py
+++ b/tests/db/test_chains.py
@@ -16,11 +16,11 @@ from aleph.db.accessors.chains import (
 from aleph.db.models.chains import ChainSyncStatusDb, IndexerSyncStatusDb
 from aleph.toolkit.range import MultiRange, Range
 from aleph.types.chain_sync import ChainEventType
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 
 @pytest.mark.asyncio
-async def test_get_last_height(session_factory: DbSessionFactory):
+async def test_get_last_height(session_factory: AsyncDbSessionFactory):
     sync_type = ChainEventType.SYNC
     eth_sync_status = ChainSyncStatusDb(
         chain=Chain.ETH,
@@ -29,20 +29,22 @@ async def test_get_last_height(session_factory: DbSessionFactory):
         last_update=pytz.utc.localize(dt.datetime(2022, 10, 1)),
     )
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add(eth_sync_status)
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
-        height = get_last_height(session=session, chain=Chain.ETH, sync_type=sync_type)
+    async with session_factory() as session:
+        height = await get_last_height(
+            session=session, chain=Chain.ETH, sync_type=sync_type
+        )
 
     assert height == eth_sync_status.height
 
 
 @pytest.mark.asyncio
-async def test_get_last_height_no_data(session_factory: DbSessionFactory):
-    with session_factory() as session:
-        height = get_last_height(
+async def test_get_last_height_no_data(session_factory: AsyncDbSessionFactory):
+    async with session_factory() as session:
+        height = await get_last_height(
             session=session, chain=Chain.NULS2, sync_type=ChainEventType.SYNC
         )
 
@@ -50,26 +52,26 @@ async def test_get_last_height_no_data(session_factory: DbSessionFactory):
 
 
 @pytest.mark.asyncio
-async def test_upsert_chain_sync_status_insert(session_factory: DbSessionFactory):
+async def test_upsert_chain_sync_status_insert(session_factory: AsyncDbSessionFactory):
     chain = Chain.ETH
     sync_type = ChainEventType.SYNC
     update_datetime = pytz.utc.localize(dt.datetime(2022, 11, 1))
     height = 10
 
-    with session_factory() as session:
-        upsert_chain_sync_status(
+    async with session_factory() as session:
+        await upsert_chain_sync_status(
             session=session,
             chain=chain,
             sync_type=sync_type,
             height=height,
             update_datetime=update_datetime,
         )
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
+    async with session_factory() as session:
 
         chain_sync_status = (
-            session.execute(
+            await session.execute(
                 select(ChainSyncStatusDb).where(ChainSyncStatusDb.chain == chain)
             )
         ).scalar_one()
@@ -81,7 +83,7 @@ async def test_upsert_chain_sync_status_insert(session_factory: DbSessionFactory
 
 
 @pytest.mark.asyncio
-async def test_upsert_peer_replace(session_factory: DbSessionFactory):
+async def test_upsert_peer_replace(session_factory: AsyncDbSessionFactory):
     existing_entry = ChainSyncStatusDb(
         chain=Chain.TEZOS,
         type=ChainEventType.SYNC,
@@ -89,26 +91,26 @@ async def test_upsert_peer_replace(session_factory: DbSessionFactory):
         last_update=pytz.utc.localize(dt.datetime(2023, 2, 6)),
     )
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add(existing_entry)
-        session.commit()
+        await session.commit()
 
     new_height = 1001
     new_update_datetime = pytz.utc.localize(dt.datetime(2023, 2, 7))
 
-    with session_factory() as session:
-        upsert_chain_sync_status(
+    async with session_factory() as session:
+        await upsert_chain_sync_status(
             session=session,
             chain=existing_entry.chain,
             sync_type=ChainEventType.SYNC,
             height=new_height,
             update_datetime=new_update_datetime,
         )
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
+    async with session_factory() as session:
         chain_sync_status = (
-            session.execute(
+            await session.execute(
                 select(ChainSyncStatusDb).where(
                     ChainSyncStatusDb.chain == existing_entry.chain
                 )
@@ -141,7 +143,8 @@ def indexer_multirange():
     )
 
 
-def test_get_indexer_multirange(session_factory: DbSessionFactory):
+@pytest.mark.asyncio
+async def test_get_indexer_multirange(session_factory: AsyncDbSessionFactory):
     chain = Chain.ETH
     event_type = ChainEventType.SYNC
 
@@ -175,12 +178,12 @@ def test_get_indexer_multirange(session_factory: DbSessionFactory):
         ),
     ]
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add_all(ranges)
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
-        db_multirange = get_indexer_multirange(
+    async with session_factory() as session:
+        db_multirange = await get_indexer_multirange(
             session=session, chain=chain, event_type=event_type
         )
 
@@ -191,17 +194,18 @@ def test_get_indexer_multirange(session_factory: DbSessionFactory):
     )
 
 
-def test_update_indexer_multirange(
-    indexer_multirange: IndexerMultiRange, session_factory: DbSessionFactory
+@pytest.mark.asyncio
+async def test_update_indexer_multirange(
+    indexer_multirange: IndexerMultiRange, session_factory: AsyncDbSessionFactory
 ):
-    with session_factory() as session:
-        update_indexer_multirange(
+    async with session_factory() as session:
+        await update_indexer_multirange(
             session=session, indexer_multirange=indexer_multirange
         )
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
-        indexer_multirange_db = get_indexer_multirange(
+    async with session_factory() as session:
+        indexer_multirange_db = await get_indexer_multirange(
             session=session,
             chain=indexer_multirange.chain,
             event_type=indexer_multirange.event_type,
@@ -210,16 +214,17 @@ def test_update_indexer_multirange(
         assert indexer_multirange_db == indexer_multirange
 
 
-def test_get_missing_indexer_datetime_multirange(
-    indexer_multirange: IndexerMultiRange, session_factory: DbSessionFactory
+@pytest.mark.asyncio
+async def test_get_missing_indexer_datetime_multirange(
+    indexer_multirange: IndexerMultiRange, session_factory: AsyncDbSessionFactory
 ):
-    with session_factory() as session:
-        update_indexer_multirange(
+    async with session_factory() as session:
+        await update_indexer_multirange(
             session=session, indexer_multirange=indexer_multirange
         )
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
+    async with session_factory() as session:
         new_multirange = MultiRange(
             Range(
                 dt.datetime(2019, 1, 1, tzinfo=dt.timezone.utc),
@@ -227,7 +232,7 @@ def test_get_missing_indexer_datetime_multirange(
                 upper_inc=True,
             )
         )
-        dt_multirange = get_missing_indexer_datetime_multirange(
+        dt_multirange = await get_missing_indexer_datetime_multirange(
             session=session,
             chain=indexer_multirange.chain,
             event_type=indexer_multirange.event_type,

--- a/tests/db/test_error_codes.py
+++ b/tests/db/test_error_codes.py
@@ -1,18 +1,20 @@
+import pytest
 from sqlalchemy import select
 
 from aleph.db.models import ErrorCodeDb
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 from aleph.types.message_status import ErrorCode
 
 
-def test_all_error_codes_mapped_in_db(session_factory: DbSessionFactory):
+@pytest.mark.asyncio
+async def test_all_error_codes_mapped_in_db(session_factory: AsyncDbSessionFactory):
     """
     Check that the ErrorCode enum values are all mapped in the database and vice-versa.
     Sanity check for developers.
     """
 
-    with session_factory() as session:
-        db_error_codes = session.execute(select(ErrorCodeDb)).scalars()
+    async with session_factory() as session:
+        db_error_codes = (await session.execute(select(ErrorCodeDb))).scalars()
         db_error_codes_dict = {e.code: e for e in db_error_codes}
 
     # All error code enum values must be mapped in the DB

--- a/tests/db/test_files.py
+++ b/tests/db/test_files.py
@@ -11,15 +11,15 @@ from aleph.db.accessors.files import (
     upsert_file_tag,
 )
 from aleph.db.models import MessageFilePinDb, StoredFileDb, TxFilePinDb
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 from aleph.types.files import FileTag, FileType
 
 
 @pytest.mark.asyncio
-async def test_is_pinned_file(session_factory: DbSessionFactory):
-    def is_pinned(_session_factory, _file_hash) -> bool:
-        with _session_factory() as _session:
-            return is_pinned_file(session=_session, file_hash=_file_hash)
+async def test_is_pinned_file(session_factory: AsyncDbSessionFactory):
+    async def is_pinned(_session_factory, _file_hash) -> bool:
+        async with _session_factory() as _session:
+            return await is_pinned_file(session=_session, file_hash=_file_hash)
 
     file = StoredFileDb(
         hash="QmTm7g1Mh3BhrQPjnedVQ5g67DR7cwhyMN3MvFt1JPPdWd",
@@ -27,27 +27,27 @@ async def test_is_pinned_file(session_factory: DbSessionFactory):
         type=FileType.FILE,
     )
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add(file)
-        session.commit()
+        await session.commit()
 
     # We check for equality with True/False to determine that the function does indeed
     # return a boolean value
-    assert is_pinned(session_factory, file.hash) is False
+    assert await is_pinned(session_factory, file.hash) is False
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add(
             TxFilePinDb(
                 file_hash=file.hash, tx_hash="1234", created=dt.datetime(2020, 1, 1)
             )
         )
-        session.commit()
+        await session.commit()
 
-    assert is_pinned(session_factory, file.hash) is True
+    assert await is_pinned(session_factory, file.hash) is True
 
 
 @pytest.mark.asyncio
-async def test_upsert_file_tag(session_factory: DbSessionFactory):
+async def test_upsert_file_tag(session_factory: AsyncDbSessionFactory):
     original_file = StoredFileDb(
         hash="QmTm7g1Mh3BhrQPjnedVQ5g67DR7cwhyMN3MvFt1JPPdWd",
         size=32,
@@ -63,57 +63,57 @@ async def test_upsert_file_tag(session_factory: DbSessionFactory):
     tag = FileTag("aleph/custom-tag")
     owner = "aleph"
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add(original_file)
         session.add(new_version)
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
-        upsert_file_tag(
+    async with session_factory() as session:
+        await upsert_file_tag(
             session=session,
             tag=tag,
             owner=owner,
             file_hash=original_file.hash,
             last_updated=original_datetime,
         )
-        session.commit()
+        await session.commit()
 
-        file_tag_db = get_file_tag(session=session, tag=tag)
+        file_tag_db = await get_file_tag(session=session, tag=tag)
         assert file_tag_db is not None
         assert file_tag_db.owner == owner
         assert file_tag_db.file_hash == original_file.hash
         assert file_tag_db.last_updated == original_datetime
 
     # Update the tag
-    with session_factory() as session:
+    async with session_factory() as session:
         new_version_datetime = pytz.utc.localize(dt.datetime(2022, 1, 1))
-        upsert_file_tag(
+        await upsert_file_tag(
             session=session,
             tag=tag,
             owner=owner,
             file_hash=new_version.hash,
             last_updated=new_version_datetime,
         )
-        session.commit()
+        await session.commit()
 
-        file_tag_db = get_file_tag(session=session, tag=tag)
+        file_tag_db = await get_file_tag(session=session, tag=tag)
         assert file_tag_db is not None
         assert file_tag_db.owner == owner
         assert file_tag_db.file_hash == new_version.hash
         assert file_tag_db.last_updated == new_version_datetime
 
     # Try to update the tag to an older version and check it has no effect
-    with session_factory() as session:
-        upsert_file_tag(
+    async with session_factory() as session:
+        await upsert_file_tag(
             session=session,
             tag=tag,
             owner=owner,
             file_hash=original_file.hash,
             last_updated=original_datetime,
         )
-        session.commit()
+        await session.commit()
 
-        file_tag_db = get_file_tag(session=session, tag=tag)
+        file_tag_db = await get_file_tag(session=session, tag=tag)
         assert file_tag_db is not None
         assert file_tag_db.owner == owner
         assert file_tag_db.file_hash == new_version.hash
@@ -121,7 +121,7 @@ async def test_upsert_file_tag(session_factory: DbSessionFactory):
 
 
 @pytest.mark.asyncio
-async def test_refresh_file_tag(session_factory: DbSessionFactory):
+async def test_refresh_file_tag(session_factory: AsyncDbSessionFactory):
     files = [
         StoredFileDb(
             hash="QmTm7g1Mh3BhrQPjnedVQ5g67DR7cwhyMN3MvFt1JPPdWd",
@@ -152,15 +152,15 @@ async def test_refresh_file_tag(session_factory: DbSessionFactory):
         owner=owner,
     )
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add_all([first_pin, second_pin])
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
-        refresh_file_tag(session=session, tag=tag)
-        session.commit()
+    async with session_factory() as session:
+        await refresh_file_tag(session=session, tag=tag)
+        await session.commit()
 
-        file_tag_db = get_file_tag(session=session, tag=tag)
+        file_tag_db = await get_file_tag(session=session, tag=tag)
         assert file_tag_db
         assert file_tag_db.file_hash == second_pin.file_hash
         assert file_tag_db.last_updated == second_pin.created

--- a/tests/helpers/message_test_helpers.py
+++ b/tests/helpers/message_test_helpers.py
@@ -8,7 +8,7 @@ from aleph_message.models import ItemType, MessageConfirmation
 from aleph.db.models import MessageDb, MessageStatusDb, PendingMessageDb
 from aleph.jobs.process_pending_messages import PendingMessageProcessor
 from aleph.toolkit.timestamp import utc_now
-from aleph.types.db_session import DbSession
+from aleph.types.db_session import AsyncDbSession
 from aleph.types.message_processing_result import MessageProcessingResult
 from aleph.types.message_status import MessageStatus
 
@@ -45,7 +45,7 @@ def make_validated_message_from_dict(
 async def process_pending_messages(
     message_processor: PendingMessageProcessor,
     pending_messages: Sequence[PendingMessageDb],
-    session: DbSession,
+    session: AsyncDbSession,
 ) -> Iterable[MessageProcessingResult]:
 
     for pending_message in pending_messages:
@@ -58,7 +58,7 @@ async def process_pending_messages(
             )
         )
     session.add_all(pending_messages)
-    session.commit()
+    await session.commit()
 
     pipeline = message_processor.make_pipeline()
 

--- a/tests/jobs/test_cron_job.py
+++ b/tests/jobs/test_cron_job.py
@@ -4,11 +4,11 @@ import pytest
 
 from aleph.jobs.cron.balance_job import BalanceCronJob
 from aleph.jobs.cron.cron_job import CronJob
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 
 @pytest.fixture
-def cron_job(session_factory: DbSessionFactory) -> CronJob:
+def cron_job(session_factory: AsyncDbSessionFactory) -> CronJob:
     return CronJob(
         session_factory=session_factory,
         jobs={"balance": BalanceCronJob(session_factory=session_factory)},
@@ -25,10 +25,10 @@ def cron_job(session_factory: DbSessionFactory) -> CronJob:
     ],
 )
 async def test_balance_job_run(
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     cron_job: CronJob,
     cron_run_datetime: dt.datetime,
 ):
-    with session_factory() as session:
+    async with session_factory() as session:
         await cron_job.run(now=cron_run_datetime)
-        session.commit()
+        await session.commit()

--- a/tests/message_processing/conftest.py
+++ b/tests/message_processing/conftest.py
@@ -13,7 +13,7 @@ from aleph.db.models import ChainTxDb, PendingMessageDb
 from aleph.handlers.message_handler import MessageHandler
 from aleph.jobs.process_pending_messages import PendingMessageProcessor
 from aleph.storage import StorageService
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 from .load_fixtures import load_fixture_messages
 
@@ -27,7 +27,7 @@ def fixture_messages():
 #       it could make sense to have some general fixtures available to all the test cases
 #       to reduce duplication between DB tests, API tests, etc.
 async def _load_fixtures(
-    session_factory: DbSessionFactory, filename: str
+    session_factory: AsyncDbSessionFactory, filename: str
 ) -> Sequence[Dict[str, Any]]:
     fixtures_dir = Path(__file__).parent / "fixtures"
     fixtures_file = fixtures_dir / filename
@@ -51,30 +51,32 @@ async def _load_fixtures(
                 chain_txs.append(ChainTxDb.from_dict(confirmation))
                 tx_hashes.add(tx_hash)
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add_all(pending_messages)
         session.add_all(chain_txs)
-        session.commit()
+        await session.commit()
 
     return messages_json
 
 
 @pytest_asyncio.fixture
 async def fixture_aggregate_messages(
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
 ) -> Sequence[Dict[str, Any]]:
     return await _load_fixtures(session_factory, "test-data-aggregates.json")
 
 
 @pytest_asyncio.fixture
 async def fixture_post_messages(
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
 ) -> Sequence[Dict[str, Any]]:
     return await _load_fixtures(session_factory, "test-data-posts.json")
 
 
 @pytest.fixture
-def message_processor(mocker, mock_config: Config, session_factory: DbSessionFactory):
+def message_processor(
+    mocker, mock_config: Config, session_factory: AsyncDbSessionFactory
+):
     storage_engine = InMemoryStorageEngine(files={})
     storage_service = StorageService(
         storage_engine=storage_engine,

--- a/tests/message_processing/test_process_pending_messages.py
+++ b/tests/message_processing/test_process_pending_messages.py
@@ -1,11 +1,12 @@
 import pytest
 from configmanager import Config
+from sqlalchemy import func, select
 
 from aleph.db.models import PendingMessageDb
 from aleph.handlers.message_handler import MessagePublisher
 from aleph.storage import StorageService
 from aleph.toolkit.timestamp import utc_now
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 from aleph.types.message_status import MessageOrigin
 
 from .load_fixtures import load_fixture_message
@@ -15,7 +16,7 @@ from .load_fixtures import load_fixture_message
 async def test_duplicated_pending_message(
     mocker,
     mock_config: Config,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     test_storage_service: StorageService,
 ):
     message = load_fixture_message("test-data-pending-messaging.json")
@@ -44,6 +45,9 @@ async def test_duplicated_pending_message(
     assert test2.content == test1.content
     assert test2.reception_time == test1.reception_time
 
-    with session_factory() as session:
-        pending_messages = session.query(PendingMessageDb).count()
+    async with session_factory() as session:
+        result = await session.execute(
+            select(func.count()).select_from(PendingMessageDb)
+        )
+        pending_messages = result.scalar_one()
         assert pending_messages == 1

--- a/tests/message_processing/test_process_programs.py
+++ b/tests/message_processing/test_process_programs.py
@@ -2,9 +2,10 @@ import datetime as dt
 import itertools
 import json
 from decimal import Decimal
-from typing import List
+from typing import List, cast
 
 import pytest
+import pytest_asyncio
 import pytz
 from aleph_message.models import Chain, ItemHash, ItemType, MessageType
 from aleph_message.models.execution import MachineType
@@ -28,13 +29,15 @@ from aleph.db.models import (
 )
 from aleph.jobs.process_pending_messages import PendingMessageProcessor
 from aleph.toolkit.timestamp import timestamp_to_datetime
-from aleph.types.db_session import DbSession, DbSessionFactory
+from aleph.types.db_session import AsyncDbSession, AsyncDbSessionFactory
 from aleph.types.files import FileTag, FileType
 from aleph.types.message_status import ErrorCode, MessageStatus
 
 
-@pytest.fixture
-def fixture_program_message(session_factory: DbSessionFactory) -> PendingMessageDb:
+@pytest_asyncio.fixture
+async def fixture_program_message(
+    session_factory: AsyncDbSessionFactory,
+) -> PendingMessageDb:
     pending_message = PendingMessageDb(
         item_hash="734a1287a2b7b5be060312ff5b05ad1bcf838950492e3428f2ac6437a1acad26",
         type=MessageType.program,
@@ -51,7 +54,7 @@ def fixture_program_message(session_factory: DbSessionFactory) -> PendingMessage
         retries=0,
         next_attempt=dt.datetime(2023, 1, 1),
     )
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add(pending_message)
         session.add(
             MessageStatusDb(
@@ -60,14 +63,14 @@ def fixture_program_message(session_factory: DbSessionFactory) -> PendingMessage
                 reception_time=pending_message.reception_time,
             )
         )
-        session.commit()
+        await session.commit()
 
     return pending_message
 
 
-@pytest.fixture
-def fixture_program_message_with_subscriptions(
-    session_factory: DbSessionFactory,
+@pytest_asyncio.fixture()
+async def fixture_program_message_with_subscriptions(
+    session_factory: AsyncDbSessionFactory,
 ) -> PendingMessageDb:
     pending_message = PendingMessageDb(
         item_hash="cad11970efe9b7478300fd04d7cc91c646ca0a792b9cc718650f86e1ccfac73e",
@@ -85,7 +88,7 @@ def fixture_program_message_with_subscriptions(
         retries=0,
         next_attempt=dt.datetime(2023, 1, 1),
     )
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add(pending_message)
         session.add(
             MessageStatusDb(
@@ -94,7 +97,7 @@ def fixture_program_message_with_subscriptions(
                 reception_time=pending_message.reception_time,
             )
         )
-        session.commit()
+        await session.commit()
 
     return pending_message
 
@@ -111,7 +114,7 @@ def get_volumes_with_ref(content: ProgramContent) -> List:
     return volumes
 
 
-def insert_volume_refs(session: DbSession, message: PendingMessageDb):
+async def insert_volume_refs(session: AsyncDbSession, message: PendingMessageDb):
     """
     Insert volume references in the DB to make the program processable.
     """
@@ -128,8 +131,8 @@ def insert_volume_refs(session: DbSession, message: PendingMessageDb):
         file_hash = volume.ref[::-1]
 
         session.add(StoredFileDb(hash=file_hash, size=1024 * 1024, type=FileType.FILE))
-        session.flush()
-        insert_message_file_pin(
+        await session.flush()
+        await insert_message_file_pin(
             session=session,
             file_hash=volume.ref[::-1],
             owner=content.address,
@@ -138,7 +141,7 @@ def insert_volume_refs(session: DbSession, message: PendingMessageDb):
             created=created,
         )
         if volume.use_latest:
-            upsert_file_tag(
+            await upsert_file_tag(
                 session=session,
                 tag=FileTag(volume.ref),
                 owner=content.address,
@@ -147,8 +150,8 @@ def insert_volume_refs(session: DbSession, message: PendingMessageDb):
             )
 
 
-@pytest.fixture
-def user_balance(session_factory: DbSessionFactory) -> AlephBalanceDb:
+@pytest_asyncio.fixture()
+async def user_balance(session_factory: AsyncDbSessionFactory) -> AlephBalanceDb:
     balance = AlephBalanceDb(
         address="0x7083b90eBA420832A03C6ac7e6328d37c72e0260",
         chain=Chain.ETH,
@@ -156,24 +159,24 @@ def user_balance(session_factory: DbSessionFactory) -> AlephBalanceDb:
         eth_height=0,
     )
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add(balance)
-        session.commit()
+        await session.commit()
     return balance
 
 
 @pytest.mark.asyncio
 async def test_process_program(
     user_balance: AlephBalanceDb,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     message_processor: PendingMessageProcessor,
     fixture_program_message: PendingMessageDb,
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
 ):
-    with session_factory() as session:
-        insert_volume_refs(session, fixture_program_message)
-        session.commit()
+    async with session_factory() as session:
+        await insert_volume_refs(session, fixture_program_message)
+        await session.commit()
 
     pipeline = message_processor.make_pipeline()
     # Exhaust the iterator
@@ -182,10 +185,11 @@ async def test_process_program(
     assert fixture_program_message.item_content
     content_dict = json.loads(fixture_program_message.item_content)
 
-    with session_factory() as session:
-        program = get_program(
+    async with session_factory() as session:
+        program = await get_program(
             session=session, item_hash=fixture_program_message.item_hash
         )
+
         assert program is not None
 
         assert program.owner == fixture_program_message.sender
@@ -226,11 +230,14 @@ async def test_process_program(
                 key=lambda v: v.__class__,
             )
         }
+
         assert EphemeralVolumeDb not in volumes_by_type
         assert len(volumes_by_type[PersistentVolumeDb]) == 1
         assert len(volumes_by_type[ImmutableVolumeDb]) == 2
 
-        persistent_volume: PersistentVolumeDb = one(volumes_by_type[PersistentVolumeDb])
+        persistent_volume: PersistentVolumeDb = cast(
+            PersistentVolumeDb, one(volumes_by_type[PersistentVolumeDb])
+        )
         assert persistent_volume.name == "data"
         assert persistent_volume.mount == "/data"
         assert persistent_volume.size_mib == 128
@@ -239,16 +246,16 @@ async def test_process_program(
 
 @pytest.mark.asyncio
 async def test_program_with_subscriptions(
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     message_processor: PendingMessageProcessor,
     fixture_program_message_with_subscriptions: PendingMessageDb,
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
 ):
     program_message = fixture_program_message_with_subscriptions
-    with session_factory() as session:
-        insert_volume_refs(session, program_message)
-        session.commit()
+    async with session_factory() as session:
+        await insert_volume_refs(session, program_message)
+        await session.commit()
 
     pipeline = message_processor.make_pipeline()
     # Exhaust the iterator
@@ -257,8 +264,8 @@ async def test_program_with_subscriptions(
     assert program_message.item_content
     json.loads(program_message.item_content)
 
-    with session_factory() as session:
-        program: VmBaseDb = session.execute(select(VmBaseDb)).scalar_one()
+    async with session_factory() as session:
+        program: VmBaseDb = (await session.execute(select(VmBaseDb))).scalar_one()
         message_triggers = program.message_triggers
         assert message_triggers
         assert len(message_triggers) == 1
@@ -270,7 +277,7 @@ async def test_program_with_subscriptions(
 
 @pytest.mark.asyncio
 async def test_process_program_missing_volumes(
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     message_processor: PendingMessageProcessor,
     fixture_program_message_with_subscriptions: PendingMessageDb,
 ):
@@ -285,17 +292,19 @@ async def test_process_program_missing_volumes(
     # Exhaust the iterator
     _ = [message async for message in pipeline]
 
-    with session_factory() as session:
-        program_db = get_program(session=session, item_hash=ItemHash(program_hash))
+    async with session_factory() as session:
+        program_db = await get_program(
+            session=session, item_hash=ItemHash(program_hash)
+        )
         assert program_db is None
 
-        message_status = get_message_status(
+        message_status = await get_message_status(
             session=session, item_hash=ItemHash(program_hash)
         )
         assert message_status is not None
         assert message_status.status == MessageStatus.REJECTED
 
-        rejected_message = get_rejected_message(
+        rejected_message = await get_rejected_message(
             session=session, item_hash=ItemHash(program_hash)
         )
         assert rejected_message is not None

--- a/tests/permissions/test_check_sender_authorization.py
+++ b/tests/permissions/test_check_sender_authorization.py
@@ -7,7 +7,7 @@ from message_test_helpers import make_validated_message_from_dict
 from aleph.db.models import AggregateDb, AggregateElementDb
 from aleph.permissions import check_sender_authorization
 from aleph.toolkit.timestamp import timestamp_to_datetime
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 
 @pytest.mark.asyncio
@@ -101,7 +101,7 @@ async def test_authorized(mocker):
 
 
 @pytest.mark.asyncio
-async def test_authorized_with_db(session_factory: DbSessionFactory):
+async def test_authorized_with_db(session_factory: AsyncDbSessionFactory):
     aggregate_content = {
         "authorizations": [{"address": "0x86F39e17910E3E6d9F38412EB7F24Bf0Ba31eb2E"}]
     }
@@ -125,9 +125,9 @@ async def test_authorized_with_db(session_factory: DbSessionFactory):
         AUTHORIZED_MESSAGE, AUTHORIZED_MESSAGE["item_content"]
     )
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add(aggregate)
-        session.commit()
+        await session.commit()
 
         is_authorized = await check_sender_authorization(
             session=session, message=message

--- a/tests/services/test_cost_service.py
+++ b/tests/services/test_cost_service.py
@@ -14,7 +14,7 @@ from aleph.services.cost import (
     _get_settings_aggregate,
     get_total_and_detailed_costs,
 )
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 
 class StoredFileDb:
@@ -270,8 +270,9 @@ def fixture_hold_program_message_complete() -> ExecutableContent:
     return CostEstimationProgramContent.model_validate(content)
 
 
-def test_compute_cost(
-    session_factory: DbSessionFactory,
+@pytest.mark.asyncio
+async def test_compute_cost(
+    session_factory: AsyncDbSessionFactory,
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
     fixture_hold_instance_message,
@@ -280,15 +281,16 @@ def test_compute_cost(
     mock = Mock()
     mock.patch("_get_file_from_ref", return_value=file_db)
 
-    with session_factory() as session:
-        cost, details = get_total_and_detailed_costs(
+    async with session_factory() as session:
+        cost, details = await get_total_and_detailed_costs(
             session=session, content=fixture_hold_instance_message, item_hash="abab"
         )
         assert cost == Decimal("1000")
 
 
-def test_compute_cost_conf(
-    session_factory: DbSessionFactory,
+@pytest.mark.asyncio
+async def test_compute_cost_conf(
+    session_factory: AsyncDbSessionFactory,
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
     fixture_hold_instance_message,
@@ -312,15 +314,16 @@ def test_compute_cost_conf(
     mock = Mock()
     mock.patch("_get_file_from_ref", return_value=file_db)
 
-    with session_factory() as session:
-        cost, _ = get_total_and_detailed_costs(
+    async with session_factory() as session:
+        cost, _ = await get_total_and_detailed_costs(
             session=session, content=rebuilt_message, item_hash="abab"
         )
         assert cost == 2000
 
 
-def test_get_additional_storage_price(
-    session_factory: DbSessionFactory,
+@pytest.mark.asyncio
+async def test_get_additional_storage_price(
+    session_factory: AsyncDbSessionFactory,
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
     fixture_hold_instance_message,
@@ -329,14 +332,14 @@ def test_get_additional_storage_price(
     mock = Mock()
     mock.patch("_get_file_from_ref", return_value=file_db)
 
-    with session_factory() as session:
+    async with session_factory() as session:
         content = fixture_hold_instance_message
-        settings = _get_settings(session)
-        pricing = _get_product_price(
+        settings = await _get_settings(session)
+        pricing = await _get_product_price(
             session=session, content=content, settings=settings
         )
 
-        cost = _get_additional_storage_price(
+        cost = await _get_additional_storage_price(
             session=session,
             content=content,
             item_hash="abab",
@@ -348,8 +351,9 @@ def test_get_additional_storage_price(
         assert additional_cost == 0
 
 
-def test_compute_cost_instance_complete(
-    session_factory: DbSessionFactory,
+@pytest.mark.asyncio
+async def test_compute_cost_instance_complete(
+    session_factory: AsyncDbSessionFactory,
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
     fixture_hold_instance_message_complete,
@@ -358,8 +362,8 @@ def test_compute_cost_instance_complete(
     mock = Mock()
     mock.patch("_get_file_from_ref", return_value=file_db)
 
-    with session_factory() as session:
-        cost, _ = get_total_and_detailed_costs(
+    async with session_factory() as session:
+        cost, _ = await get_total_and_detailed_costs(
             session=session,
             content=fixture_hold_instance_message_complete,
             item_hash="abab",
@@ -367,8 +371,9 @@ def test_compute_cost_instance_complete(
         assert cost == 1017.50
 
 
-def test_compute_cost_program_complete(
-    session_factory: DbSessionFactory,
+@pytest.mark.asyncio
+async def test_compute_cost_program_complete(
+    session_factory: AsyncDbSessionFactory,
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
     fixture_hold_program_message_complete,
@@ -377,8 +382,8 @@ def test_compute_cost_program_complete(
     mock = Mock()
     mock.patch("_get_file_from_ref", return_value=file_db)
 
-    with session_factory() as session:
-        cost, _ = get_total_and_detailed_costs(
+    async with session_factory() as session:
+        cost, _ = await get_total_and_detailed_costs(
             session=session,
             content=fixture_hold_program_message_complete,
             item_hash="asdf",
@@ -386,8 +391,9 @@ def test_compute_cost_program_complete(
         assert cost == Decimal("630.400000000000000000")
 
 
-def test_compute_flow_cost(
-    session_factory: DbSessionFactory,
+@pytest.mark.asyncio
+async def test_compute_flow_cost(
+    session_factory: AsyncDbSessionFactory,
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
     fixture_flow_instance_message,
@@ -396,16 +402,16 @@ def test_compute_flow_cost(
     mock = Mock()
     mock.patch("_get_file_from_ref", return_value=file_db)
 
-    with session_factory() as session:
-        cost, _ = get_total_and_detailed_costs(
+    async with session_factory() as session:
+        cost, _ = await get_total_and_detailed_costs(
             session=session, content=fixture_flow_instance_message, item_hash="abab"
         )
 
         assert cost == Decimal("0.000015277777777777")
 
 
-def test_compute_flow_cost_conf(
-    session_factory: DbSessionFactory,
+async def test_compute_flow_cost_conf(
+    session_factory: AsyncDbSessionFactory,
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
     fixture_flow_instance_message,
@@ -430,16 +436,17 @@ def test_compute_flow_cost_conf(
     mock = Mock()
     mock.patch("_get_file_from_ref", return_value=file_db)
 
-    with session_factory() as session:
-        cost, _ = get_total_and_detailed_costs(
+    async with session_factory() as session:
+        cost, _ = await get_total_and_detailed_costs(
             session=session, content=rebuilt_message, item_hash="abab"
         )
 
         assert cost == Decimal("0.000030555555555555")
 
 
-def test_compute_flow_cost_complete(
-    session_factory: DbSessionFactory,
+@pytest.mark.asyncio
+async def test_compute_flow_cost_complete(
+    session_factory: AsyncDbSessionFactory,
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
     fixture_flow_instance_message_complete,
@@ -448,8 +455,8 @@ def test_compute_flow_cost_complete(
     mock = Mock()
     mock.patch("_get_file_from_ref", return_value=file_db)
 
-    with session_factory() as session:
-        cost, _ = get_total_and_detailed_costs(
+    async with session_factory() as session:
+        cost, _ = await get_total_and_detailed_costs(
             session=session,
             content=fixture_flow_instance_message_complete,
             item_hash="abab",
@@ -458,33 +465,37 @@ def test_compute_flow_cost_complete(
         assert cost == Decimal("0.000032243382777775")
 
 
-def test_default_settings_aggregates(
-    session_factory: DbSessionFactory,
+@pytest.mark.asyncio
+async def test_default_settings_aggregates(
+    session_factory: AsyncDbSessionFactory,
 ):
-    with session_factory() as session:
-        aggregate = _get_settings_aggregate(session)
+    async with session_factory() as session:
+        aggregate = await _get_settings_aggregate(session)
         assert isinstance(aggregate, dict)
 
 
-def test_default_price_aggregates(
-    session_factory: DbSessionFactory,
+@pytest.mark.asyncio
+async def test_default_price_aggregates(
+    session_factory: AsyncDbSessionFactory,
 ):
-    with session_factory() as session:
-        price_aggregate = _get_price_aggregate(session=session)
+    async with session_factory() as session:
+        price_aggregate = await _get_price_aggregate(session=session)
         assert isinstance(price_aggregate, dict)
 
 
-def test_default_settings_aggregates_db(
-    session_factory: DbSessionFactory, fixture_settings_aggregate_in_db
+@pytest.mark.asyncio
+async def test_default_settings_aggregates_db(
+    session_factory: AsyncDbSessionFactory, fixture_settings_aggregate_in_db
 ):
-    with session_factory() as session:
-        aggregate = _get_settings_aggregate(session)
+    async with session_factory() as session:
+        aggregate = await _get_settings_aggregate(session)
         assert isinstance(aggregate, AggregateDb)
 
 
-def test_default_price_aggregates_db(
-    session_factory: DbSessionFactory, fixture_product_prices_aggregate_in_db
+@pytest.mark.asyncio
+async def test_default_price_aggregates_db(
+    session_factory: AsyncDbSessionFactory, fixture_product_prices_aggregate_in_db
 ):
-    with session_factory() as session:
-        price_aggregate = _get_price_aggregate(session=session)
+    async with session_factory() as session:
+        price_aggregate = await _get_price_aggregate(session=session)
         assert isinstance(price_aggregate, AggregateDb)

--- a/tests/storage/test_store_message.py
+++ b/tests/storage/test_store_message.py
@@ -11,7 +11,7 @@ from aleph.handlers.content.store import StoreMessageHandler
 from aleph.schemas.message_content import ContentSource, RawContent
 from aleph.services.ipfs import IpfsService
 from aleph.storage import StorageService
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 from aleph.types.files import FileType
 
 
@@ -56,7 +56,7 @@ def fixture_message_directory() -> MessageDb:
 @pytest.mark.asyncio
 async def test_handle_new_storage_file(
     mocker,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     mock_config: Config,
     fixture_message_file: MessageDb,
 ):
@@ -88,14 +88,14 @@ async def test_handle_new_storage_file(
     store_message_handler = StoreMessageHandler(
         storage_service=storage_service, grace_period=24
     )
-    with session_factory() as session:
+    async with session_factory() as session:
         await store_message_handler.fetch_related_content(
             session=session, message=message
         )
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
-        stored_files = list((session.execute(select(StoredFileDb))).scalars())
+    async with session_factory() as session:
+        stored_files = list((await session.execute(select(StoredFileDb))).scalars())
 
     assert len(stored_files) == 1
     stored_file: StoredFileDb = stored_files[0]
@@ -110,7 +110,7 @@ async def test_handle_new_storage_file(
 @pytest.mark.asyncio
 async def test_handle_new_storage_directory(
     mocker,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     mock_config: Config,
     fixture_message_directory: MessageDb,
 ):
@@ -136,14 +136,14 @@ async def test_handle_new_storage_directory(
         storage_service=storage_service, grace_period=24
     )
 
-    with session_factory() as session:
+    async with session_factory() as session:
         await store_message_handler.fetch_related_content(
             session=session, message=message
         )
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
-        stored_files = list((session.execute(select(StoredFileDb))).scalars())
+    async with session_factory() as session:
+        stored_files = list((await session.execute(select(StoredFileDb))).scalars())
 
     assert len(stored_files) == 1
     stored_file = stored_files[0]
@@ -159,7 +159,7 @@ async def test_handle_new_storage_directory(
 @pytest.mark.asyncio
 async def test_store_files_is_false(
     mocker,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     mock_config: Config,
     fixture_message_directory: MessageDb,
 ):
@@ -188,14 +188,14 @@ async def test_store_files_is_false(
         storage_service=storage_service, grace_period=24
     )
 
-    with session_factory() as session:
+    async with session_factory() as session:
         await store_message_handler.fetch_related_content(
             session=session, message=message
         )
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
-        stored_files = list((session.execute(select(StoredFileDb))).scalars())
+    async with session_factory() as session:
+        stored_files = list((await session.execute(select(StoredFileDb))).scalars())
 
     assert len(stored_files) == 1
     stored_file = stored_files[0]
@@ -212,7 +212,7 @@ async def test_store_files_is_false(
 @pytest.mark.asyncio
 async def test_store_files_is_false_ipfs_is_disabled(
     mocker,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     mock_config: Config,
     fixture_message_directory: MessageDb,
 ):
@@ -242,14 +242,14 @@ async def test_store_files_is_false_ipfs_is_disabled(
         storage_service=storage_service, grace_period=24
     )
 
-    with session_factory() as session:
+    async with session_factory() as session:
         await store_message_handler.fetch_related_content(
             session=session, message=message
         )
-        session.commit()
+        await session.commit()
 
-    with session_factory() as session:
-        stored_files = list((session.execute(select(StoredFileDb))).scalars())
+    async with session_factory() as session:
+        stored_files = list((await session.execute(select(StoredFileDb))).scalars())
 
     assert len(stored_files) == 1
     stored_file = stored_files[0]

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -8,7 +8,7 @@ from aleph.db.models import PendingMessageDb
 from aleph.handlers.message_handler import MessageHandler
 from aleph.schemas.pending_messages import parse_message
 from aleph.storage import StorageService
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 from aleph.types.message_status import InvalidMessageException
 
 
@@ -91,7 +91,7 @@ async def test_invalid_signature_message_2(mocker):
 @pytest.mark.asyncio
 async def test_incoming_inline_content(
     mock_config: Config,
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
     test_storage_service: StorageService,
 ):
     message_dict = {

--- a/tests/web/controllers/test_programs.py
+++ b/tests/web/controllers/test_programs.py
@@ -8,12 +8,12 @@ import pytest_asyncio
 from message_test_helpers import make_validated_message_from_dict
 
 from aleph.db.models import MessageDb
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import AsyncDbSessionFactory
 
 
 @pytest_asyncio.fixture
 async def fixture_program_messages(
-    session_factory: DbSessionFactory,
+    session_factory: AsyncDbSessionFactory,
 ) -> List[MessageDb]:
     fixtures_file = Path(__file__).parent / "fixtures/messages/program.json"
 
@@ -37,9 +37,9 @@ async def fixture_program_messages(
             )
         )
 
-    with session_factory() as session:
+    async with session_factory() as session:
         session.add_all(messages)
-        session.commit()
+        await session.commit()
 
     return messages
 


### PR DESCRIPTION
This PR remove I/O blocking operations on parts used by message processing to bring back message parallelization

Related Clickup or Jira tickets : ALEPH-526

## Self proofreading checklist

- [x] Is my code clear enough and well documented
- [x] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [x] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes
This pull request introduces a comprehensive migration from synchronous database session handling to asynchronous session handling across multiple modules in the `aleph` codebase. The changes aim to improve performance and scalability by leveraging asynchronous operations. The most important changes include replacing `DbSessionFactory` and `DbSession` with their asynchronous counterparts, updating session-related method calls to use `async with`, and modifying database operations to use `await`.

### Migration to Asynchronous Database Sessions:

#### Core API Entrypoint Updates:
* Replaced `make_engine` and `make_session_factory` with `make_async_engine` and `make_async_session_factory` in `src/aleph/api_entrypoint.py`. Updated session initialization in `configure_aiohttp_app` to use asynchronous methods. [[1]](diffhunk://#diff-5251b770cccdd46b8d0fdc9c8171bed3f1f2544df29acae2a3ac42b886c8f65fL10-R10) [[2]](diffhunk://#diff-5251b770cccdd46b8d0fdc9c8171bed3f1f2544df29acae2a3ac42b886c8f65fL37-R42)

#### Chain-Specific Connector Updates:
* Migrated `DbSessionFactory` to `AsyncDbSessionFactory` in `src/aleph/chains/bsc.py`, `src/aleph/chains/connector.py`, `src/aleph/chains/ethereum.py`, and `src/aleph/chains/nuls2.py`. Updated constructors and session usage within these chain connectors to use asynchronous operations. [[1]](diffhunk://#diff-ac9e0a8e344525587fea269f43b6e55300994e0a009adfb416a6ea767700d27eL8-R14) [[2]](diffhunk://#diff-0df3a7014e83ebae68a39f56abb3a226a4ce4b571f35133a6d61e1a2c36fe65bL8-R8) [[3]](diffhunk://#diff-2f39706cf71381630f34b484924b097f8364ba399b71c9c9a3f153d32878bea0L26-R26) [[4]](diffhunk://#diff-33865e311ad16d0f296266e8e79f0cb40611977d20fe979763f7b515ca907649L32-R32)

#### Chain Data Service Updates:
* Migrated `DbSessionFactory` and `DbSession` to `AsyncDbSessionFactory` and `AsyncDbSession` in `src/aleph/chains/chain_data_service.py`. Updated methods like `add_pending_tx`, `add_and_publish_pending_tx`, and others to use `async with` for session handling and added `await` for database operations. [[1]](diffhunk://#diff-221b492d81e12022dd39dbd31bfdbaeb0522d88320643c2130f27d1a2985935cL34-R49) [[2]](diffhunk://#diff-221b492d81e12022dd39dbd31bfdbaeb0522d88320643c2130f27d1a2985935cL132-R147) [[3]](diffhunk://#diff-221b492d81e12022dd39dbd31bfdbaeb0522d88320643c2130f27d1a2985935cL249-R259) [[4]](diffhunk://#diff-221b492d81e12022dd39dbd31bfdbaeb0522d88320643c2130f27d1a2985935cL268-R269)

#### Indexer Reader Updates:
* Migrated `DbSessionFactory` and `DbSession` to `AsyncDbSessionFactory` and `AsyncDbSession` in `src/aleph/chains/indexer_reader.py`. Updated methods such as `fetch_range`, `fetch_new_events`, and `fetcher` to use asynchronous session handling and database operations. [[1]](diffhunk://#diff-ec20833fe0bddd72a9f049976fa0a6c1eb8386a0557cbd75b6db6ec1498525e4L41-R41) [[2]](diffhunk://#diff-ec20833fe0bddd72a9f049976fa0a6c1eb8386a0557cbd75b6db6ec1498525e4L249-R249) [[3]](diffhunk://#diff-ec20833fe0bddd72a9f049976fa0a6c1eb8386a0557cbd75b6db6ec1498525e4L298-R300) [[4]](diffhunk://#diff-ec20833fe0bddd72a9f049976fa0a6c1eb8386a0557cbd75b6db6ec1498525e4L402-R411)

### Additional Updates:
* Updated all database-related calls (e.g., `commit`, `upsert`, `get_last_height`) to use asynchronous versions with `await`. This ensures consistency and compatibility with the asynchronous session handling across the codebase.

## How to test
This PR doesn't add any breaking change, it's just running things in Non I/O blockign way

