### PR TITLE
Share WebSocket metrics across gunicorn workers via Redis

### DIFF
--- a/src/aleph/api_entrypoint.py
+++ b/src/aleph/api_entrypoint.py
@@ -74,7 +74,9 @@ async def configure_aiohttp_app(
             node_cache=node_cache,
             max_connections=config.websocket.max_status_connections.value,
         )
-        message_broadcaster = MessageBroadcaster(mq_conn=mq_conn, config=config)
+        message_broadcaster = MessageBroadcaster(
+            mq_conn=mq_conn, config=config, node_cache=node_cache
+        )
 
         app[APP_STATE_CONFIG] = config
         app[APP_STATE_P2P_CLIENT] = p2p_client

--- a/src/aleph/services/cache/node_cache.py
+++ b/src/aleph/services/cache/node_cache.py
@@ -71,6 +71,9 @@ class NodeCache:
     async def decr(self, key: CacheKey):
         await self.redis_client.decr(key)
 
+    async def decrby(self, key: CacheKey, amount: int):
+        await self.redis_client.decrby(key, amount)
+
     async def get_api_servers(self) -> Set[str]:
         return set(
             api_server.decode()

--- a/src/aleph/web/controllers/main.py
+++ b/src/aleph/web/controllers/main.py
@@ -29,6 +29,11 @@ logger = logging.getLogger(__name__)
 
 _STATUS_SEND_BATCH_SIZE = 100
 
+# Redis keys for WS status metrics. Shared across gunicorn workers so
+# Prometheus sees cluster-wide state regardless of which worker serves /metrics.
+WS_STATUS_CONNECTIONS_ACTIVE_KEY = "pyaleph_ws_status_connections_active"
+WS_STATUS_CONNECTIONS_REJECTED_KEY = "pyaleph_ws_status_connections_rejected_total"
+
 
 class StatusBroadcaster:
     """Single polling loop that broadcasts status to all connected WS clients."""
@@ -46,16 +51,12 @@ class StatusBroadcaster:
         self._task: Optional[asyncio.Task] = None
         self._poll_interval = poll_interval
 
-        # Connection limit
+        # Connection limit (same on every worker — from config).
         self.max_connections: int = max_connections
         self._semaphore = asyncio.Semaphore(max_connections)
-
-        # Metrics
-        self.connections_rejected_total: int = 0
-
-    @property
-    def active_connections(self) -> int:
-        return len(self._clients)
+        # Note: counter state lives in Redis (see WS_*_KEY constants). This
+        # class never holds it locally so that all gunicorn workers share
+        # the same observed values.
 
     @property
     def is_at_capacity(self) -> bool:
@@ -64,20 +65,38 @@ class StatusBroadcaster:
     def acquire_slot(self) -> asyncio.Semaphore:
         return self._semaphore
 
-    def add(self, ws: web.WebSocketResponse):
+    async def record_rejection(self) -> None:
+        """Increment the shared 'connection rejected' counter."""
+        await self._node_cache.incr(WS_STATUS_CONNECTIONS_REJECTED_KEY)
+
+    async def add(self, ws: web.WebSocketResponse):
+        if ws in self._clients:
+            return
         self._clients.add(ws)
+        await self._node_cache.incr(WS_STATUS_CONNECTIONS_ACTIVE_KEY)
         if self._task is None or self._task.done():
             self._task = asyncio.create_task(self._poll_loop())
 
-    def remove(self, ws: web.WebSocketResponse):
+    async def remove(self, ws: web.WebSocketResponse):
+        # Guard against double-remove: Redis DECR must be idempotent-safe.
+        if ws not in self._clients:
+            return
         self._clients.discard(ws)
+        await self._node_cache.decr(WS_STATUS_CONNECTIONS_ACTIVE_KEY)
 
     async def shutdown(self):
         """Graceful shutdown — called from aiohttp on_cleanup."""
         if self._task and not self._task.done():
             self._task.cancel()
             self._task = None
-        self._clients.clear()
+        # Decrement the shared active counter once per client this worker
+        # owned, so the Redis value reflects only clients still connected
+        # through other workers.
+        if self._clients:
+            await self._node_cache.decrby(
+                WS_STATUS_CONNECTIONS_ACTIVE_KEY, len(self._clients)
+            )
+            self._clients.clear()
 
     async def _poll_loop(self):
         previous_status = None
@@ -108,7 +127,7 @@ class StatusBroadcaster:
                             dead.append(ws)
 
                 for ws in dead:
-                    self._clients.discard(ws)
+                    await self.remove(ws)
                 previous_status = status
 
             await asyncio.sleep(self._poll_interval)
@@ -155,7 +174,7 @@ async def status_ws(request: web.Request) -> web.WebSocketResponse:
     broadcaster: StatusBroadcaster = request.app[APP_STATE_STATUS_BROADCASTER]
 
     if broadcaster.is_at_capacity:
-        broadcaster.connections_rejected_total += 1
+        await broadcaster.record_rejection()
         logger.warning(
             "Status WS connection limit reached (%d)", broadcaster.max_connections
         )
@@ -166,7 +185,7 @@ async def status_ws(request: web.Request) -> web.WebSocketResponse:
         return ws
 
     async with broadcaster.acquire_slot():
-        broadcaster.add(ws)
+        await broadcaster.add(ws)
 
         try:
             while not ws.closed:
@@ -178,7 +197,7 @@ async def status_ws(request: web.Request) -> web.WebSocketResponse:
                 ):
                     break
         finally:
