### PR TITLE
build: exclude .git from docker image, require VERSION build-arg

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -52,6 +52,11 @@ cover/*
 MANIFEST
 .github/
 
+# Git metadata — version is injected via --build-arg VERSION
+.git
+.gitignore
+.gitattributes
+
 # Per-project virtualenvs
 .venv*/
 venv*/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,19 @@ jobs:
       - name: Download Docker cache image (if available)
         run: docker pull ghcr.io/$GITHUB_REPOSITORY/build-cache || true
 
-      - name: Build the Docker image
+      - name: Compute version
+        id: version
         run: |
           git fetch --prune --unshallow --tags
-          docker build . -t pyaleph-node:${GITHUB_REF##*/} -f deployment/docker-build/pyaleph.dockerfile --cache-from=ghcr.io/$GITHUB_REPOSITORY/build-cache
+          python3 -m pip install --quiet --user hatch hatch-vcs
+          echo "value=$(hatch version)" >> "$GITHUB_OUTPUT"
+
+      - name: Build the Docker image
+        run: |
+          docker build . -t pyaleph-node:${GITHUB_REF##*/} \
+            --build-arg VERSION=${{ steps.version.outputs.value }} \
+            -f deployment/docker-build/pyaleph.dockerfile \
+            --cache-from=ghcr.io/$GITHUB_REPOSITORY/build-cache
 
       - name: Push the image to the cache
         # It's not possible to push packages from fork PRs.

--- a/.github/workflows/test-keygen.yml
+++ b/.github/workflows/test-keygen.yml
@@ -24,10 +24,19 @@ jobs:
       - name: Download Docker cache image (if available)
         run: docker pull ghcr.io/$GITHUB_REPOSITORY/build-cache || true
 
-      - name: Build the Docker image
+      - name: Compute version
+        id: version
         run: |
           git fetch --prune --unshallow --tags
-          docker build . -t alephim/pyaleph-node:${GITHUB_REF##*/} -f deployment/docker-build/pyaleph.dockerfile --cache-from=ghcr.io/$GITHUB_REPOSITORY/build-cache
+          python3 -m pip install --quiet --user hatch hatch-vcs
+          echo "value=$(hatch version)" >> "$GITHUB_OUTPUT"
+
+      - name: Build the Docker image
+        run: |
+          docker build . -t alephim/pyaleph-node:${GITHUB_REF##*/} \
+            --build-arg VERSION=${{ steps.version.outputs.value }} \
+            -f deployment/docker-build/pyaleph.dockerfile \
+            --cache-from=ghcr.io/$GITHUB_REPOSITORY/build-cache
 
       - name: Tag the image
         run: |

--- a/deployment/docker-build/pyaleph.dockerfile
+++ b/deployment/docker-build/pyaleph.dockerfile
@@ -48,8 +48,8 @@ ENV PATH="/opt/venv/bin:${PATH}"
 RUN mkdir --parents /opt/pyaleph
 WORKDIR /opt/pyaleph
 COPY . .
-RUN git config --global --add safe.directory /opt/pyaleph
 ARG VERSION
+RUN : "${VERSION:?--build-arg VERSION is required (e.g. from 'hatch version')}"
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION
 RUN pip install -e .
 


### PR DESCRIPTION
## Summary

- `.git/` was being shipped inside the runtime Docker image via `COPY . .` in the builder stage, then re-copied into the final stage via `COPY --from=builder /opt/pyaleph /opt/pyaleph`. On a CI checkout where history is expanded with `git fetch --prune --unshallow --tags`, this can contribute a noticeable amount to the image size and also drifts between builds.
- Exclude `.git`, `.gitignore`, and `.gitattributes` from the build context via `.dockerignore`.
- With `.git/` gone, hatch-vcs can no longer derive the version during `pip install -e .`, so the already-declared `VERSION` build-arg (wired to `SETUPTOOLS_SCM_PRETEND_VERSION`) is now required. A guard `RUN : "${VERSION:?...}"` fails the build early with a clear message if it's missing.
- CI computes the version via `hatch version` and passes it as `--build-arg VERSION=...`.
- The `RUN git config --global --add safe.directory /opt/pyaleph` line is removed — no longer needed since setuptools-scm/hatch-vcs never runs against the in-image tree.

Context: investigating why `0.10.1-rc7` ended up several hundred MB larger than `0.10.1-rc6` despite a trivial source diff. This change removes one of the non-determinism sources (varying `.git/` size across builds) and is a first step; separate follow-ups could look at pinning transitive pip deps and the rolling `ubuntu:24.04` base.

## Test plan

- [x] Local build with `--build-arg VERSION=$(hatch version)` succeeds; final image is 754 MB
- [x] `/opt/pyaleph/.git` does not exist in the resulting image
- [x] `importlib.metadata.version('pyaleph')` inside the image returns the version passed via `--build-arg`
- [x] Build without `--build-arg VERSION=...` fails early with the guard message
- [ ] CI build green on this PR
- [ ] Verify image size on CI is smaller than the most recent `main`/`dev` build