### PR TITLE
feat: add include_credit_details param to /balance endpoint

### DIFF
--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -768,9 +768,7 @@ def update_credit_balances_transfer(
     # Compute sender's remaining credits once for all entries in this transfer
     sender_remaining: list[PositiveCredit] = []
     if not is_whitelisted:
-        sender_remaining = _apply_fifo_consumption(
-            session, sender_address, last_update
-        )
+        sender_remaining = _apply_fifo_consumption(session, sender_address, last_update)
 
     for credit_entry in credits_list:
         recipient_address = credit_entry["address"]

--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -5,7 +5,7 @@ import time
 from dataclasses import dataclass
 from decimal import Decimal
 from io import StringIO
-from typing import Any, Dict, Mapping, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from aleph_message.models import Chain
 from sqlalchemy import func, select, text
@@ -240,7 +240,13 @@ class NegativeAmount:
     timestamp: dt.datetime
 
 
-def _get_remaining_credits_fifo(
+@dataclass
+class CreditBalanceDetail:
+    expiration_date: Optional[dt.datetime]
+    amount: int
+
+
+def _apply_fifo_consumption(
     session: DbSession, address: str, now: Optional[dt.datetime] = None
 ) -> list[PositiveCredit]:
     """
@@ -367,13 +373,49 @@ def _calculate_credit_balance_fifo(
     4. Return remaining balance considering current expiration status
     """
     now = now if now is not None else utc_now()
-    positive_credits = _get_remaining_credits_fifo(session, address, now)
+    positive_credits = _apply_fifo_consumption(session, address, now)
     total_balance = sum(
         c.remaining
         for c in positive_credits
         if c.expiration_date is None or c.expiration_date > now
     )
     return max(0, total_balance)
+
+
+def get_credit_balance_with_details(
+    session: DbSession, address: str, now: Optional[dt.datetime] = None
+) -> Tuple[int, List[CreditBalanceDetail]]:
+    """
+    Calculate credit balance with a breakdown by expiration date.
+
+    Returns (total_balance, details) where details is a list of
+    CreditBalanceDetail grouped by expiration_date, sorted with
+    non-expiring (None) first, then by expiration_date ascending.
+
+    Always recalculates (bypasses cache) since details are not cached.
+    """
+    now = now if now is not None else utc_now()
+    positive_credits = _apply_fifo_consumption(session, address, now)
+
+    details_map: Dict[Optional[dt.datetime], int] = {}
+    total_balance = 0
+    for credit in positive_credits:
+        if credit.expiration_date is None or credit.expiration_date > now:
+            if credit.remaining > 0:
+                total_balance += credit.remaining
+                key = credit.expiration_date
+                details_map[key] = details_map.get(key, 0) + credit.remaining
+
+    # Sort: non-expiring first (None), then by expiration_date ascending
+    details = [
+        CreditBalanceDetail(expiration_date=k, amount=v)
+        for k, v in sorted(
+            details_map.items(),
+            key=lambda x: (x[0] is not None, x[0] or dt.datetime.min),
+        )
+    ]
+
+    return max(0, total_balance), details
 
 
 def get_credit_balance(
@@ -726,7 +768,7 @@ def update_credit_balances_transfer(
     # Compute sender's remaining credits once for all entries in this transfer
     sender_remaining: list[PositiveCredit] = []
     if not is_whitelisted:
-        sender_remaining = _get_remaining_credits_fifo(
+        sender_remaining = _apply_fifo_consumption(
             session, sender_address, last_update
         )
 

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -14,11 +14,20 @@ class GetAccountQueryParams(BaseModel):
     chain: Optional[Chain] = Field(
         default=None, description="Get Balance on a specific EVM Chain"
     )
+    include_credit_details: bool = Field(
+        default=False,
+        description="Include credit balance breakdown by expiration date (after FIFO consumption).",
+    )
 
 
 FloatDecimal = Annotated[
     Decimal, PlainSerializer(lambda x: float(x), return_type=float, when_used="always")
 ]
+
+
+class CreditBalanceDetailItem(BaseModel):
+    expiration_date: Optional[dt.datetime] = None
+    amount: int
 
 
 class GetAccountBalanceResponse(BaseModel):
@@ -27,6 +36,7 @@ class GetAccountBalanceResponse(BaseModel):
     details: Optional[Dict[str, FloatDecimal]] = None
     locked_amount: FloatDecimal
     credit_balance: int = 0
+    credit_balance_details: Optional[List[CreditBalanceDetailItem]] = None
 
 
 class GetAccountFilesQueryParams(BaseModel):

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -14,6 +14,7 @@ from aleph.db.accessors.balances import (
     get_address_credit_history,
     get_balances_by_chain,
     get_credit_balance,
+    get_credit_balance_with_details,
     get_credit_balances,
     get_resource_consumed_credits,
     get_total_detailed_balance,
@@ -29,6 +30,7 @@ from aleph.schemas.addresses_query_params import AddressesQueryParams
 from aleph.schemas.api.accounts import (
     AddressBalanceResponse,
     AddressCreditBalanceResponse,
+    CreditBalanceDetailItem,
     CreditHistoryResponseItem,
     GetAccountBalanceResponse,
     GetAccountChannelsResponse,
@@ -307,6 +309,12 @@ async def get_account_balance(request: web.Request):
         schema:
           type: string
         description: Filter by EVM chain
+      - name: include_credit_details
+        in: query
+        schema:
+          type: boolean
+          default: false
+        description: Include credit balance breakdown by expiration date (after FIFO consumption)
     responses:
       '200':
         description: Account balance details
@@ -330,9 +338,25 @@ async def get_account_balance(request: web.Request):
             session=session, address=address, chain=query_params.chain
         )
         total_cost = get_total_cost_for_address(session=session, address=address)
-        credits = get_credit_balance(session=session, address=address)
+
+        credit_balance_details = None
+        if query_params.include_credit_details:
+            credits, detail_items = get_credit_balance_with_details(
+                session=session, address=address
+            )
+            credit_balance_details = [
+                CreditBalanceDetailItem(
+                    expiration_date=d.expiration_date,
+                    amount=d.amount,
+                )
+                for d in detail_items
+            ]
+        else:
+            credits = get_credit_balance(session=session, address=address)
+
         if credits is None:
             credits = 0
+
     return web.json_response(
         text=GetAccountBalanceResponse(
             address=address,
@@ -340,6 +364,7 @@ async def get_account_balance(request: web.Request):
             locked_amount=total_cost,
             details=details,
             credit_balance=credits,
+            credit_balance_details=credit_balance_details,
         ).model_dump_json()
     )
 

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -1229,7 +1229,6 @@ _DIST_TS = dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
 _XFER_TS = dt.datetime(2023, 6, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
 
 
-
 def _give_credits(
     session,
     address: str,

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -8,6 +8,7 @@ from sqlalchemy import update as sql_update
 
 from aleph.db.accessors.balances import (
     get_credit_balance,
+    get_credit_balance_with_details,
     get_resource_consumed_credits,
     update_credit_balances_distribution,
     update_credit_balances_expense,
@@ -1228,6 +1229,7 @@ _DIST_TS = dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
 _XFER_TS = dt.datetime(2023, 6, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
 
 
+
 def _give_credits(
     session,
     address: str,
@@ -1538,3 +1540,329 @@ def test_chain_transfer_a_b_c_expiration_and_balances(
         assert get_credit_balance(session, "0xA", now=now_after_a) == 50 * MUL
         assert get_credit_balance(session, "0xB", now=now_after_a) == 0
         assert get_credit_balance(session, "0xC", now=now_after_a) == 0
+
+
+# ── Credit balance details tests ──────────────────────────────────────
+
+
+def _insert_credit_history_entries(session, entries: List[Dict[str, Any]]):
+    """Helper to bulk-insert credit history rows for testing."""
+    for entry in entries:
+        session.add(AlephCreditHistoryDb(**entry))
+    session.flush()
+
+
+def test_credit_balance_details_non_expiring_only(session_factory: DbSessionFactory):
+    """Details with only non-expiring credits."""
+    ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        {
+            "address": "0xdetails1",
+            "amount": 1000,
+            "credit_ref": "d1_a",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "expiration_date": None,
+        },
+        {
+            "address": "0xdetails1",
+            "amount": 2000,
+            "credit_ref": "d1_b",
+            "credit_index": 0,
+            "message_timestamp": ts + dt.timedelta(hours=1),
+            "last_update": ts,
+            "expiration_date": None,
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        total, details = get_credit_balance_with_details(
+            session=session, address="0xdetails1"
+        )
+        assert total == 3000
+        assert len(details) == 1
+        assert details[0].expiration_date is None
+        assert details[0].amount == 3000
+
+
+def test_credit_balance_details_mixed_expiration(session_factory: DbSessionFactory):
+    """Details group by different expiration dates."""
+    ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+    exp1 = dt.datetime(2026, 6, 1, tzinfo=dt.timezone.utc)
+    exp2 = dt.datetime(2026, 9, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        {
+            "address": "0xdetails2",
+            "amount": 1000,
+            "credit_ref": "d2_a",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "expiration_date": None,
+        },
+        {
+            "address": "0xdetails2",
+            "amount": 500,
+            "credit_ref": "d2_b",
+            "credit_index": 0,
+            "message_timestamp": ts + dt.timedelta(hours=1),
+            "last_update": ts,
+            "expiration_date": exp1,
+        },
+        {
+            "address": "0xdetails2",
+            "amount": 300,
+            "credit_ref": "d2_c",
+            "credit_index": 0,
+            "message_timestamp": ts + dt.timedelta(hours=2),
+            "last_update": ts,
+            "expiration_date": exp2,
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        total, details = get_credit_balance_with_details(
+            session=session, address="0xdetails2"
+        )
+        assert total == 1800
+        # Non-expiring first, then by expiration_date ascending
+        assert len(details) == 3
+        assert details[0].expiration_date is None
+        assert details[0].amount == 1000
+        assert details[1].expiration_date == exp1
+        assert details[1].amount == 500
+        assert details[2].expiration_date == exp2
+        assert details[2].amount == 300
+
+
+def test_credit_balance_details_partial_consumption(session_factory: DbSessionFactory):
+    """Details are accurate after FIFO partial consumption."""
+    ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+    exp1 = dt.datetime(2026, 9, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        # Non-expiring credit (oldest, consumed first by FIFO)
+        {
+            "address": "0xdetails3",
+            "amount": 1000,
+            "credit_ref": "d3_a",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "expiration_date": None,
+        },
+        # Expiring credit
+        {
+            "address": "0xdetails3",
+            "amount": 500,
+            "credit_ref": "d3_b",
+            "credit_index": 0,
+            "message_timestamp": ts + dt.timedelta(hours=1),
+            "last_update": ts,
+            "expiration_date": exp1,
+        },
+        # Expense consuming 700 from the oldest (non-expiring) credit
+        {
+            "address": "0xdetails3",
+            "amount": -700,
+            "credit_ref": "d3_exp",
+            "credit_index": 0,
+            "message_timestamp": ts + dt.timedelta(hours=2),
+            "last_update": ts,
+            "expiration_date": None,
+            "payment_method": "credit_expense",
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        total, details = get_credit_balance_with_details(
+            session=session, address="0xdetails3"
+        )
+        # 1000 - 700 = 300 non-expiring remaining, 500 expiring remaining
+        assert total == 800
+        assert len(details) == 2
+        assert details[0].expiration_date is None
+        assert details[0].amount == 300
+        assert details[1].expiration_date == exp1
+        assert details[1].amount == 500
+
+
+def test_credit_balance_details_fully_consumed(session_factory: DbSessionFactory):
+    """Fully consumed credits don't appear in details."""
+    ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        {
+            "address": "0xdetails4",
+            "amount": 500,
+            "credit_ref": "d4_a",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "expiration_date": None,
+        },
+        {
+            "address": "0xdetails4",
+            "amount": -500,
+            "credit_ref": "d4_exp",
+            "credit_index": 0,
+            "message_timestamp": ts + dt.timedelta(hours=1),
+            "last_update": ts,
+            "expiration_date": None,
+            "payment_method": "credit_expense",
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        total, details = get_credit_balance_with_details(
+            session=session, address="0xdetails4"
+        )
+        assert total == 0
+        assert len(details) == 0
+
+
+def test_credit_balance_details_expired_excluded(session_factory: DbSessionFactory):
+    """Expired credits are excluded from details."""
+    ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+    past_exp = dt.datetime(2026, 3, 15, tzinfo=dt.timezone.utc)
+    future_exp = dt.datetime(2027, 6, 1, tzinfo=dt.timezone.utc)
+    now = dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        # Already expired
+        {
+            "address": "0xdetails5",
+            "amount": 1000,
+            "credit_ref": "d5_expired",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "expiration_date": past_exp,
+        },
+        # Still valid
+        {
+            "address": "0xdetails5",
+            "amount": 500,
+            "credit_ref": "d5_valid",
+            "credit_index": 0,
+            "message_timestamp": ts + dt.timedelta(hours=1),
+            "last_update": ts,
+            "expiration_date": future_exp,
+        },
+        # Non-expiring
+        {
+            "address": "0xdetails5",
+            "amount": 200,
+            "credit_ref": "d5_noexp",
+            "credit_index": 0,
+            "message_timestamp": ts + dt.timedelta(hours=2),
+            "last_update": ts,
+            "expiration_date": None,
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        total, details = get_credit_balance_with_details(
+            session=session, address="0xdetails5", now=now
+        )
+        # Expired 1000 excluded, remaining: 500 + 200 = 700
+        assert total == 700
+        assert len(details) == 2
+        assert details[0].expiration_date is None
+        assert details[0].amount == 200
+        assert details[1].expiration_date == future_exp
+        assert details[1].amount == 500
+
+
+def test_credit_balance_details_no_history(session_factory: DbSessionFactory):
+    """No credit history returns 0 balance and empty details."""
+    with session_factory() as session:
+        total, details = get_credit_balance_with_details(
+            session=session, address="0xno_history"
+        )
+        assert total == 0
+        assert len(details) == 0
+
+
+def test_credit_balance_details_matches_total(session_factory: DbSessionFactory):
+    """Sum of details amounts equals the total balance."""
+    ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+    exp1 = dt.datetime(2026, 9, 1, tzinfo=dt.timezone.utc)
+    exp2 = dt.datetime(2026, 12, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        {
+            "address": "0xdetails6",
+            "amount": 1000,
+            "credit_ref": "d6_a",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "expiration_date": None,
+        },
+        {
+            "address": "0xdetails6",
+            "amount": 800,
+            "credit_ref": "d6_b",
+            "credit_index": 0,
+            "message_timestamp": ts + dt.timedelta(hours=1),
+            "last_update": ts,
+            "expiration_date": exp1,
+        },
+        {
+            "address": "0xdetails6",
+            "amount": 600,
+            "credit_ref": "d6_c",
+            "credit_index": 0,
+            "message_timestamp": ts + dt.timedelta(hours=2),
+            "last_update": ts,
+            "expiration_date": exp2,
+        },
+        # Expense consuming 1200 total (FIFO: 1000 from non-expiring, 200 from exp1)
+        {
+            "address": "0xdetails6",
+            "amount": -1200,
+            "credit_ref": "d6_exp",
+            "credit_index": 0,
+            "message_timestamp": ts + dt.timedelta(hours=3),
+            "last_update": ts,
+            "expiration_date": None,
+            "payment_method": "credit_expense",
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        total, details = get_credit_balance_with_details(
+            session=session, address="0xdetails6"
+        )
+        # 1000 - 1000 = 0 non-expiring, 800 - 200 = 600 exp1, 600 exp2
+        assert total == 1200
+        details_sum = sum(d.amount for d in details)
+        assert details_sum == total
+
+        assert len(details) == 2
+        assert details[0].expiration_date == exp1
+        assert details[0].amount == 600
+        assert details[1].expiration_date == exp2
+        assert details[1].amount == 600


### PR DESCRIPTION
## Summary

  Adds an optional `include_credit_details` boolean parameter to `GET /api/v0/addresses/{address}/balance`. When enabled, the response includes a `credit_balance_details` field with a FIFO-accurate breakdown of the remaining credit balance grouped by expiration date.

  Example response with `include_credit_details=true`:
  ```json
  {
    "address": "0x...",
    "balance": 10.5,
    "locked_amount": 2.0,
    "credit_balance": 1200,
    "credit_balance_details": [
      { "expiration_date": null, "amount": 300 },
      { "expiration_date": "2026-06-01T00:00:00+00:00", "amount": 600 },
      { "expiration_date": "2026-12-01T00:00:00+00:00", "amount": 300 }
    ]
  }
```

  The amounts reflect actual remaining credits after FIFO consumption — partially consumed credits are correctly accounted for. Non-expiring credits (null) are listed first, followed by expiring buckets sorted by date ascending.

  When include_credit_details is omitted or false, the response is unchanged (uses the existing cached balance path).

##  Changes

  - src/aleph/schemas/api/accounts.py — add include_credit_details to GetAccountQueryParams, new CreditBalanceDetailItem model, extend GetAccountBalanceResponse with optional credit_balance_details
  - src/aleph/db/accessors/balances.py — refactor FIFO logic into shared _apply_fifo_consumption helper, add CreditBalanceDetail dataclass and get_credit_balance_with_details() public function
  - src/aleph/web/controllers/accounts.py — wire include_credit_details in get_account_balance handler, update OpenAPI docstring
  - tests/db/test_credit_balances.py — 7 new tests for the details calculation

##  Test plan

  - Non-expiring credits only → single bucket with null expiration
  - Mixed expiration dates → grouped correctly, sorted null first then by date ASC
  - Partial FIFO consumption → remaining amounts are accurate per bucket
  - Fully consumed credits → empty details list, total = 0
  - Expired credits excluded from details
  - No credit history → total = 0, empty details
  - Sum of detail amounts equals total balance (invariant check)
  - All existing tests still pass