### PR TITLE
feat: add POST /api/v0/price/estimate/instance endpoint

### DIFF
--- a/src/aleph/schemas/cost_estimation_messages.py
+++ b/src/aleph/schemas/cost_estimation_messages.py
@@ -52,6 +52,12 @@ class CostEstimationInstanceContent(InstanceContent):
         default=[], description="Volumes to mount on the filesystem"
     )
 
+    # Fields required by InstanceContent but irrelevant for cost estimation.
+    # Made optional so callers of the /price/estimate/instance endpoint don't
+    # need to provide them.
+    time: Optional[float] = None  # type: ignore[assignment]
+    allow_amend: bool = False
+
 
 class CostEstimationCodeContent(CodeContent):
     estimated_size_mib: Optional[int] = None

--- a/src/aleph/web/controllers/prices.py
+++ b/src/aleph/web/controllers/prices.py
@@ -37,6 +37,7 @@ from aleph.schemas.api.costs import (
     ResourceCostItem,
 )
 from aleph.schemas.cost_estimation_messages import (
+    CostEstimationInstanceContent,
     validate_cost_estimation_message_content,
     validate_cost_estimation_message_dict,
 )
@@ -280,6 +281,92 @@ async def message_price_estimate(request: web.Request):
             raise web.HTTPNotFound(reason=str(e))
 
         # Enrich detail with size information
+        detail_list = []
+        for cost in costs:
+            size_mib = get_cost_component_size_mib(session, cost, content)
+            detail_list.append(
+                EstimatedCostDetailResponse(
+                    type=(
+                        cost.type.value
+                        if hasattr(cost.type, "value")
+                        else str(cost.type)
+                    ),
+                    name=cost.name,
+                    cost_hold=str(cost.cost_hold),
+                    cost_stream=str(cost.cost_stream),
+                    cost_credit=str(cost.cost_credit),
+                    size_mib=size_mib,
+                )
+            )
+
+    model = {
+        "required_tokens": float(required_tokens),
+        "payment_type": payment_type,
+        "cost": format_cost_str(required_tokens),
+        "detail": detail_list,
+        "charged_address": content.address,
+    }
+
+    response = EstimatedCostsResponse.model_validate(model)
+
+    return web.json_response(text=aleph_json.dumps(response).decode("utf-8"))
+
+
+async def instance_cost_estimate(request: web.Request):
+    """
+    Returns the estimated cost of an instance from its content alone.
+
+    Accepts a CostEstimationInstanceContent body directly, without requiring
+    a full Aleph message wrapper. This is useful for UIs and tools that want
+    to compute the cost of a hypothetical instance before submitting it.
+
+    ---
+    summary: Estimate instance cost from content
+    tags:
+      - Prices
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+    responses:
+      '200':
+        description: Estimated costs
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EstimatedCostsResponse'
+      '422':
+        description: Invalid instance content
+      '404':
+        description: Pricing error
+    """
+
+    session_factory = get_session_factory_from_request(request)
+
+    try:
+        body = await request.json()
+    except Exception:
+        raise web.HTTPBadRequest(reason="Invalid JSON body")
+
+    try:
+        content = CostEstimationInstanceContent.model_validate(body)
+    except ValidationError as e:
+        raise web.HTTPUnprocessableEntity(text=str(e))
+
+    # Use a placeholder item_hash — it's only used as a label on cost entries
+    item_hash = "estimate"
+
+    with session_factory() as session:
+        try:
+            payment_type = get_payment_type(content)
+            required_tokens, costs = get_total_and_detailed_costs(
+                session, content, item_hash
+            )
+        except RuntimeError as e:
+            raise web.HTTPNotFound(reason=str(e))
+
         detail_list = []
         for cost in costs:
             size_mib = get_cost_component_size_mib(session, cost, content)

--- a/src/aleph/web/controllers/routes.py
+++ b/src/aleph/web/controllers/routes.py
@@ -89,6 +89,10 @@ def register_routes(app: web.Application, swagger: Optional[SwaggerDocs]):
         web.get("/api/v0/price/{item_hash}", prices.message_price),
         web.post("/api/v0/price/estimate", prices.message_price_estimate),
         web.post(
+            "/api/v0/price/estimate/instance",
+            prices.instance_cost_estimate,
+        ),
+        web.post(
             "/api/v0/price/recalculate",
             prices.recalculate_message_costs,
         ),

