### PR TITLE
Cast IPFS byte size method

### DIFF
--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -111,6 +111,11 @@ class IpfsService:
                     LOGGER.info(
                         f"Warning: CID {hash} did not return a dictionary structure. Type: {type(dag_node)}"
                     )
+
+                if result == 0:
+                    LOGGER.info(
+                        f"INFO: CID {hash} didn't return a Size field. Executing a block stat operation"
+                    )
                     block_stat = await asyncio.wait_for(
                         self.ipfs_client.block.stat(hash), timeout=timeout
                     )


### PR DESCRIPTION
Detected an issue getting IPFS file sizes for byte file types on the balance pre-check filter.

## Self proofreading checklist

- [X] Is my code clear enough and well documented
- [X] Are my files well typed
- [ ] New translations have been added or updated if new strings have been introduced in the frontend
- [ ] Database migrations file are included
- [X] Are there enough tests
- [X] Documentation has been included (for new feature)

## Changes

If `ipfs dag get` command doesn't return a Size field or return 0, use `ipfs block stat` command instead to get the bytes size.

## How to test

Pin a bytes file type to IPFS and check the logs to see if the good file size is detected.