-            broadcaster.remove(ws)
+            await broadcaster.remove(ws)
             if not ws.closed:
                 await ws.close()
 

--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -45,6 +45,7 @@ from aleph.schemas.messages_query_params import (
     MessageQueryParams,
     WsMessageQueryParams,
 )
+from aleph.services.cache.node_cache import NodeCache
 from aleph.toolkit.cursor import decode_message_cursor, encode_message_cursor
 from aleph.types.db_session import DbSession, DbSessionFactory
 from aleph.types.message_status import MessageStatus, RemovedMessageReason
@@ -65,6 +66,13 @@ LOGGER = logging.getLogger(__name__)
 
 _SEND_BATCH_SIZE = 100
 _HEALTH_CHECK_INTERVAL = 5
+
+# Redis keys for WS message metrics. Shared across gunicorn workers so
+# Prometheus sees cluster-wide state regardless of which worker serves /metrics.
+WS_MESSAGES_BROADCAST_TOTAL_KEY = "pyaleph_ws_messages_broadcast_total"
+WS_MESSAGES_CONNECTIONS_ACTIVE_KEY = "pyaleph_ws_messages_connections_active"
+WS_MESSAGES_CONNECTIONS_REJECTED_KEY = "pyaleph_ws_messages_connections_rejected_total"
+WS_BROADCASTER_CONSUMER_RESTARTS_KEY = "pyaleph_ws_broadcaster_consumer_restarts_total"
 
 
 class _WsClient:
@@ -88,27 +96,27 @@ class MessageBroadcaster:
         self,
         mq_conn: aio_pika.abc.AbstractConnection,
         config: Config,
+        node_cache: NodeCache,
     ):
         self._mq_conn = mq_conn
         self._config = config
+        self._node_cache = node_cache
         self._clients: Set[_WsClient] = set()
         self._channel: Optional[aio_pika.abc.AbstractChannel] = None
         self._queue: Optional[aio_pika.abc.AbstractQueue] = None
         self._consumer_tag: Optional[aio_pika.abc.ConsumerTag] = None
         self._health_task: Optional[asyncio.Task] = None
 
-        # Connection limit
+        # Connection limit (same on every worker — from config).
         self.max_connections: int = config.websocket.max_message_connections.value
         self._semaphore = asyncio.Semaphore(self.max_connections)
+        # Note: counter state lives in Redis (see WS_*_KEY constants). This
+        # class never holds it locally so that all gunicorn workers share
+        # the same observed values.
 
-        # Metrics
-        self.broadcast_total: int = 0
-        self.connections_rejected_total: int = 0
-        self.consumer_restarts_total: int = 0
-
-    @property
-    def active_connections(self) -> int:
-        return len(self._clients)
+    async def record_rejection(self) -> None:
+        """Increment the shared 'connection rejected' counter."""
+        await self._node_cache.incr(WS_MESSAGES_CONNECTIONS_REJECTED_KEY)
 
     @property
     def is_at_capacity(self) -> bool:
@@ -155,11 +163,8 @@ class MessageBroadcaster:
 
     async def _restart_consumer(self):
         """Restart the consumer after a channel failure."""
-        self.consumer_restarts_total += 1
-        LOGGER.warning(
-            "MessageBroadcaster: restarting consumer (restart #%d)",
-            self.consumer_restarts_total,
-        )
+        await self._node_cache.incr(WS_BROADCASTER_CONSUMER_RESTARTS_KEY)
+        LOGGER.warning("MessageBroadcaster: restarting consumer")
         await self._stop_consumer()
         try:
             await self._start_consumer()
@@ -179,14 +184,21 @@ class MessageBroadcaster:
             LOGGER.debug("MessageBroadcaster: health check loop cancelled")
 
     async def add(self, client: _WsClient):
+        if client in self._clients:
+            return
         self._clients.add(client)
+        await self._node_cache.incr(WS_MESSAGES_CONNECTIONS_ACTIVE_KEY)
         if self._consumer_tag is None:
             await self._start_consumer()
         if self._health_task is None or self._health_task.done():
             self._health_task = asyncio.create_task(self._health_check_loop())
 
     async def remove(self, client: _WsClient):
+        # Guard against double-remove: Redis DECR must be idempotent-safe.
+        if client not in self._clients:
+            return
         self._clients.discard(client)
+        await self._node_cache.decr(WS_MESSAGES_CONNECTIONS_ACTIVE_KEY)
         if not self._clients:
             if self._health_task and not self._health_task.done():
                 self._health_task.cancel()
@@ -199,7 +211,14 @@ class MessageBroadcaster:
             self._health_task.cancel()
             self._health_task = None
         await self._stop_consumer()
-        self._clients.clear()
+        # Decrement the shared active counter once per client this worker
+        # owned, so the Redis value reflects only clients still connected
+        # through other workers.
+        if self._clients:
+            await self._node_cache.decrby(
+                WS_MESSAGES_CONNECTIONS_ACTIVE_KEY, len(self._clients)
+            )
+            self._clients.clear()
 
     async def _on_message(self, mq_message: aio_pika.abc.AbstractMessage):
         """Called for each message from RabbitMQ. Fan out to matching clients."""
@@ -211,7 +230,7 @@ class MessageBroadcaster:
             LOGGER.exception("MessageBroadcaster: failed to parse MQ message")
             return
 
-        self.broadcast_total += 1
+        await self._node_cache.incr(WS_MESSAGES_BROADCAST_TOTAL_KEY)
         clients = list(self._clients)
         if not clients:
             return
@@ -640,7 +659,7 @@ async def messages_ws(request: web.Request) -> web.WebSocketResponse:
     broadcaster: MessageBroadcaster = request.app[APP_STATE_MESSAGE_BROADCASTER]
 
     if broadcaster.is_at_capacity:
-        broadcaster.connections_rejected_total += 1
+        await broadcaster.record_rejection()
         LOGGER.warning(
             "WebSocket connection limit reached (%d)", broadcaster.max_connections
         )

--- a/src/aleph/web/controllers/metrics.py
+++ b/src/aleph/web/controllers/metrics.py
@@ -30,6 +30,16 @@ LOGGER = getLogger("WEB.metrics")
 
 config = get_config()
 
+# Redis keys for WS metrics shared across gunicorn workers.
+# Mirrors the constants defined in main.py / messages.py — duplicated here
+# to avoid circular imports. Names match Prometheus metric fields exactly.
+_WS_MESSAGES_BROADCAST_TOTAL_KEY = "pyaleph_ws_messages_broadcast_total"
+_WS_MESSAGES_CONNECTIONS_ACTIVE_KEY = "pyaleph_ws_messages_connections_active"
+_WS_MESSAGES_CONNECTIONS_REJECTED_KEY = "pyaleph_ws_messages_connections_rejected_total"
+_WS_BROADCASTER_CONSUMER_RESTARTS_KEY = "pyaleph_ws_broadcaster_consumer_restarts_total"
+_WS_STATUS_CONNECTIONS_ACTIVE_KEY = "pyaleph_ws_status_connections_active"
+_WS_STATUS_CONNECTIONS_REJECTED_KEY = "pyaleph_ws_status_connections_rejected_total"
+
 
 def format_dict_for_prometheus(values: Dict) -> str:
     """Format a dict to a Prometheus tags string"""