--- a/tests/api/test_costs.py
+++ b/tests/api/test_costs.py
@@ -581,3 +581,136 @@ async def test_message_price_estimate_includes_size_mib(
     # of get_cost_component_size_mib is already thoroughly tested in
     # unit tests and the other integration tests.
     pytest.skip("Complex message format validation - covered by other tests")
+
+
+INSTANCE_COST_ESTIMATE_URI = "/api/v0/price/estimate/instance"
+
+SAMPLE_INSTANCE_CONTENT = {
+    "address": "0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
+    "allow_amend": False,
+    "environment": {
+        "reproducible": True,
+        "internet": False,
+        "aleph_api": False,
+        "shared_cache": False,
+    },
+    "resources": {"vcpus": 1, "memory": 128, "seconds": 30},
+    "requirements": {"cpu": {"architecture": "x86_64"}},
+    "rootfs": {
+        "parent": {
+            "ref": "549ec451d9b099cad112d4aaa2c00ac40fb6729a92ff252ff22eef0b5c3cb613",
+            "use_latest": True,
+        },
+        "persistence": "host",
+        "name": "test-rootfs",
+        "size_mib": 20 * 1024,
+    },
+    "authorized_keys": [
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGULT6A41Msmw2KEu0R9MvUjhuWNAsbdeZ0DOwYbt4Qt user@example",
+    ],
+    "volumes": [],
+}
+
+
+@pytest.mark.asyncio
+async def test_instance_cost_estimate(
+    ccn_api_client,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """Test POST /api/v0/price/estimate/instance returns cost from content alone."""
+    response = await ccn_api_client.post(
+        INSTANCE_COST_ESTIMATE_URI, json=SAMPLE_INSTANCE_CONTENT
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    assert data["required_tokens"] > 0
+    assert data["payment_type"] == "hold"
+    assert float(data["cost"]) > 0
+    assert data["charged_address"] == SAMPLE_INSTANCE_CONTENT["address"]
+    assert isinstance(data["detail"], list)
+    assert len(data["detail"]) > 0
+
+    # Should have at least an EXECUTION cost component
+    detail_types = {d["type"] for d in data["detail"]}
+    assert "EXECUTION" in detail_types
+
+
+@pytest.mark.asyncio
+async def test_instance_cost_estimate_with_credit_payment(
+    ccn_api_client,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """Test instance cost estimate with credit payment type."""
+    content = {
+        **SAMPLE_INSTANCE_CONTENT,
+        "payment": {"chain": "ETH", "type": "credit"},
+        "requirements": {
+            "cpu": {"architecture": "x86_64"},
+            "node": {"node_hash": "ab" * 32},
+        },
+    }
+    response = await ccn_api_client.post(INSTANCE_COST_ESTIMATE_URI, json=content)
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    assert data["payment_type"] == "credit"
+    assert float(data["cost"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_instance_cost_estimate_with_volumes(
+    ccn_api_client,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """Test instance cost estimate with additional volumes."""
+    content = {
+        **SAMPLE_INSTANCE_CONTENT,
+        "volumes": [
+            {
+                "mount": "/var/lib/data",
+                "name": "data",
+                "persistence": "host",
+                "size_mib": 1024,
+            },
+        ],
+    }
+    response = await ccn_api_client.post(INSTANCE_COST_ESTIMATE_URI, json=content)
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    assert data["required_tokens"] > 0
+    detail_types = {d["type"] for d in data["detail"]}
+    assert "EXECUTION_VOLUME_PERSISTENT" in detail_types
+
+
+@pytest.mark.asyncio
+async def test_instance_cost_estimate_invalid_body(ccn_api_client):
+    """Test that invalid content body returns 422."""
+    response = await ccn_api_client.post(
+        INSTANCE_COST_ESTIMATE_URI, json={"invalid": "content"}
+    )
+    assert response.status == 422
+
+
+@pytest.mark.asyncio
+async def test_instance_cost_estimate_detail_has_size_mib(
+    ccn_api_client,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """Test that size_mib is included in the cost detail for volume components."""
+    response = await ccn_api_client.post(
+        INSTANCE_COST_ESTIMATE_URI, json=SAMPLE_INSTANCE_CONTENT
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    for detail in data["detail"]:
+        if detail["type"] == "EXECUTION_INSTANCE_VOLUME_ROOTFS":
+            assert detail["size_mib"] == 20 * 1024
+        elif detail["type"] == "EXECUTION":
+            assert detail["size_mib"] is None


### PR DESCRIPTION
## Summary

- Adds `POST /api/v0/price/estimate/instance` — a simplified cost estimation endpoint that accepts `InstanceContent` directly instead of requiring a full Aleph message wrapper
- Makes `time` and `allow_amend` optional on `CostEstimationInstanceContent` since they're irrelevant for cost estimation
- Includes 5 integration tests covering basic estimation, credit payment, volumes, invalid body, and size_mib detail

## Test plan

- [ ] Verify `POST /api/v0/price/estimate/instance` returns correct cost breakdown for a minimal instance content body
- [ ] Verify credit payment type is correctly detected and priced
- [ ] Verify additional volumes are reflected in cost detail
- [ ] Verify invalid body returns 422
- [ ] Verify existing `/price/estimate` endpoint still works unchanged