### PR TITLE
fix: treat GPU tier compute units as a lower bound

### DIFF
--- a/src/aleph/services/cost.py
+++ b/src/aleph/services/cost.py
@@ -615,6 +615,23 @@ def _calculate_multi_tier_gpu_execution_cost(
         content, settings, premium_pricing, standard_pricing
     )
 
+    # GPU tier CUs are a lower bound. If the VM's resource requirements
+    # (vCPUs, memory) translate to more CUs, use the higher value.
+    dominant_tier_type = (
+        ProductPriceType.INSTANCE_GPU_PREMIUM
+        if ProductPriceType.INSTANCE_GPU_PREMIUM in tier_breakdown
+        else ProductPriceType.INSTANCE_GPU_STANDARD
+    )
+    dominant_pricing = (
+        premium_pricing
+        if dominant_tier_type == ProductPriceType.INSTANCE_GPU_PREMIUM
+        else standard_pricing
+    )
+    resource_cus = _get_nb_compute_units(content, dominant_pricing.compute_unit)
+    total_gpu_cus = sum(tier_breakdown.values())
+    if resource_cus > total_gpu_cus:
+        tier_breakdown[dominant_tier_type] += resource_cus - total_gpu_cus
+
     costs = []
     compute_unit_multiplier = _get_compute_unit_multiplier(content)
 

--- a/tests/services/test_cost_service.py
+++ b/tests/services/test_cost_service.py
@@ -937,9 +937,11 @@ def test_compute_cost_single_gpu_standard(
             item_hash="gpu_single",
         )
 
-        # RTX 4090: 6 compute units × $0.28/hour = $1.68/hour
-        # Expected hold cost: $1680 (in smallest unit)
-        assert cost == Decimal("1680")
+        # RTX 4090: GPU tier minimum is 6 CUs, but resource-based CUs are
+        # max(8 vcpus, ceil(16384/6144) mem) = 8, which is higher.
+        # 8 compute units × $0.28/hour = $2.24/hour
+        # Expected hold cost: $2240 (in smallest unit)
+        assert cost == Decimal("2240")
 
         # Should have execution cost entries (GPU + storage)
         execution_costs = [d for d in details if d.type == CostType.EXECUTION]


### PR DESCRIPTION
## Summary
- GPU tier `compute_units` values were used as the exact CU count for cost calculation, ignoring the VM's actual resource demands (vCPUs, memory)
- Now computes resource-based CUs (same logic as non-GPU VMs) and takes `max(gpu_tier_cus, resource_based_cus)`, making the GPU tier value a minimum
- For multi-tier GPU instances, excess CUs are attributed to the dominant (premium) tier

## Test plan
- [x] All 22 cost service tests pass
- [x] Updated single GPU test expectation (RTX 4090 with 8 vCPUs now correctly charges 8 CUs instead of 6)
- [x] Verified no change for VMs where GPU tier CUs already exceed resource-based CUs (A100, H100, mixed-tier cases)