### PR TITLE
feat: denormalize message and post tags into TEXT[] columns

### DIFF
--- a/deployment/migrations/versions/0056_7e5a630e4b36_denormalize_message_tags.py
+++ b/deployment/migrations/versions/0056_7e5a630e4b36_denormalize_message_tags.py
@@ -58,9 +58,13 @@ def _batched_update(connection, label: str, sql: str) -> None:
 
 
 # Backfill SQL: each rebuilds the new column from the legacy JSONB
-# location for the relevant content types. ``jsonb_array_length > 0``
-# keeps empty tag lists out of the column so an absent value and an
-# empty array stay distinguishable.
+# location for the relevant content types. The non-empty filter uses
+# a JSONB literal comparison (``<> '[]'::jsonb``) rather than
+# ``jsonb_array_length(...) > 0``: production data contains rows where
+# ``tags`` is a scalar string, and ``jsonb_array_length`` aborts the
+# query on a scalar. JSONB equality is defined across all types, so
+# the comparison is safe regardless of the planner's predicate order.
+# Absent and empty tag lists both stay NULL in the new column.
 
 BACKFILL_MESSAGES_SQL = f"""
 WITH batch AS (
@@ -69,13 +73,13 @@ WITH batch AS (
       AND (
         (type IN ('POST', 'AGGREGATE')
             AND jsonb_typeof(content->'content'->'tags') = 'array'
-            AND jsonb_array_length(content->'content'->'tags') > 0)
+            AND content->'content'->'tags' <> '[]'::jsonb)
         OR (type = 'STORE'
             AND jsonb_typeof(content->'tags') = 'array'
-            AND jsonb_array_length(content->'tags') > 0)
+            AND content->'tags' <> '[]'::jsonb)
         OR (type IN ('INSTANCE', 'PROGRAM')
             AND jsonb_typeof(content->'metadata'->'tags') = 'array'
-            AND jsonb_array_length(content->'metadata'->'tags') > 0)
+            AND content->'metadata'->'tags' <> '[]'::jsonb)
       )
     LIMIT {BATCH_SIZE}
 )
@@ -96,7 +100,7 @@ WITH batch AS (
     SELECT item_hash FROM posts
     WHERE tags IS NULL
       AND jsonb_typeof(content->'tags') = 'array'
-      AND jsonb_array_length(content->'tags') > 0
+      AND content->'tags' <> '[]'::jsonb
     LIMIT {BATCH_SIZE}
 )
 UPDATE posts

--- a/deployment/migrations/versions/0056_7e5a630e4b36_denormalize_message_tags.py
+++ b/deployment/migrations/versions/0056_7e5a630e4b36_denormalize_message_tags.py
@@ -1,0 +1,183 @@
+"""Denormalize message and post tags into TEXT[] columns
+
+Revision ID: 7e5a630e4b36
+Revises: b3c4d5e6f7a8
+Create Date: 2026-05-05
+
+Promotes the tag list out of JSONB into native TEXT[] columns on
+``messages`` and ``posts`` so that filtering uses a single GIN index
+that covers every message type and matches the per-type validation
+introduced in aleph-message 1.2.0.dev0.
+
+Tags currently live in three different places depending on the
+content type:
+
+* POST + AGGREGATE: ``content -> 'content' -> 'tags'``
+* STORE:            ``content -> 'tags'``
+* INSTANCE/PROGRAM: ``content -> 'metadata' -> 'tags'``
+
+The previous ``ix_messages_content_tags_gin`` indexed only the POST
+path, so tag queries fell back to a full heap scan for every other
+type. The new column unifies the three locations under one indexed
+predicate.
+
+Backfill is batched with intermediate COMMITs to bound WAL growth
+and lock duration on large tables. Indexes are built CONCURRENTLY
+on a separate AUTOCOMMIT connection.
+"""
+
+import logging
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "7e5a630e4b36"
+down_revision = "b3c4d5e6f7a8"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+BATCH_SIZE = 50000
+
+
+def _batched_update(connection, label: str, sql: str) -> None:
+    """Run an UPDATE in batches, committing between each."""
+    total = 0
+    while True:
+        connection.execute(text("BEGIN"))
+        result = connection.execute(text(sql))
+        rows = result.rowcount
+        total += rows
+        connection.execute(text("COMMIT"))
+        logger.info(f"  {label}: {total} rows so far (+{rows})")
+        if rows < BATCH_SIZE:
+            break
+    logger.info(f"  {label}: done ({total} rows total)")
+
+
+# Backfill SQL: each rebuilds the new column from the legacy JSONB
+# location for the relevant content types. ``jsonb_array_length > 0``
+# keeps empty tag lists out of the column so an absent value and an
+# empty array stay distinguishable.
+
+BACKFILL_MESSAGES_SQL = f"""
+WITH batch AS (
+    SELECT item_hash FROM messages
+    WHERE tags IS NULL
+      AND (
+        (type IN ('POST', 'AGGREGATE')
+            AND jsonb_typeof(content->'content'->'tags') = 'array'
+            AND jsonb_array_length(content->'content'->'tags') > 0)
+        OR (type = 'STORE'
+            AND jsonb_typeof(content->'tags') = 'array'
+            AND jsonb_array_length(content->'tags') > 0)
+        OR (type IN ('INSTANCE', 'PROGRAM')
+            AND jsonb_typeof(content->'metadata'->'tags') = 'array'
+            AND jsonb_array_length(content->'metadata'->'tags') > 0)
+      )
+    LIMIT {BATCH_SIZE}
+)
+UPDATE messages
+SET tags = CASE
+    WHEN type IN ('POST', 'AGGREGATE')
+        THEN ARRAY(SELECT jsonb_array_elements_text(content->'content'->'tags'))
+    WHEN type = 'STORE'
+        THEN ARRAY(SELECT jsonb_array_elements_text(content->'tags'))
+    WHEN type IN ('INSTANCE', 'PROGRAM')
+        THEN ARRAY(SELECT jsonb_array_elements_text(content->'metadata'->'tags'))
+END
+WHERE item_hash IN (SELECT item_hash FROM batch)
+"""
+
+BACKFILL_POSTS_SQL = f"""
+WITH batch AS (
+    SELECT item_hash FROM posts
+    WHERE tags IS NULL
+      AND jsonb_typeof(content->'tags') = 'array'
+      AND jsonb_array_length(content->'tags') > 0
+    LIMIT {BATCH_SIZE}
+)
+UPDATE posts
+SET tags = ARRAY(SELECT jsonb_array_elements_text(content->'tags'))
+WHERE item_hash IN (SELECT item_hash FROM batch)
+"""
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    was_in_transaction = connection.in_transaction()
+    if was_in_transaction:
+        connection.execute(text("COMMIT"))
+
+    # Step 1: schema additions, fast metadata-only ALTERs.
+    logger.info("Step 1/3: Adding tags columns...")
+    connection.execute(text("BEGIN"))
+    connection.execute(
+        text("ALTER TABLE messages ADD COLUMN IF NOT EXISTS tags TEXT[]")
+    )
+    connection.execute(text("ALTER TABLE posts ADD COLUMN IF NOT EXISTS tags TEXT[]"))
+    connection.execute(text("COMMIT"))
+
+    # Step 2: backfill from legacy JSONB locations.
+    logger.info("Step 2/3: Backfilling messages.tags...")
+    _batched_update(connection, "messages.tags", BACKFILL_MESSAGES_SQL)
+
+    logger.info("Step 2/3: Backfilling posts.tags...")
+    _batched_update(connection, "posts.tags", BACKFILL_POSTS_SQL)
+
+    # Step 3: build GIN indexes CONCURRENTLY, drop the obsolete one.
+    logger.info("Step 3/3: Building GIN indexes...")
+    engine = connection.engine
+    with engine.connect() as conn:
+        conn = conn.execution_options(isolation_level="AUTOCOMMIT")
+        conn.execute(
+            text(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_messages_tags_gin "
+                "ON messages USING GIN (tags) WHERE tags IS NOT NULL"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_posts_tags_gin "
+                "ON posts USING GIN (tags) WHERE tags IS NOT NULL"
+            )
+        )
+        conn.execute(
+            text("DROP INDEX CONCURRENTLY IF EXISTS ix_messages_content_tags_gin")
+        )
+
+    if was_in_transaction:
+        connection.execute(text("BEGIN"))
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+
+    was_in_transaction = connection.in_transaction()
+    if was_in_transaction:
+        connection.execute(text("COMMIT"))
+
+    # Restore the previous POST-only JSONB GIN index, drop the new ones.
+    engine = connection.engine
+    with engine.connect() as conn:
+        conn = conn.execution_options(isolation_level="AUTOCOMMIT")
+        conn.execute(text("DROP INDEX CONCURRENTLY IF EXISTS ix_messages_tags_gin"))
+        conn.execute(text("DROP INDEX CONCURRENTLY IF EXISTS ix_posts_tags_gin"))
+        conn.execute(
+            text(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_messages_content_tags_gin "
+                "ON messages USING GIN ((content['content']['tags'])) "
+                "WHERE type = 'POST'"
+            )
+        )
+
+    connection.execute(text("BEGIN"))
+    connection.execute(text("ALTER TABLE messages DROP COLUMN IF EXISTS tags"))
+    connection.execute(text("ALTER TABLE posts DROP COLUMN IF EXISTS tags"))
+    connection.execute(text("COMMIT"))
+
+    if was_in_transaction:
+        connection.execute(text("BEGIN"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "aiohttp-swagger3>=0.10.0",
   "aioipfs~=0.7.1",
   "alembic==1.18.4",
-  "aleph-message==1.1.1",
+  "aleph-message @ git+https://github.com/aleph-im/aleph-message@3c71a82ca41245091767eb06889c69753df3658a",
   "aleph-nuls2==0.1.1",
   "aleph-p2p-client @ git+https://github.com/aleph-im/p2p-service-client-python@cbfebb871db94b2ca580e66104a67cd730c5020c",
   "asyncpg==0.31.0",

--- a/src/aleph/db/accessors/messages.py
+++ b/src/aleph/db/accessors/messages.py
@@ -131,9 +131,7 @@ def make_matching_messages_query(
     if content_keys:
         select_stmt = select_stmt.where(MessageDb.content_key.in_(content_keys))
     if tags:
-        select_stmt = select_stmt.where(
-            MessageDb.content["content"]["tags"].has_any(array(tags))
-        )
+        select_stmt = select_stmt.where(MessageDb.tags.overlap(array(tags)))
     if channels:
         select_stmt = select_stmt.where(MessageDb.channel.in_(channels))
     # Payment types - direct column, no JOIN to account_costs

--- a/src/aleph/db/accessors/posts.py
+++ b/src/aleph/db/accessors/posts.py
@@ -25,7 +25,7 @@ from sqlalchemy import (
     select,
     update,
 )
-from sqlalchemy.dialects.postgresql import JSONB, array
+from sqlalchemy.dialects.postgresql import ARRAY, array
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import Select
 
@@ -93,6 +93,7 @@ def make_select_merged_post_stmt() -> Select:
             Original.channel.label("channel"),
             Original.creation_datetime.label("created"),
             Original.type.label("original_type"),
+            func.coalesce(Amend.tags, Original.tags).label("tags"),
         ).join(
             Amend,
             Original.latest_amend == Amend.item_hash,
@@ -142,6 +143,7 @@ def make_select_merged_post_with_message_info_stmt() -> Select:
                 ),
                 Float,
             ).label("time"),
+            func.coalesce(Amend.tags, Original.tags).label("tags"),
         )
         .join(
             Amend,
@@ -231,7 +233,7 @@ def filter_post_select_stmt(
         select_stmt = select_stmt.where(literal_column("original_type").in_(post_types))
     if tags:
         select_stmt = select_stmt.where(
-            literal_column("content", type_=JSONB)["tags"].has_any(array(tags))
+            literal_column("tags", type_=ARRAY(String)).overlap(array(tags))
         )
     if channels:
         select_stmt = select_stmt.where(literal_column("channel").in_(channels))

--- a/src/aleph/db/models/messages.py
+++ b/src/aleph/db/models/messages.py
@@ -15,7 +15,6 @@ from aleph_message.models import (
 )
 from pydantic import ValidationError
 from sqlalchemy import (
-    ARRAY,
     TIMESTAMP,
     BigInteger,
     Column,
@@ -25,7 +24,7 @@ from sqlalchemy import (
     Table,
     UniqueConstraint,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy_utils.types.choice import ChoiceType
 
@@ -45,6 +44,42 @@ CONTENT_TYPE_MAP: Dict[MessageType, Type[BaseContent]] = {
     MessageType.program: ProgramContent,
     MessageType.store: StoreContent,
 }
+
+
+def extract_tags(
+    message_type: Any, content_dict: Mapping[str, Any]
+) -> Optional[List[str]]:
+    """Pull the tag list out of a content payload.
+
+    Tags live in different keys depending on the message type:
+
+    * POST + AGGREGATE: ``content -> 'content' -> 'tags'``
+    * STORE:            ``content -> 'tags'``
+    * INSTANCE/PROGRAM: ``content -> 'metadata' -> 'tags'``
+
+    Returns ``None`` when the message carries no tags so the caller can
+    leave the column NULL, distinguishable from an explicitly empty list.
+    """
+    if not isinstance(message_type, MessageType):
+        try:
+            message_type = MessageType(message_type)
+        except (ValueError, KeyError):
+            return None
+
+    if message_type in (MessageType.post, MessageType.aggregate):
+        inner = content_dict.get("content")
+        tags = inner.get("tags") if isinstance(inner, dict) else None
+    elif message_type == MessageType.store:
+        tags = content_dict.get("tags")
+    elif message_type in (MessageType.instance, MessageType.program):
+        metadata = content_dict.get("metadata")
+        tags = metadata.get("tags") if isinstance(metadata, dict) else None
+    else:
+        tags = None
+
+    if not isinstance(tags, list) or not tags:
+        return None
+    return [t for t in tags if isinstance(t, str)] or None
 
 
 message_confirmations = Table(
@@ -115,6 +150,7 @@ class MessageDb(Base):
             "first_confirmed_at",
             "first_confirmed_height",
             "payment_type",
+            "tags",
         }
     )
 
@@ -158,6 +194,7 @@ class MessageDb(Base):
     )
     payment_type: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     content_item_hash: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    tags: Mapped[Optional[List[str]]] = mapped_column(ARRAY(String), nullable=True)
 
     confirmations: Mapped[List[ChainTxDb]] = relationship(
         "ChainTxDb", secondary=message_confirmations
@@ -188,6 +225,9 @@ class MessageDb(Base):
             payment = content.get("payment")
             if isinstance(payment, dict) and payment.get("type"):
                 kwargs.setdefault("payment_type", payment["type"])
+            message_type = kwargs.get("type")
+            if message_type is not None:
+                kwargs.setdefault("tags", extract_tags(message_type, content))
         super().__init__(**kwargs)
         self._parsed_content: Optional[BaseContent] = None
 
@@ -256,6 +296,7 @@ class MessageDb(Base):
             content_key=content_dict.get("key"),
             content_item_hash=content_dict.get("item_hash"),
             payment_type=payment_type,
+            tags=extract_tags(pending_message.type, content_dict),
         )
         message._parsed_content = parsed_content
         return message

--- a/src/aleph/db/models/posts.py
+++ b/src/aleph/db/models/posts.py
@@ -1,8 +1,8 @@
 import datetime as dt
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from sqlalchemy import TIMESTAMP, ForeignKey, String
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from aleph.types.channel import Channel
@@ -27,3 +27,14 @@ class PostDb(Base):
     )
 
     latest_amend: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    tags: Mapped[Optional[List[str]]] = mapped_column(ARRAY(String), nullable=True)
+
+    def __init__(self, **kwargs: Any) -> None:
+        if "tags" not in kwargs:
+            content = kwargs.get("content")
+            if isinstance(content, dict):
+                raw = content.get("tags")
+                if isinstance(raw, list) and raw:
+                    cleaned = [t for t in raw if isinstance(t, str)]
+                    kwargs["tags"] = cleaned or None
+        super().__init__(**kwargs)

--- a/tests/api/test_list_messages.py
+++ b/tests/api/test_list_messages.py
@@ -269,6 +269,98 @@ async def test_get_messages_filter_by_tags_no_match(fixture_messages, ccn_api_cl
     assert len(messages) == 0
 
 
+# Tags live in a different JSONB key per message type. The denormalized
+# ``messages.tags`` column unifies them, so the filter must hit each type.
+TAGGED_MESSAGES_PER_TYPE: List[Tuple[str, str, str, Dict[str, Any]]] = [
+    ("hash-post", "POST", "only-post", {"content": {"tags": ["only-post", "shared"]}}),
+    (
+        "hash-aggr",
+        "AGGREGATE",
+        "only-aggr",
+        {"content": {"tags": ["only-aggr", "shared"]}},
+    ),
+    ("hash-stor", "STORE", "only-stor", {"tags": ["only-stor", "shared"]}),
+    (
+        "hash-inst",
+        "INSTANCE",
+        "only-inst",
+        {"metadata": {"tags": ["only-inst", "shared"]}},
+    ),
+    (
+        "hash-prog",
+        "PROGRAM",
+        "only-prog",
+        {"metadata": {"tags": ["only-prog", "shared"]}},
+    ),
+]
+
+
+@pytest_asyncio.fixture
+async def messages_with_tags_per_type(session_factory: DbSessionFactory):
+    """One message of each tagged content type, each carrying a unique tag
+    plus a ``shared`` tag, with tags stored at the legacy per-type key."""
+    common_time = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+    with session_factory() as session:
+        for item_hash, msg_type, _, content in TAGGED_MESSAGES_PER_TYPE:
+            session.add_all(
+                [
+                    MessageDb(
+                        item_hash=item_hash,
+                        chain="ETH",
+                        sender="0xtest",
+                        signature=None,
+                        item_type="storage",
+                        item_content=None,
+                        type=msg_type,
+                        content=content,
+                        time=common_time,
+                        channel=None,
+                        size=100,
+                    ),
+                    MessageStatusDb(
+                        item_hash=item_hash,
+                        status=MessageStatus.PROCESSED,
+                        reception_time=utc_now(),
+                    ),
+                ]
+            )
+        session.commit()
+
+
+@pytest.mark.parametrize(
+    "msg_type,unique_tag",
+    [(t, tag) for _, t, tag, _ in TAGGED_MESSAGES_PER_TYPE],
+)
+@pytest.mark.asyncio
+async def test_get_messages_filter_by_tags_per_type(
+    messages_with_tags_per_type,
+    ccn_api_client,
+    msg_type: str,
+    unique_tag: str,
+):
+    """A type-specific tag returns exactly the message of that type. Guards
+    against regressing back into the POST-only JSONB filter."""
+    response = await ccn_api_client.get(MESSAGES_URI, params={"tags": unique_tag})
+    assert response.status == 200, await response.text()
+    messages = (await response.json())["messages"]
+    assert len(messages) == 1
+    assert messages[0]["type"] == msg_type
+
+
+@pytest.mark.asyncio
+async def test_get_messages_filter_by_shared_tag_returns_all_types(
+    messages_with_tags_per_type,
+    ccn_api_client,
+):
+    """A tag carried by every type returns one match per type."""
+    response = await ccn_api_client.get(MESSAGES_URI, params={"tags": "shared"})
+    assert response.status == 200, await response.text()
+    messages = (await response.json())["messages"]
+    assert {m["type"] for m in messages} == {
+        t for _, t, _, _ in TAGGED_MESSAGES_PER_TYPE
+    }
+
+
 @pytest.mark.asyncio
 async def test_get_messages_filter_by_invalid_content_hash(
     fixture_messages, ccn_api_client


### PR DESCRIPTION
## Summary

- Adds `messages.tags TEXT[]` and `posts.tags TEXT[]` with GIN indexes, populated by an Alembic migration that backfills from the per-type JSONB locations and drops the obsolete POST-only `ix_messages_content_tags_gin`.
- Switches the tag filter on `/messages` and `/posts` from a JSONB `?|` probe (POST-only, full heap scan elsewhere) to `tags && ARRAY[...]` against the new column. Side effect: tag filtering now actually works for STORE / INSTANCE / PROGRAM.
- Models auto-extract tags from JSONB content based on message type at write time (`extract_tags` helper in `db/models/messages.py`, plus a tiny `PostDb.__init__`).
- Pins `aleph-message` to commit [`3c71a82`](https://github.com/aleph-im/aleph-message/commit/3c71a82ca41245091767eb06889c69753df3658a) (aleph-im/aleph-message#156, "Tighten tag storage per content type") so the schema matches the validator's per-type rules:
  * POST + AGGREGATE: `content -> 'content' -> 'tags'`
  * STORE:            `content -> 'tags'`
  * INSTANCE/PROGRAM: `content -> 'metadata' -> 'tags'`

## Migration notes

- Single migration `0056_7e5a630e4b36_denormalize_message_tags`: schema add, batched backfill (50k/batch with intermediate COMMITs), GIN indexes built `CONCURRENTLY` on a separate AUTOCOMMIT connection, then drop of the legacy index.
- Empty/absent tag lists stay `NULL` in the column (distinguishable from explicit `[]`).
- Downgrade restores the old POST-only JSONB GIN index and drops both new columns.

## Test plan

- [ ] `hatch run testing:test tests/api/test_list_messages.py::test_get_messages_filter_by_tags`
- [ ] `hatch run testing:test tests/api/test_list_messages.py::test_get_messages_filter_by_tags_per_type`
- [ ] `hatch run testing:test tests/api/test_list_messages.py::test_get_messages_filter_by_shared_tag_returns_all_types`
- [ ] `hatch run testing:test tests/api/test_posts.py::test_get_posts_tags`
- [ ] Run migration against a staging snapshot and spot-check `messages.tags` / `posts.tags` populated for each message type that carries tags
- [ ] `hatch run linting:all`