### PR TITLE
Allow /messages/{hash}/content to return non-POST message content

### DIFF
--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -884,9 +884,7 @@ async def view_message_content(request: web.Request):
             session=session, status_db=message_status_db
         )
 
-    if message_with_status.status != MessageStatus.PROCESSED or not isinstance(
-        message_with_status, ProcessedMessageStatus
-    ):
+    if not isinstance(message_with_status, ProcessedMessageStatus):
         raise web.HTTPUnprocessableEntity(
             text=(
                 f"Message {item_hash} is not processed "
@@ -894,13 +892,13 @@ async def view_message_content(request: web.Request):
             )
         )
 
-    message = message_with_status.message
-    if isinstance(message, PostMessage):
+    # Serialize the full message once; extract the content portion below.
+    # Using model_dump keeps mypy happy through the AlephMessage union.
+    message_dict = message_with_status.message.model_dump(mode="json")
+    content = message_dict["content"]
+    if isinstance(message_with_status.message, PostMessage):
         # POST messages wrap the user payload in content.content
-        content = message.content.content
-    else:
-        # All other types expose the payload directly in content
-        content = message.content.model_dump(mode="json")
+        content = content["content"]
 
     return web.json_response(text=json.dumps(content))
 

--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Iterable, List, Optional, Set
 import aio_pika.abc
 import aiohttp.web_ws
 from aiohttp import WSCloseCode, WSMsgType, web
-from aleph_message.models import ItemHash, MessageType
+from aleph_message.models import ItemHash
 from configmanager import Config
 from pydantic import ValidationError
 from sqlalchemy.orm import defer
@@ -846,7 +846,10 @@ async def view_message(request: web.Request):
 
 async def view_message_content(request: web.Request):
     """
-    Get the content of a POST message by item hash.
+    Get the content of a processed message by item hash.
+
+    For POST messages, returns the nested user content (content.content).
+    For all other message types, returns the full message content.
 
     ---
     summary: Get message content
@@ -868,7 +871,7 @@ async def view_message_content(request: web.Request):
       '404':
         description: Message not found
       '422':
-        description: Invalid message type or status
+        description: Message is not in a PROCESSED state
     """
     item_hash = get_item_hash_from_request(request)
 
@@ -881,23 +884,24 @@ async def view_message_content(request: web.Request):
             session=session, status_db=message_status_db
         )
 
-    status = message_with_status.status
-    if (
-        status != MessageStatus.PROCESSED
-        or not hasattr(message_with_status, "message")
-        or not isinstance(message_with_status.message, PostMessage)
+    if message_with_status.status != MessageStatus.PROCESSED or not isinstance(
+        message_with_status, ProcessedMessageStatus
     ):
         raise web.HTTPUnprocessableEntity(
-            text=f"Invalid message hash status {status} for hash {item_hash}"
+            text=(
+                f"Message {item_hash} is not processed "
+                f"(status: {message_with_status.status})"
+            )
         )
 
-    message_type = message_with_status.message.type
-    if message_type != MessageType.post:
-        raise web.HTTPUnprocessableEntity(
-            text=f"Invalid message hash type {message_type} for hash {item_hash}"
-        )
+    message = message_with_status.message
+    if isinstance(message, PostMessage):
+        # POST messages wrap the user payload in content.content
+        content = message.content.content
+    else:
+        # All other types expose the payload directly in content
+        content = message.content.model_dump(mode="json")
 
-    content = message_with_status.message.content.content
     return web.json_response(text=json.dumps(content))
 
 

--- a/tests/api/test_get_message.py
+++ b/tests/api/test_get_message.py
@@ -217,13 +217,17 @@ async def test_get_processed_message_content(
     fixture_messages_with_status: Mapping[MessageStatus, Sequence[Any]], ccn_api_client
 ):
     for processed_message in fixture_messages_with_status[MessageStatus.PROCESSED]:
+        response = await ccn_api_client.get(
+            MESSAGE_CONTENT_URI.format(processed_message.item_hash)
+        )
+        assert response.status == 200, await response.text()
+        response_json = await response.json()
         if processed_message.type == MessageType.post:
-            response = await ccn_api_client.get(
-                MESSAGE_CONTENT_URI.format(processed_message.item_hash)
-            )
-            assert response.status == 200, await response.text()
-            response_json = await response.json()
+            # POST messages unwrap content.content
             assert response_json == processed_message.content["content"]
+        else:
+            # All other types return the full content payload
+            assert response_json == processed_message.content
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
  The endpoint was POST-only and rejected all other message types with a
  confusing 422 "Invalid message hash status" error, the status was
  actually PROCESSED, but the real failure was that the handler's
  isinstance(message, PostMessage) check refused any non-POST type.

  Extend to all message types:
  - POST: return content.content (unwrapped user payload - unchanged)
  - Others (PROGRAM, INSTANCE, STORE, AGGREGATE, FORGET): return full message.content, since those types don't double-wrap their payload.