@@ -211,43 +221,56 @@ async def get_metrics(
     )
 
 
+async def _read_int_key(node_cache: NodeCache, key: str) -> int:
+    """Read an integer Redis value. Returns 0 if the key does not exist."""
+    value = await node_cache.get(key)
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
 async def get_metrics_with_ws(
     session_factory: DbSessionFactory,
     node_cache: NodeCache,
     message_broadcaster: Optional["MessageBroadcaster"] = None,
     status_broadcaster: Optional["StatusBroadcaster"] = None,
 ) -> Metrics:
-    """get_metrics + live WebSocket metrics from broadcasters."""
+    """get_metrics + live WebSocket metrics shared across gunicorn workers."""
     cached_metrics = await get_metrics(
         session_factory=session_factory, node_cache=node_cache
     )
     # Copy to avoid mutating the cached dataclass
     metrics = replace(cached_metrics)
 
+    # Counters and active gauges: shared Redis state.
+    metrics.pyaleph_ws_messages_broadcast_total = await _read_int_key(
+        node_cache, _WS_MESSAGES_BROADCAST_TOTAL_KEY
+    )
+    metrics.pyaleph_ws_messages_connections_active = await _read_int_key(
+        node_cache, _WS_MESSAGES_CONNECTIONS_ACTIVE_KEY
+    )
+    metrics.pyaleph_ws_messages_connections_rejected_total = await _read_int_key(
+        node_cache, _WS_MESSAGES_CONNECTIONS_REJECTED_KEY
+    )
+    metrics.pyaleph_ws_broadcaster_consumer_restarts_total = await _read_int_key(
+        node_cache, _WS_BROADCASTER_CONSUMER_RESTARTS_KEY
+    )
+    metrics.pyaleph_ws_status_connections_active = await _read_int_key(
+        node_cache, _WS_STATUS_CONNECTIONS_ACTIVE_KEY
+    )
+    metrics.pyaleph_ws_status_connections_rejected_total = await _read_int_key(
+        node_cache, _WS_STATUS_CONNECTIONS_REJECTED_KEY
+    )
+
+    # Config-value gauges: same on every worker, read from the local instance.
     if message_broadcaster:
-        metrics.pyaleph_ws_messages_connections_active = (
-            message_broadcaster.active_connections
-        )
         metrics.pyaleph_ws_messages_connections_max = (
             message_broadcaster.max_connections
         )
-        metrics.pyaleph_ws_messages_broadcast_total = (
-            message_broadcaster.broadcast_total
-        )
-        metrics.pyaleph_ws_messages_connections_rejected_total = (
-            message_broadcaster.connections_rejected_total
-        )
-        metrics.pyaleph_ws_broadcaster_consumer_restarts_total = (
-            message_broadcaster.consumer_restarts_total
-        )
-
     if status_broadcaster:
-        metrics.pyaleph_ws_status_connections_active = (
-            status_broadcaster.active_connections
-        )
         metrics.pyaleph_ws_status_connections_max = status_broadcaster.max_connections
-        metrics.pyaleph_ws_status_connections_rejected_total = (
-            status_broadcaster.connections_rejected_total
-        )
 
     return metrics


### PR DESCRIPTION
  The /metrics endpoint exposed WebSocket counters that appeared to
  fluctuate (e.g. pyaleph_ws_messages_broadcast_total bouncing between 25,
  33, and 0) without any process restart. Root cause: the API runs under
  gunicorn with multiple workers, and each worker had its own
  MessageBroadcaster / StatusBroadcaster instance with in-process counter
  attributes. Prometheus scrapes were load-balanced to different workers
  and returned whichever worker's local state happened to be there.

  Move all WS metric state to shared Redis keys via NodeCache so every
  worker reads and writes the same values.