### PR TITLE
Solve format issue on balance pre-check

### DIFF
--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -68,6 +68,8 @@ class IpfsService:
                 dag_node = await asyncio.wait_for(
                     self.ipfs_client.dag.get(hash), timeout=timeout
                 )
+                if isinstance(dag_node, str):
+                    dag_node = json.loads(dag_node)
                 if isinstance(dag_node, dict):
                     if "Data" in dag_node and isinstance(dag_node["Data"], dict):
                         # This is the common structure for UnixFS nodes after aioipfs parsing
@@ -81,7 +83,11 @@ class IpfsService:
                             "Tsize" in dag_node
                         ):  # Sometimes it might be at the top level directly
                             result = dag_node["Tsize"]
-                    elif "Links" in dag_node and isinstance(dag_node["Links"], list):
+                    if (
+                        result == 0
+                        and "Links" in dag_node
+                        and isinstance(dag_node["Links"], list)
+                    ):
                         total_size = 0
                         for link in dag_node["Links"]:
                             # In case it's a link list, get the Tsize property if exists

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -68,6 +68,7 @@ class IpfsService:
                 dag_node = await asyncio.wait_for(
                     self.ipfs_client.dag.get(hash), timeout=timeout
                 )
+                result = 0
                 if isinstance(dag_node, str):
                     dag_node = json.loads(dag_node)
                 if isinstance(dag_node, dict):


### PR DESCRIPTION
Fix: Solve issue on format getting IPFS file sizes before downloading the entire content.

## Self proofreading checklist

- [X] Is my code clear enough and well documented
- [X] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [X] Are there enough tests
- [ ] Documentation has been included (for new feature)

## Changes

Cast `dag_node` object to `json` if it's a string and not a dict.

## How to test

Try to store a file without balance and check on IPFS that the file is not pinned or saved inside.
