### PR TITLE
fix: handle unknown NULS chain IDs gracefully

### DIFF
--- a/src/aleph/chains/nuls2.py
+++ b/src/aleph/chains/nuls2.py
@@ -64,6 +64,13 @@ class Nuls2Verifier(Verifier):
                     chain_id=sender_chain_id,
                 ),
             )
+        except KeyError:
+            LOGGER.warning(
+                "'%s': unsupported NULS chain ID %d",
+                message.item_hash,
+                sender_chain_id,
+            )
+            return False
         except Exception:
             LOGGER.exception("NULS Signature verification error")
             return False


### PR DESCRIPTION
## Summary
- Catch `KeyError` from `recover_message_address` when the sender's NULS chain ID is not in the known `NETWORKS` dict (e.g. chain IDs 256, 6420)
- Log a clean warning with the message hash and chain ID instead of a full exception traceback at ERROR level
- The generic `Exception` handler remains for truly unexpected errors

## Test plan
- [ ] Verify that messages with unknown NULS chain IDs produce a single-line warning instead of a full traceback
- [ ] Verify that other signature verification errors still log full tracebacks