### PR TITLE
fix: resolve consumed_credits for volume resources in /costs endpoint

### DIFF
--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -1034,7 +1034,11 @@ def get_total_consumed_credits(
     if address:
         query = query.where(AlephCreditHistoryDb.address == address)
     if item_hash:
-        query = query.where(AlephCreditHistoryDb.origin == item_hash)
+        effective_origin = func.coalesce(
+            func.nullif(AlephCreditHistoryDb.origin, ""),
+            AlephCreditHistoryDb.origin_ref,
+        )
+        query = query.where(effective_origin == item_hash)
 
     result = session.execute(query).scalar()
     return result or 0
@@ -1077,17 +1081,22 @@ def get_consumed_credits_by_resource(
     if not item_hashes:
         return {}
 
+    effective_origin = func.coalesce(
+        func.nullif(AlephCreditHistoryDb.origin, ""),
+        AlephCreditHistoryDb.origin_ref,
+    )
+
     query = (
         select(
-            AlephCreditHistoryDb.origin,
+            effective_origin.label("resource_hash"),
             func.sum(func.abs(AlephCreditHistoryDb.amount)).label("consumed_credits"),
         )
         .where(
             (AlephCreditHistoryDb.payment_method == "credit_expense")
-            & (AlephCreditHistoryDb.origin.in_(item_hashes))
+            & (effective_origin.in_(item_hashes))
         )
-        .group_by(AlephCreditHistoryDb.origin)
+        .group_by(effective_origin)
     )
 
     results = session.execute(query).all()
-    return {row.origin: row.consumed_credits for row in results}
+    return {row.resource_hash: row.consumed_credits for row in results}

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -7,9 +7,11 @@ from sqlalchemy import select
 from sqlalchemy import update as sql_update
 
 from aleph.db.accessors.balances import (
+    get_consumed_credits_by_resource,
     get_credit_balance,
     get_credit_balance_with_details,
     get_resource_consumed_credits,
+    get_total_consumed_credits,
     update_credit_balances_distribution,
     update_credit_balances_expense,
     update_credit_balances_transfer,
@@ -1865,3 +1867,108 @@ def test_credit_balance_details_matches_total(session_factory: DbSessionFactory)
         assert details[0].amount == 600
         assert details[1].expiration_date == exp2
         assert details[1].amount == 600
+
+
+# ── Volume (origin_ref) consumed credits tests ───────────────────────
+
+
+def test_get_resource_consumed_credits_uses_origin_ref_for_volumes(
+    session_factory: DbSessionFactory,
+):
+    """Volumes store the resource hash in origin_ref, not origin.
+    get_resource_consumed_credits (via get_total_consumed_credits) must
+    fall back to origin_ref when origin is empty."""
+
+    message_timestamp = dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {"address": "0xvol_user", "amount": 200, "ref": "vol_hash_1"}
+            ],
+            message_hash="vol_expense_1",
+            message_timestamp=message_timestamp,
+        )
+        # Volume expenses: origin="" (no execution_id), origin_ref="vol_hash_1"
+        session.commit()
+
+        consumed = get_resource_consumed_credits(
+            session=session, item_hash="vol_hash_1"
+        )
+        assert consumed == 2000000  # 200 * 10000
+
+
+def test_get_total_consumed_credits_uses_origin_ref_for_volumes(
+    session_factory: DbSessionFactory,
+):
+    """get_total_consumed_credits must match on origin_ref when origin is empty."""
+
+    message_timestamp = dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {"address": "0xvol_total", "amount": 100, "ref": "vol_total_hash"},
+            ],
+            message_hash="vol_total_expense",
+            message_timestamp=message_timestamp,
+        )
+        session.commit()
+
+        # Filter by item_hash (should match via origin_ref)
+        consumed = get_total_consumed_credits(
+            session=session, item_hash="vol_total_hash"
+        )
+        assert consumed == 1000000  # 100 * 10000
+
+        # Filter by address only (no origin check, should always work)
+        consumed_addr = get_total_consumed_credits(
+            session=session, address="0xvol_total"
+        )
+        assert consumed_addr == 1000000
+
+
+def test_get_consumed_credits_by_resource_uses_origin_ref_for_volumes(
+    session_factory: DbSessionFactory,
+):
+    """get_consumed_credits_by_resource must resolve origin_ref for volume
+    resources whose origin is empty."""
+
+    message_timestamp = dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        # Instance expense (has execution_id → origin is set)
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {
+                    "address": "0xmixed",
+                    "amount": 300,
+                    "execution_id": "instance_hash_1",
+                    "ref": "some_ref",
+                },
+            ],
+            message_hash="inst_exp_mixed",
+            message_timestamp=message_timestamp,
+        )
+
+        # Volume expense (no execution_id → origin is empty, ref → origin_ref)
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {"address": "0xmixed", "amount": 150, "ref": "vol_hash_mixed"},
+            ],
+            message_hash="vol_exp_mixed",
+            message_timestamp=message_timestamp,
+        )
+        session.commit()
+
+        result = get_consumed_credits_by_resource(
+            session=session,
+            item_hashes=["instance_hash_1", "vol_hash_mixed"],
+        )
+
+        assert result["instance_hash_1"] == 3000000  # 300 * 10000
+        assert result["vol_hash_mixed"] == 1500000  # 150 * 10000


### PR DESCRIPTION
## Summary

  - Fix `consumed_credits` showing 0 for volume (STORE) resources in `/api/v0/costs?include_details=1`
  - Root cause: volume credit expenses store the resource hash in `origin_ref` (from `ref` field), not `origin` (from `execution_id`), but the queries only checked `origin`
  - Both `get_total_consumed_credits()` and `get_consumed_credits_by_resource()` now use `COALESCE(NULLIF(origin, ''), origin_ref)` to fall back to `origin_ref` when `origin` is empty

  ## Test plan

  - [x] 3 new unit tests covering the origin_ref fallback for volumes
  - [x] All existing credit_balances and costs tests pass (23 + 15 = 38 tests)
  - [x] Linting and mypy pass
  - [ ] Manual verification: query `/api/v0/costs?address=0xB6B5358493AF8159B17506C5cC85df69193444BC&include_details=1` and confirm volume resources show non-zero `consumed_credits`