### PR TITLE
refactor: lift denormalized-column list to MessageDb.DENORMALIZED_COLUMNS

### DIFF
--- a/src/aleph/db/models/messages.py
+++ b/src/aleph/db/models/messages.py
@@ -1,5 +1,5 @@
 import datetime as dt
-from typing import Any, Dict, List, Mapping, Optional, Type
+from typing import Any, ClassVar, Dict, FrozenSet, List, Mapping, Optional, Type
 
 from aleph_message.models import (
     AggregateContent,
@@ -97,6 +97,26 @@ class MessageDb(Base):
     """
 
     __tablename__ = "messages"
+
+    # Column names that exist on the table for indexing/joining but are NOT
+    # part of the canonical aleph-message wire format. API responses and any
+    # ``MessageDb.to_dict()`` payload bound for an aleph-message validator
+    # must strip these — pydantic models like ``PostMessage`` use
+    # ``extra="forbid"`` and will reject a stray denormalized field.
+    DENORMALIZED_COLUMNS: ClassVar[FrozenSet[str]] = frozenset(
+        {
+            "status",
+            "reception_time",
+            "owner",
+            "content_type",
+            "content_ref",
+            "content_key",
+            "content_item_hash",
+            "first_confirmed_at",
+            "first_confirmed_height",
+            "payment_type",
+        }
+    )
 
     item_hash: Mapped[str] = mapped_column(String, primary_key=True)
     type: Mapped[MessageType] = mapped_column(ChoiceType(MessageType), nullable=False)

--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -299,18 +299,7 @@ def message_to_dict(
     message_dict["confirmed"] = bool(confirmations)
 
     # Remove denormalized columns from API response to avoid breaking SDKs
-    for key in (
-        "status",
-        "reception_time",
-        "owner",
-        "content_type",
-        "content_ref",
-        "content_key",
-        "content_item_hash",
-        "first_confirmed_at",
-        "first_confirmed_height",
-        "payment_type",
-    ):
+    for key in MessageDb.DENORMALIZED_COLUMNS:
         message_dict.pop(key, None)
 
     return message_dict

--- a/tests/api/test_list_messages.py
+++ b/tests/api/test_list_messages.py
@@ -841,26 +841,21 @@ async def test_owners_filter_ws_logic(owners_test_messages):
     # hash1: sender1, owner1
     # hash3: owner1, owner2
 
-    _denorm_cols = {
-        "status",
-        "reception_time",
-        "owner",
-        "content_type",
-        "content_ref",
-        "content_key",
-        "content_item_hash",
-        "first_confirmed_at",
-        "first_confirmed_height",
-        "payment_type",
-    }
-
     msg1_db = owners_test_messages[0]
-    msg1_dict = {k: v for k, v in msg1_db.to_dict().items() if k not in _denorm_cols}
+    msg1_dict = {
+        k: v
+        for k, v in msg1_db.to_dict().items()
+        if k not in MessageDb.DENORMALIZED_COLUMNS
+    }
     msg1_dict["time"] = msg1_db.time.timestamp()
     msg1_aleph = AlephPostMessage.model_validate(msg1_dict)
 
     msg3_db = owners_test_messages[2]
-    msg3_dict = {k: v for k, v in msg3_db.to_dict().items() if k not in _denorm_cols}
+    msg3_dict = {
+        k: v
+        for k, v in msg3_db.to_dict().items()
+        if k not in MessageDb.DENORMALIZED_COLUMNS
+    }
     msg3_dict["time"] = msg3_db.time.timestamp()
     msg3_aleph = AlephPostMessage.model_validate(msg3_dict)
 


### PR DESCRIPTION
## Summary

- Both `message_to_dict` (in `src/aleph/web/controllers/messages.py`) and `test_owners_filter_ws_logic` (in `tests/api/test_list_messages.py`) carry their own hardcoded copy of the columns to strip from a `MessageDb` payload before validating it against `aleph_message` schemas (which use `extra="forbid"`).
- Adding a new denormalized column requires remembering to update both lists; forgetting either leaks the column onto the wire (and breaks SDK clients that validate responses) or fails the WebSocket-filtering test.
- Lift the set onto the model as `MessageDb.DENORMALIZED_COLUMNS` (`ClassVar[FrozenSet[str]]`) so future denormalizations only need to extend a single source of truth. Behavior is unchanged.

## Test plan

- [ ] `hatch run testing:test tests/api/test_list_messages.py::test_owners_filter_ws_logic`
- [ ] `hatch run testing:test tests/api/test_list_messages.py -v`
- [ ] `hatch run linting:all`
- [ ] Spot-check `/messages.json` response shape unchanged (no denormalized columns leak)