### PR TITLE
feat: add filters and sorting to /credit_history endpoint

### DIFF
--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -883,7 +883,6 @@ CREDIT_HISTORY_SORT_COLUMN_MAP = {
 # Columns that are nullable and need NULLS LAST handling
 _NULLABLE_SORT_COLUMNS = {
     SortByCreditHistory.EXPIRATION_DATE,
-    SortByCreditHistory.PAYMENT_METHOD,
     SortByCreditHistory.ORIGIN,
     SortByCreditHistory.TX_HASH,
     SortByCreditHistory.PROVIDER,
@@ -1035,6 +1034,7 @@ def get_address_credit_history(
                         )
                     )
                 )
+                # NULLs come after all non-NULLs due to NULLS LAST ordering
                 | (primary_col.is_(None))
             )
         else:
@@ -1050,6 +1050,7 @@ def get_address_credit_history(
                         )
                     )
                 )
+                # NULLs come after all non-NULLs due to NULLS LAST ordering
                 | (primary_col.is_(None))
             )
 

--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -18,6 +18,7 @@ from aleph.toolkit.constants import (
 )
 from aleph.toolkit.timestamp import timestamp_to_datetime, utc_now
 from aleph.types.db_session import DbSession
+from aleph.types.sort_order import SortByCreditHistory, SortOrder
 
 
 def _apply_credit_precision_multiplier(
@@ -869,11 +870,28 @@ def validate_credit_transfer_balance(
     return current_balance >= total_transfer_amount
 
 
-def get_address_credit_history(
-    session: DbSession,
-    address: str,
-    page: int = 1,
-    pagination: int = 0,
+CREDIT_HISTORY_SORT_COLUMN_MAP = {
+    SortByCreditHistory.MESSAGE_TIMESTAMP: AlephCreditHistoryDb.message_timestamp,
+    SortByCreditHistory.EXPIRATION_DATE: AlephCreditHistoryDb.expiration_date,
+    SortByCreditHistory.PAYMENT_METHOD: AlephCreditHistoryDb.payment_method,
+    SortByCreditHistory.AMOUNT: AlephCreditHistoryDb.amount,
+    SortByCreditHistory.ORIGIN: AlephCreditHistoryDb.origin,
+    SortByCreditHistory.TX_HASH: AlephCreditHistoryDb.tx_hash,
+    SortByCreditHistory.PROVIDER: AlephCreditHistoryDb.provider,
+}
+
+# Columns that are nullable and need NULLS LAST handling
+_NULLABLE_SORT_COLUMNS = {
+    SortByCreditHistory.EXPIRATION_DATE,
+    SortByCreditHistory.PAYMENT_METHOD,
+    SortByCreditHistory.ORIGIN,
+    SortByCreditHistory.TX_HASH,
+    SortByCreditHistory.PROVIDER,
+}
+
+
+def _apply_credit_history_filters(
+    query: Select,
     tx_hash: Optional[str] = None,
     token: Optional[str] = None,
     chain: Optional[str] = None,
@@ -881,44 +899,10 @@ def get_address_credit_history(
     origin: Optional[str] = None,
     origin_ref: Optional[str] = None,
     payment_method: Optional[str] = None,
-    after_time: Optional[dt.datetime] = None,
-    after_credit_ref: Optional[str] = None,
-    after_credit_index: Optional[int] = None,
-    cursor_mode: bool = False,
-) -> Sequence[AlephCreditHistoryDb]:
-    """
-    Get paginated credit history entries for a specific address, ordered from newest to oldest.
-
-    Args:
-        session: Database session
-        address: Address to get credit history for
-        page: Page number (starts at 1)
-        pagination: Number of entries per page (0 for all entries)
-        tx_hash: Filter by transaction hash
-        token: Filter by token
-        chain: Filter by chain
-        provider: Filter by provider
-        origin: Filter by origin
-        origin_ref: Filter by origin reference
-        payment_method: Filter by payment method
-        after_time: Cursor-based: only return entries older than this timestamp
-        after_credit_ref: Cursor-based: tiebreaker credit_ref for entries with the same timestamp
-        after_credit_index: Cursor-based: tiebreaker credit_index for entries with the same timestamp and credit_ref
-
-    Returns:
-        List of credit history entries ordered by message_timestamp desc
-    """
-    query = (
-        select(AlephCreditHistoryDb)
-        .where(AlephCreditHistoryDb.address == address)
-        .order_by(
-            AlephCreditHistoryDb.message_timestamp.desc(),
-            AlephCreditHistoryDb.credit_ref.desc(),
-            AlephCreditHistoryDb.credit_index.desc(),
-        )
-    )
-
-    # Apply filters
+    has_expiration: Optional[bool] = None,
+    exclude_payment_method: Optional[List[str]] = None,
+) -> Select:
+    """Apply common filters to a credit history query."""
     if tx_hash is not None:
         query = query.where(AlephCreditHistoryDb.tx_hash == tx_hash)
     if token is not None:
@@ -933,23 +917,143 @@ def get_address_credit_history(
         query = query.where(AlephCreditHistoryDb.origin_ref == origin_ref)
     if payment_method is not None:
         query = query.where(AlephCreditHistoryDb.payment_method == payment_method)
-
-    if after_time is not None:
+    if has_expiration is True:
+        query = query.where(AlephCreditHistoryDb.expiration_date.isnot(None))
+    elif has_expiration is False:
+        query = query.where(AlephCreditHistoryDb.expiration_date.is_(None))
+    if exclude_payment_method:
         query = query.where(
-            (AlephCreditHistoryDb.message_timestamp < after_time)
-            | (
-                (AlephCreditHistoryDb.message_timestamp == after_time)
-                & (
-                    (AlephCreditHistoryDb.credit_ref < after_credit_ref)
-                    | (
-                        (AlephCreditHistoryDb.credit_ref == after_credit_ref)
-                        & (AlephCreditHistoryDb.credit_index < after_credit_index)
-                    )
-                )
-            )
+            AlephCreditHistoryDb.payment_method.notin_(exclude_payment_method)
+        )
+    return query
+
+
+def get_address_credit_history(
+    session: DbSession,
+    address: str,
+    page: int = 1,
+    pagination: int = 0,
+    tx_hash: Optional[str] = None,
+    token: Optional[str] = None,
+    chain: Optional[str] = None,
+    provider: Optional[str] = None,
+    origin: Optional[str] = None,
+    origin_ref: Optional[str] = None,
+    payment_method: Optional[str] = None,
+    has_expiration: Optional[bool] = None,
+    exclude_payment_method: Optional[List[str]] = None,
+    sort_by: SortByCreditHistory = SortByCreditHistory.MESSAGE_TIMESTAMP,
+    sort_order: SortOrder = SortOrder.DESCENDING,
+    after_sort_value: Optional[Any] = None,
+    after_credit_ref: Optional[str] = None,
+    after_credit_index: Optional[int] = None,
+    cursor_mode: bool = False,
+) -> Sequence[AlephCreditHistoryDb]:
+    """
+    Get paginated credit history entries for a specific address.
+
+    Supports dynamic sorting and cursor-based or page-based pagination.
+    """
+    query = select(AlephCreditHistoryDb).where(AlephCreditHistoryDb.address == address)
+
+    # Dynamic ordering
+    primary_col = CREDIT_HISTORY_SORT_COLUMN_MAP[sort_by]
+    is_desc = sort_order == SortOrder.DESCENDING
+
+    if sort_by in _NULLABLE_SORT_COLUMNS:
+        if is_desc:
+            order_primary = primary_col.desc().nullslast()
+        else:
+            order_primary = primary_col.asc().nullslast()
+    else:
+        order_primary = primary_col.desc() if is_desc else primary_col.asc()
+
+    # Tiebreakers for stable pagination
+    if is_desc:
+        query = query.order_by(
+            order_primary,
+            AlephCreditHistoryDb.credit_ref.desc(),
+            AlephCreditHistoryDb.credit_index.desc(),
+        )
+    else:
+        query = query.order_by(
+            order_primary,
+            AlephCreditHistoryDb.credit_ref.asc(),
+            AlephCreditHistoryDb.credit_index.asc(),
         )
 
-    if after_time is not None or cursor_mode:
+    # Apply filters
+    query = _apply_credit_history_filters(
+        query,
+        tx_hash=tx_hash,
+        token=token,
+        chain=chain,
+        provider=provider,
+        origin=origin,
+        origin_ref=origin_ref,
+        payment_method=payment_method,
+        has_expiration=has_expiration,
+        exclude_payment_method=exclude_payment_method,
+    )
+
+    # Cursor-based keyset pagination
+    if after_credit_ref is not None:
+        if after_sort_value is None and sort_by in _NULLABLE_SORT_COLUMNS:
+            # Last entry had NULL sort value — only compare tiebreakers within NULL group
+            if is_desc:
+                query = query.where(
+                    (primary_col.is_(None))
+                    & (
+                        (AlephCreditHistoryDb.credit_ref < after_credit_ref)
+                        | (
+                            (AlephCreditHistoryDb.credit_ref == after_credit_ref)
+                            & (AlephCreditHistoryDb.credit_index < after_credit_index)
+                        )
+                    )
+                )
+            else:
+                query = query.where(
+                    (primary_col.is_(None))
+                    & (
+                        (AlephCreditHistoryDb.credit_ref > after_credit_ref)
+                        | (
+                            (AlephCreditHistoryDb.credit_ref == after_credit_ref)
+                            & (AlephCreditHistoryDb.credit_index > after_credit_index)
+                        )
+                    )
+                )
+        elif is_desc:
+            query = query.where(
+                (primary_col < after_sort_value)
+                | (
+                    (primary_col == after_sort_value)
+                    & (
+                        (AlephCreditHistoryDb.credit_ref < after_credit_ref)
+                        | (
+                            (AlephCreditHistoryDb.credit_ref == after_credit_ref)
+                            & (AlephCreditHistoryDb.credit_index < after_credit_index)
+                        )
+                    )
+                )
+                | (primary_col.is_(None))
+            )
+        else:
+            query = query.where(
+                (primary_col > after_sort_value)
+                | (
+                    (primary_col == after_sort_value)
+                    & (
+                        (AlephCreditHistoryDb.credit_ref > after_credit_ref)
+                        | (
+                            (AlephCreditHistoryDb.credit_ref == after_credit_ref)
+                            & (AlephCreditHistoryDb.credit_index > after_credit_index)
+                        )
+                    )
+                )
+                | (primary_col.is_(None))
+            )
+
+    if after_credit_ref is not None or cursor_mode:
         if pagination > 0:
             query = query.limit(pagination + 1)
     elif pagination > 0:
@@ -968,43 +1072,28 @@ def count_address_credit_history(
     origin: Optional[str] = None,
     origin_ref: Optional[str] = None,
     payment_method: Optional[str] = None,
+    has_expiration: Optional[bool] = None,
+    exclude_payment_method: Optional[List[str]] = None,
 ) -> int:
     """
     Count total credit history entries for a specific address with optional filters.
-
-    Args:
-        session: Database session
-        address: Address to count credit history for
-        tx_hash: Filter by transaction hash
-        token: Filter by token
-        chain: Filter by chain
-        provider: Filter by provider
-        origin: Filter by origin
-        origin_ref: Filter by origin reference
-        payment_method: Filter by payment method
-
-    Returns:
-        Total number of credit history entries for the address matching the filters
     """
     query = select(func.count(AlephCreditHistoryDb.credit_ref)).where(
         AlephCreditHistoryDb.address == address
     )
 
-    # Apply filters
-    if tx_hash is not None:
-        query = query.where(AlephCreditHistoryDb.tx_hash == tx_hash)
-    if token is not None:
-        query = query.where(AlephCreditHistoryDb.token == token)
-    if chain is not None:
-        query = query.where(AlephCreditHistoryDb.chain == chain)
-    if provider is not None:
-        query = query.where(AlephCreditHistoryDb.provider == provider)
-    if origin is not None:
-        query = query.where(AlephCreditHistoryDb.origin == origin)
-    if origin_ref is not None:
-        query = query.where(AlephCreditHistoryDb.origin_ref == origin_ref)
-    if payment_method is not None:
-        query = query.where(AlephCreditHistoryDb.payment_method == payment_method)
+    query = _apply_credit_history_filters(
+        query,
+        tx_hash=tx_hash,
+        token=token,
+        chain=chain,
+        provider=provider,
+        origin=origin,
+        origin_ref=origin_ref,
+        payment_method=payment_method,
+        has_expiration=has_expiration,
+        exclude_payment_method=exclude_payment_method,
+    )
 
     return session.execute(query).scalar_one()
 

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, PlainSerializer, field_valida
 
 from aleph.schemas.messages_query_params import DEFAULT_PAGE, LIST_FIELD_SEPARATOR
 from aleph.types.files import FileType
-from aleph.types.sort_order import SortOrder
+from aleph.types.sort_order import SortByCreditHistory, SortOrder
 
 
 class GetAccountQueryParams(BaseModel):
@@ -158,6 +158,30 @@ class GetAccountCreditHistoryQueryParams(BaseModel):
     payment_method: Optional[str] = Field(
         default=None, description="Filter by payment method"
     )
+    has_expiration: Optional[bool] = Field(
+        default=None,
+        description="Filter by presence of expiration_date. "
+        "true: only entries with an expiration date, "
+        "false: only entries without an expiration date.",
+    )
+    exclude_payment_method: Optional[List[str]] = Field(
+        default=None,
+        description="Exclude entries matching these payment methods (comma-separated).",
+    )
+    sort_by: SortByCreditHistory = Field(
+        default=SortByCreditHistory.MESSAGE_TIMESTAMP,
+        description="Field to sort by.",
+    )
+    sort_order: SortOrder = Field(
+        default=SortOrder.DESCENDING,
+        description="Sort direction: 1 (ASC) or -1 (DESC).",
+    )
+
+    @field_validator("exclude_payment_method", mode="before")
+    def split_exclude_payment_method(cls, v):
+        if isinstance(v, str):
+            return v.split(LIST_FIELD_SEPARATOR)
+        return v
 
 
 class CreditHistoryResponseItem(BaseModel):

--- a/src/aleph/toolkit/cursor.py
+++ b/src/aleph/toolkit/cursor.py
@@ -90,6 +90,38 @@ def decode_credit_history_cursor(cursor: str) -> Tuple[dt.datetime, str, int]:
         raise ValueError("Invalid cursor: missing required fields")
 
 
+def encode_credit_history_sort_cursor(
+    sort_by: str,
+    sort_value: Any,
+    credit_ref: str,
+    credit_index: int,
+) -> str:
+    """Encode a credit history cursor with sort field info."""
+    value = (
+        sort_value.isoformat() if isinstance(sort_value, dt.datetime) else sort_value
+    )
+    return encode_cursor({"s": sort_by, "v": value, "r": credit_ref, "i": credit_index})
+
+
+def decode_credit_history_sort_cursor(
+    cursor: str,
+) -> Tuple[str, Any, str, int]:
+    """Decode a credit history sort cursor.
+
+    Returns (sort_by, sort_value, credit_ref, credit_index).
+    For backward compat, if 's' key is missing, assumes 'message_timestamp' sort
+    and uses the 't' key as the sort value.
+    """
+    try:
+        d = decode_cursor(cursor)
+        if "s" in d:
+            return str(d["s"]), d["v"], str(d["r"]), int(d["i"])
+        # Backward compat: old cursor format with (t, r, i)
+        return "message_timestamp", d["t"], str(d["r"]), int(d["i"])
+    except KeyError:
+        raise ValueError("Invalid cursor: missing required fields")
+
+
 def encode_address_stats_cursor(sort_value: Any, address: str) -> str:
     """Encode an address stats cursor: (sort_value, address)."""
     return encode_cursor({"v": sort_value, "a": address})

--- a/src/aleph/toolkit/cursor.py
+++ b/src/aleph/toolkit/cursor.py
@@ -93,31 +93,40 @@ def decode_credit_history_cursor(cursor: str) -> Tuple[dt.datetime, str, int]:
 def encode_credit_history_sort_cursor(
     sort_by: str,
     sort_value: Any,
+    sort_order: int,
     credit_ref: str,
     credit_index: int,
 ) -> str:
-    """Encode a credit history cursor with sort field info."""
+    """Encode a credit history cursor with sort field and order info."""
     value = (
         sort_value.isoformat() if isinstance(sort_value, dt.datetime) else sort_value
     )
-    return encode_cursor({"s": sort_by, "v": value, "r": credit_ref, "i": credit_index})
+    return encode_cursor(
+        {"s": sort_by, "v": value, "o": sort_order, "r": credit_ref, "i": credit_index}
+    )
 
 
 def decode_credit_history_sort_cursor(
     cursor: str,
-) -> Tuple[str, Any, str, int]:
+) -> Tuple[str, Any, int, str, int]:
     """Decode a credit history sort cursor.
 
-    Returns (sort_by, sort_value, credit_ref, credit_index).
+    Returns (sort_by, sort_value, sort_order, credit_ref, credit_index).
     For backward compat, if 's' key is missing, assumes 'message_timestamp' sort
-    and uses the 't' key as the sort value.
+    with DESC order and uses the 't' key as the sort value.
     """
     try:
         d = decode_cursor(cursor)
         if "s" in d:
-            return str(d["s"]), d["v"], str(d["r"]), int(d["i"])
+            return (
+                str(d["s"]),
+                d["v"],
+                int(d["o"]),
+                str(d["r"]),
+                int(d["i"]),
+            )
         # Backward compat: old cursor format with (t, r, i)
-        return "message_timestamp", d["t"], str(d["r"]), int(d["i"])
+        return "message_timestamp", d["t"], -1, str(d["r"]), int(d["i"])
     except KeyError:
         raise ValueError("Invalid cursor: missing required fields")
 

--- a/src/aleph/types/sort_order.py
+++ b/src/aleph/types/sort_order.py
@@ -55,3 +55,18 @@ class SortByAggregate(str, Enum):
 
     CREATION_TIME = "creation_time"
     LAST_MODIFIED = "last_modified"
+
+
+class SortByCreditHistory(str, Enum):
+    """
+    Determines by which field credit history entries should be sorted.
+    Values match AlephCreditHistoryDb column names.
+    """
+
+    MESSAGE_TIMESTAMP = "message_timestamp"
+    EXPIRATION_DATE = "expiration_date"
+    PAYMENT_METHOD = "payment_method"
+    AMOUNT = "amount"
+    ORIGIN = "origin"
+    TX_HASH = "tx_hash"
+    PROVIDER = "provider"

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -842,6 +842,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
                 (
                     cursor_sort_by,
                     after_sort_value,
+                    cursor_sort_order,
                     after_credit_ref,
                     after_credit_index,
                 ) = decode_credit_history_sort_cursor(cursor)
@@ -854,6 +855,14 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
                     text="Cursor sort field mismatch: cursor was created with "
                     f"sort_by={cursor_sort_by}, but request has "
                     f"sort_by={query_params.sort_by.value}"
+                )
+
+            # Validate cursor sort_order matches request sort_order
+            if cursor_sort_order != int(query_params.sort_order):
+                raise web.HTTPUnprocessableEntity(
+                    text="Cursor sort order mismatch: cursor was created with "
+                    f"sort_order={cursor_sort_order}, but request has "
+                    f"sort_order={int(query_params.sort_order)}"
                 )
 
             # Parse sort value back to correct type for datetime columns
@@ -922,6 +931,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             next_cursor = encode_credit_history_sort_cursor(
                 sort_by=query_params.sort_by.value,
                 sort_value=sort_value,
+                sort_order=int(query_params.sort_order),
                 credit_ref=last_entry.credit_ref,
                 credit_index=last_entry.credit_index,
             )

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import json
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Sequence
@@ -48,11 +49,11 @@ from aleph.schemas.api.accounts import (
 from aleph.toolkit.cursor import (
     decode_address_cursor,
     decode_address_stats_cursor,
-    decode_credit_history_cursor,
+    decode_credit_history_sort_cursor,
     decode_message_cursor,
     encode_address_cursor,
     encode_address_stats_cursor,
-    encode_credit_history_cursor,
+    encode_credit_history_sort_cursor,
     encode_message_cursor,
 )
 from aleph.types.db_session import DbSessionFactory
@@ -734,7 +735,7 @@ async def get_account_files(request: web.Request) -> web.Response:
 
 async def get_account_credit_history(request: web.Request) -> web.Response:
     """
-    Returns the credit history of an account, ordered from newest to oldest.
+    Returns the credit history of an account.
 
     ---
     summary: Get account credit history
@@ -786,6 +787,28 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
         in: query
         schema:
           type: string
+      - name: has_expiration
+        in: query
+        schema:
+          type: boolean
+        description: "Filter by presence of expiration_date (true/false)"
+      - name: exclude_payment_method
+        in: query
+        schema:
+          type: string
+        description: "Comma-separated payment methods to exclude"
+      - name: sort_by
+        in: query
+        schema:
+          type: string
+          default: message_timestamp
+          enum: [message_timestamp, expiration_date, payment_method, amount, origin, tx_hash, provider]
+      - name: sort_order
+        in: query
+        schema:
+          type: integer
+          default: -1
+          enum: [1, -1]
     responses:
       '200':
         description: Account credit history
@@ -813,14 +836,32 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             cursor, query_params.pagination
         )
 
-        after_time, after_credit_ref, after_credit_index = None, None, None
+        after_sort_value, after_credit_ref, after_credit_index = None, None, None
         if cursor:
             try:
-                after_time, after_credit_ref, after_credit_index = (
-                    decode_credit_history_cursor(cursor)
-                )
+                (
+                    cursor_sort_by,
+                    after_sort_value,
+                    after_credit_ref,
+                    after_credit_index,
+                ) = decode_credit_history_sort_cursor(cursor)
             except ValueError as e:
                 raise web.HTTPUnprocessableEntity(text=str(e))
+
+            # Validate cursor sort_by matches request sort_by
+            if cursor_sort_by != query_params.sort_by.value:
+                raise web.HTTPUnprocessableEntity(
+                    text="Cursor sort field mismatch: cursor was created with "
+                    f"sort_by={cursor_sort_by}, but request has "
+                    f"sort_by={query_params.sort_by.value}"
+                )
+
+            # Parse sort value back to correct type for datetime columns
+            if after_sort_value is not None and query_params.sort_by.value in (
+                "message_timestamp",
+                "expiration_date",
+            ):
+                after_sort_value = dt.datetime.fromisoformat(after_sort_value)
 
         with session_factory() as session:
             cursor_entries = list(
@@ -835,7 +876,11 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
                     origin=query_params.origin,
                     origin_ref=query_params.origin_ref,
                     payment_method=query_params.payment_method,
-                    after_time=after_time,
+                    has_expiration=query_params.has_expiration,
+                    exclude_payment_method=query_params.exclude_payment_method,
+                    sort_by=query_params.sort_by,
+                    sort_order=query_params.sort_order,
+                    after_sort_value=after_sort_value,
                     after_credit_ref=after_credit_ref,
                     after_credit_index=after_credit_index,
                     cursor_mode=True,
@@ -873,10 +918,12 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
         next_cursor: Optional[str] = None
         if has_more and cursor_entries:
             last_entry = cursor_entries[-1]
-            next_cursor = encode_credit_history_cursor(
-                last_entry.message_timestamp,
-                last_entry.credit_ref,
-                last_entry.credit_index,
+            sort_value = getattr(last_entry, query_params.sort_by.value)
+            next_cursor = encode_credit_history_sort_cursor(
+                sort_by=query_params.sort_by.value,
+                sort_value=sort_value,
+                credit_ref=last_entry.credit_ref,
+                credit_index=last_entry.credit_index,
             )
 
         response_data = {
@@ -900,6 +947,10 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             origin=query_params.origin,
             origin_ref=query_params.origin_ref,
             payment_method=query_params.payment_method,
+            has_expiration=query_params.has_expiration,
+            exclude_payment_method=query_params.exclude_payment_method,
+            sort_by=query_params.sort_by,
+            sort_order=query_params.sort_order,
         )
 
         if not credit_history_entries:
@@ -915,6 +966,8 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             origin=query_params.origin,
             origin_ref=query_params.origin_ref,
             payment_method=query_params.payment_method,
+            has_expiration=query_params.has_expiration,
+            exclude_payment_method=query_params.exclude_payment_method,
         )
 
         # Convert to response items

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -2356,3 +2356,135 @@ def test_has_expiration_and_exclude_combined(session_factory: DbSessionFactory):
         )
         assert len(results) == 1
         assert results[0].credit_ref == "combo_a"
+
+
+def test_cursor_pagination_nullable_sort_nulls_on_last_page(
+    session_factory: DbSessionFactory,
+):
+    """When sorting by expiration_date DESC with pagination, NULLs appear only on the last page."""
+    base_ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        # 3 entries with expiration dates
+        {
+            "address": "0xpagnull",
+            "amount": 100,
+            "credit_ref": "pn_a",
+            "credit_index": 0,
+            "message_timestamp": base_ts,
+            "last_update": base_ts,
+            "expiration_date": dt.datetime(2026, 9, 1, tzinfo=dt.timezone.utc),
+            "payment_method": "credit_distribution",
+        },
+        {
+            "address": "0xpagnull",
+            "amount": 200,
+            "credit_ref": "pn_b",
+            "credit_index": 0,
+            "message_timestamp": base_ts + dt.timedelta(hours=1),
+            "last_update": base_ts,
+            "expiration_date": dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc),
+            "payment_method": "credit_distribution",
+        },
+        {
+            "address": "0xpagnull",
+            "amount": 300,
+            "credit_ref": "pn_c",
+            "credit_index": 0,
+            "message_timestamp": base_ts + dt.timedelta(hours=2),
+            "last_update": base_ts,
+            "expiration_date": dt.datetime(2026, 5, 1, tzinfo=dt.timezone.utc),
+            "payment_method": "credit_distribution",
+        },
+        # 2 entries with NULL expiration (should appear last)
+        {
+            "address": "0xpagnull",
+            "amount": 400,
+            "credit_ref": "pn_d",
+            "credit_index": 0,
+            "message_timestamp": base_ts + dt.timedelta(hours=3),
+            "last_update": base_ts,
+            "expiration_date": None,
+            "payment_method": "credit_distribution",
+        },
+        {
+            "address": "0xpagnull",
+            "amount": 500,
+            "credit_ref": "pn_e",
+            "credit_index": 0,
+            "message_timestamp": base_ts + dt.timedelta(hours=4),
+            "last_update": base_ts,
+            "expiration_date": None,
+            "payment_method": "credit_distribution",
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        # Page 1: pagination=2, sort by expiration_date DESC → 2 non-NULL entries
+        page1 = get_address_credit_history(
+            session=session,
+            address="0xpagnull",
+            pagination=2,
+            sort_by=SortByCreditHistory.EXPIRATION_DATE,
+            sort_order=SortOrder.DESCENDING,
+            cursor_mode=True,
+        )
+        # Returns 3 rows (limit = pagination + 1 = 3), so has_more = True
+        assert len(page1) == 3
+        page1_trimmed = page1[:2]
+        # DESC order: 2026-09-01, 2026-07-01
+        assert page1_trimmed[0].credit_ref == "pn_a"
+        assert page1_trimmed[1].credit_ref == "pn_b"
+        # No NULLs on page 1
+        assert all(e.expiration_date is not None for e in page1_trimmed)
+
+        # Page 2: cursor from last entry of page 1
+        last = page1_trimmed[-1]
+        page2 = get_address_credit_history(
+            session=session,
+            address="0xpagnull",
+            pagination=2,
+            sort_by=SortByCreditHistory.EXPIRATION_DATE,
+            sort_order=SortOrder.DESCENDING,
+            after_sort_value=last.expiration_date,
+            after_credit_ref=last.credit_ref,
+            after_credit_index=last.credit_index,
+            cursor_mode=True,
+        )
+        # Returns 3 rows (1 non-NULL + 2 NULLs), has_more = True
+        assert len(page2) == 3
+        page2_trimmed = page2[:2]
+        # 2026-05-01, then first NULL
+        assert page2_trimmed[0].credit_ref == "pn_c"
+        assert page2_trimmed[0].expiration_date is not None
+        assert page2_trimmed[1].credit_ref in ("pn_d", "pn_e")
+        assert page2_trimmed[1].expiration_date is None
+
+        # Page 3: cursor from last entry of page 2 (which is a NULL)
+        last2 = page2_trimmed[-1]
+        page3 = get_address_credit_history(
+            session=session,
+            address="0xpagnull",
+            pagination=2,
+            sort_by=SortByCreditHistory.EXPIRATION_DATE,
+            sort_order=SortOrder.DESCENDING,
+            after_sort_value=last2.expiration_date,
+            after_credit_ref=last2.credit_ref,
+            after_credit_index=last2.credit_index,
+            cursor_mode=True,
+        )
+        # Only 1 remaining NULL entry
+        assert len(page3) == 1
+        assert page3[0].expiration_date is None
+
+        # Verify all entries were seen exactly once across all pages
+        all_refs = (
+            [e.credit_ref for e in page1_trimmed]
+            + [e.credit_ref for e in page2_trimmed]
+            + [e.credit_ref for e in page3]
+        )
+        assert len(all_refs) == 5
+        assert len(set(all_refs)) == 5

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -7,6 +7,8 @@ from sqlalchemy import select
 from sqlalchemy import update as sql_update
 
 from aleph.db.accessors.balances import (
+    count_address_credit_history,
+    get_address_credit_history,
     get_consumed_credits_by_resource,
     get_credit_balance,
     get_credit_balance_with_details,
@@ -19,6 +21,7 @@ from aleph.db.accessors.balances import (
 )
 from aleph.db.models import AlephCreditBalanceDb, AlephCreditHistoryDb
 from aleph.types.db_session import DbSessionFactory
+from aleph.types.sort_order import SortByCreditHistory, SortOrder
 
 
 def test_update_credit_balances_distribution(session_factory: DbSessionFactory):
@@ -1972,3 +1975,384 @@ def test_get_consumed_credits_by_resource_uses_origin_ref_for_volumes(
 
         assert result["instance_hash_1"] == 3000000  # 300 * 10000
         assert result["vol_hash_mixed"] == 1500000  # 150 * 10000
+
+
+# ── Credit history filter and sort tests ──────────────────────────────
+
+
+def test_has_expiration_filter_true(session_factory: DbSessionFactory):
+    """has_expiration=True returns only entries WITH an expiration_date."""
+    ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+    exp = dt.datetime(2026, 6, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        {
+            "address": "0xfilter",
+            "amount": 100,
+            "credit_ref": "ref_exp",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "expiration_date": exp,
+            "payment_method": "credit_distribution",
+        },
+        {
+            "address": "0xfilter",
+            "amount": 200,
+            "credit_ref": "ref_noexp",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "expiration_date": None,
+            "payment_method": "credit_distribution",
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        results = get_address_credit_history(
+            session=session, address="0xfilter", has_expiration=True
+        )
+        assert len(results) == 1
+        assert results[0].credit_ref == "ref_exp"
+
+
+def test_has_expiration_filter_false(session_factory: DbSessionFactory):
+    """has_expiration=False returns only entries WITHOUT an expiration_date."""
+    ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+    exp = dt.datetime(2026, 6, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        {
+            "address": "0xfilter2",
+            "amount": 100,
+            "credit_ref": "ref2_exp",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "expiration_date": exp,
+            "payment_method": "credit_distribution",
+        },
+        {
+            "address": "0xfilter2",
+            "amount": 200,
+            "credit_ref": "ref2_noexp",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "expiration_date": None,
+            "payment_method": "credit_distribution",
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        results = get_address_credit_history(
+            session=session, address="0xfilter2", has_expiration=False
+        )
+        assert len(results) == 1
+        assert results[0].credit_ref == "ref2_noexp"
+
+
+def test_exclude_payment_method(session_factory: DbSessionFactory):
+    """exclude_payment_method removes entries matching given payment methods."""
+    ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        {
+            "address": "0xexclude",
+            "amount": 100,
+            "credit_ref": "ref_dist",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "payment_method": "credit_distribution",
+        },
+        {
+            "address": "0xexclude",
+            "amount": -50,
+            "credit_ref": "ref_expense",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "payment_method": "credit_expense",
+        },
+        {
+            "address": "0xexclude",
+            "amount": 75,
+            "credit_ref": "ref_transfer",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "payment_method": "credit_transfer",
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        # Exclude expense
+        results = get_address_credit_history(
+            session=session,
+            address="0xexclude",
+            exclude_payment_method=["credit_expense"],
+        )
+        assert len(results) == 2
+        refs = {r.credit_ref for r in results}
+        assert refs == {"ref_dist", "ref_transfer"}
+
+        # Exclude both expense and transfer
+        results = get_address_credit_history(
+            session=session,
+            address="0xexclude",
+            exclude_payment_method=["credit_expense", "credit_transfer"],
+        )
+        assert len(results) == 1
+        assert results[0].credit_ref == "ref_dist"
+
+
+def test_exclude_payment_method_count(session_factory: DbSessionFactory):
+    """count_address_credit_history respects exclude_payment_method."""
+    ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        {
+            "address": "0xcnt",
+            "amount": 100,
+            "credit_ref": "cnt_dist",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "payment_method": "credit_distribution",
+        },
+        {
+            "address": "0xcnt",
+            "amount": -50,
+            "credit_ref": "cnt_expense",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "payment_method": "credit_expense",
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        total = count_address_credit_history(session=session, address="0xcnt")
+        assert total == 2
+
+        filtered = count_address_credit_history(
+            session=session,
+            address="0xcnt",
+            exclude_payment_method=["credit_expense"],
+        )
+        assert filtered == 1
+
+
+def test_sort_by_amount_ascending(session_factory: DbSessionFactory):
+    """sort_by=AMOUNT, sort_order=ASC orders by amount ascending."""
+    base_ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        {
+            "address": "0xsort",
+            "amount": 300,
+            "credit_ref": "sort_a",
+            "credit_index": 0,
+            "message_timestamp": base_ts,
+            "last_update": base_ts,
+        },
+        {
+            "address": "0xsort",
+            "amount": 100,
+            "credit_ref": "sort_b",
+            "credit_index": 0,
+            "message_timestamp": base_ts + dt.timedelta(hours=1),
+            "last_update": base_ts,
+        },
+        {
+            "address": "0xsort",
+            "amount": 200,
+            "credit_ref": "sort_c",
+            "credit_index": 0,
+            "message_timestamp": base_ts + dt.timedelta(hours=2),
+            "last_update": base_ts,
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        results = get_address_credit_history(
+            session=session,
+            address="0xsort",
+            sort_by=SortByCreditHistory.AMOUNT,
+            sort_order=SortOrder.ASCENDING,
+        )
+        amounts = [r.amount for r in results]
+        assert amounts == [100, 200, 300]
+
+
+def test_sort_by_amount_descending(session_factory: DbSessionFactory):
+    """sort_by=AMOUNT, sort_order=DESC orders by amount descending."""
+    base_ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        {
+            "address": "0xsortd",
+            "amount": 300,
+            "credit_ref": "sortd_a",
+            "credit_index": 0,
+            "message_timestamp": base_ts,
+            "last_update": base_ts,
+        },
+        {
+            "address": "0xsortd",
+            "amount": 100,
+            "credit_ref": "sortd_b",
+            "credit_index": 0,
+            "message_timestamp": base_ts + dt.timedelta(hours=1),
+            "last_update": base_ts,
+        },
+        {
+            "address": "0xsortd",
+            "amount": 200,
+            "credit_ref": "sortd_c",
+            "credit_index": 0,
+            "message_timestamp": base_ts + dt.timedelta(hours=2),
+            "last_update": base_ts,
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        results = get_address_credit_history(
+            session=session,
+            address="0xsortd",
+            sort_by=SortByCreditHistory.AMOUNT,
+            sort_order=SortOrder.DESCENDING,
+        )
+        amounts = [r.amount for r in results]
+        assert amounts == [300, 200, 100]
+
+
+def test_sort_by_expiration_date_nulls_last(session_factory: DbSessionFactory):
+    """Sorting by expiration_date puts NULLs last."""
+    base_ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        {
+            "address": "0xnull",
+            "amount": 100,
+            "credit_ref": "null_a",
+            "credit_index": 0,
+            "message_timestamp": base_ts,
+            "last_update": base_ts,
+            "expiration_date": None,
+        },
+        {
+            "address": "0xnull",
+            "amount": 200,
+            "credit_ref": "null_b",
+            "credit_index": 0,
+            "message_timestamp": base_ts + dt.timedelta(hours=1),
+            "last_update": base_ts,
+            "expiration_date": dt.datetime(2026, 5, 1, tzinfo=dt.timezone.utc),
+        },
+        {
+            "address": "0xnull",
+            "amount": 300,
+            "credit_ref": "null_c",
+            "credit_index": 0,
+            "message_timestamp": base_ts + dt.timedelta(hours=2),
+            "last_update": base_ts,
+            "expiration_date": dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc),
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        # ASC: earliest expiration first, NULLs last
+        results = get_address_credit_history(
+            session=session,
+            address="0xnull",
+            sort_by=SortByCreditHistory.EXPIRATION_DATE,
+            sort_order=SortOrder.ASCENDING,
+        )
+        refs = [r.credit_ref for r in results]
+        assert refs == ["null_c", "null_b", "null_a"]
+
+        # DESC: latest expiration first, NULLs last
+        results = get_address_credit_history(
+            session=session,
+            address="0xnull",
+            sort_by=SortByCreditHistory.EXPIRATION_DATE,
+            sort_order=SortOrder.DESCENDING,
+        )
+        refs = [r.credit_ref for r in results]
+        assert refs == ["null_b", "null_c", "null_a"]
+
+
+def test_has_expiration_and_exclude_combined(session_factory: DbSessionFactory):
+    """has_expiration and exclude_payment_method work together."""
+    ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+    exp = dt.datetime(2026, 6, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        {
+            "address": "0xcombo",
+            "amount": 100,
+            "credit_ref": "combo_a",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "expiration_date": exp,
+            "payment_method": "credit_distribution",
+        },
+        {
+            "address": "0xcombo",
+            "amount": -50,
+            "credit_ref": "combo_b",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "expiration_date": None,
+            "payment_method": "credit_expense",
+        },
+        {
+            "address": "0xcombo",
+            "amount": 75,
+            "credit_ref": "combo_c",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "expiration_date": exp,
+            "payment_method": "credit_expense",
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        # has_expiration=True + exclude credit_expense => only combo_a
+        results = get_address_credit_history(
+            session=session,
+            address="0xcombo",
+            has_expiration=True,
+            exclude_payment_method=["credit_expense"],
+        )
+        assert len(results) == 1
+        assert results[0].credit_ref == "combo_a"


### PR DESCRIPTION
# Summary

  Adds three new capabilities to `GET /api/v0/addresses/{address}/credit_history`:

  - **`has_expiration` filter** (boolean) — filter entries by whether they have an expiration date (`true` = only expiring credits, `false` = only non-expiring)
  - **`exclude_payment_method` filter** (comma-separated list) — exclude entries matching given payment methods (e.g. `exclude_payment_method=credit_expense` to see only distributions and transfers)
  - **`sort_by` / `sort_order` params** — sort results by any field (`message_timestamp`, `expiration_date`, `payment_method`, `amount`, `origin`, `tx_hash`, `provider`) in ascending or descending order. Default remains `message_timestamp DESC`. Nullable columns use `NULLS LAST` ordering.

  Cursor-based pagination is fully supported with custom sort fields — the cursor encodes the sort field name and value, with backward compatibility for existing cursors.

  ## Changes

  - **`src/aleph/types/sort_order.py`** — new `SortByCreditHistory` enum
  - **`src/aleph/schemas/api/accounts.py`** — new query params on `GetAccountCreditHistoryQueryParams`
  - **`src/aleph/toolkit/cursor.py`** — sort-aware cursor encode/decode functions
  - **`src/aleph/db/accessors/balances.py`** — dynamic sorting, generalized keyset pagination, extracted shared filter logic into `_apply_credit_history_filters()`
  - **`src/aleph/web/controllers/accounts.py`** — wired new params in handler, cursor sort validation
  - **`tests/db/test_credit_balances.py`** — 8 new tests covering filters, sorting, nulls ordering, and combinations

  ## Test plan

  - [x] `has_expiration=true` returns only entries with expiration_date
  - [x] `has_expiration=false` returns only entries without expiration_date
  - [x] `exclude_payment_method` filters out specified payment methods
  - [x] `count_address_credit_history` respects `exclude_payment_method`
  - [x] `sort_by=amount` with ASC/DESC ordering
  - [x] `sort_by=expiration_date` places NULLs last in both directions
  - [x] Combined `has_expiration` + `exclude_payment_method` filters
  - [x] All existing tests still pass
