### PR TITLE
Fix: Prevent unauthorized message processing due to missing permission validation

### DIFF
--- a/src/aleph/handlers/content/content_handler.py
+++ b/src/aleph/handlers/content/content_handler.py
@@ -5,6 +5,7 @@ from aleph.db.models import MessageDb
 from aleph.db.models.account_costs import AccountCostsDb
 from aleph.permissions import check_sender_authorization
 from aleph.types.db_session import DbSession
+from aleph.types.message_status import PermissionDenied
 
 
 class ContentHandler(abc.ABC):
@@ -99,7 +100,13 @@ class ContentHandler(abc.ABC):
         :return:
         """
 
-        await check_sender_authorization(session=session, message=message)
+        is_authorized = await check_sender_authorization(
+            session=session, message=message
+        )
+        if not is_authorized:
+            raise PermissionDenied(
+                f"Sender {message.sender} is not authorized to post on behalf of address {message.parsed_content.address}"
+            )
 
     @abc.abstractmethod
     async def forget_message(self, session: DbSession, message: MessageDb) -> Set[str]:


### PR DESCRIPTION
  **Issue**

  A critical security vulnerability was discovered in the message processing system where
  an attacker could send a message with another account's address in the address field,
  and the system would accept and process the message instead of rejecting it.

  Root Cause:
  The bug was introduced in October 2022 during the PostgreSQL migration (commit afb17f9
  by Olivier Desenfans). The check_permissions method in ContentHandler calls
  check_sender_authorization() but ignores the return value instead of raising an
  exception when authorization fails.

  Before fix - BUG: 
ignores return value
  async def check_permissions(self, session: DbSession, message: MessageDb) -> None:
      await check_sender_authorization(session=session, message=message)  # ❌ Return 
  value ignored

  Attack Scenario:
  1. Attacker creates a message signed with their private key
  2. Sets message.sender to their address (required for valid signature)
  3. Sets content.address to victim's address
  4. System processes the message as if it came from the victim

  **Solution**

  Modified src/aleph/handlers/content/content_handler.py to properly handle the return
  value of check_sender_authorization() and raise a PermissionDenied exception when
  authorization fails:

  After fix - Properly validates and raises exception
```  async def check_permissions(self, session: DbSession, message: MessageDb) -> None:
      is_authorized = await check_sender_authorization(session=session, message=message)
      if not is_authorized:
          raise PermissionDenied(
              f"Sender {message.sender} is not authorized to post on behalf of address 
  {message.parsed_content.address}"
          )
```
  Testing

  Added comprehensive test test_message_processing_should_fail_on_permission_bug that:
  1. Creates a malicious message where sender ≠ content.address
  2. Mocks no authorization aggregate exists for the victim
  3. Verifies that MessageHandler.process() raises PermissionDenied
  4. Tests the full message processing pipeline, not just the authorization function

  Impact

  Before fix: Unauthorized messages were silently accepted and processed
  After fix: Unauthorized messages are properly rejected with PermissionDenied exception

  This fix ensures that messages can only be processed by:
  1. The account owner themselves (sender == content.address), OR
  2. Accounts with proper delegation via security aggregates

  