### PR TITLE
feat: maintain eager running_balance on credit_balances writes

### DIFF
--- a/deployment/migrations/versions/0057_c7d8e9f0a1b2_add_credit_balances_running_balance.py
+++ b/deployment/migrations/versions/0057_c7d8e9f0a1b2_add_credit_balances_running_balance.py
@@ -1,0 +1,26 @@
+"""Add running_balance column to credit_balances for eager-maintained sum
+
+Revision ID: c7d8e9f0a1b2
+Revises: 7e5a630e4b36
+Create Date: 2026-05-08
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c7d8e9f0a1b2"
+down_revision = "7e5a630e4b36"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "credit_balances",
+        sa.Column("running_balance", sa.BigInteger(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("credit_balances", "running_balance")

--- a/deployment/scripts/backfill_credit_balances_running_balance.py
+++ b/deployment/scripts/backfill_credit_balances_running_balance.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Backfill credit_balances.running_balance for every address in credit_history.
+
+One-shot maintenance script. Run once after deploying the eager-update writers
+so existing addresses get their running_balance populated. Idempotent: a
+re-run recomputes from credit_history and overwrites.
+
+Per-address transactions keep the script restartable.
+
+Usage:
+    python deployment/scripts/backfill_credit_balances_running_balance.py
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+# Allow running this file directly from a repo checkout.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from sqlalchemy import func, select  # noqa: E402
+from sqlalchemy.dialects.postgresql import insert as pg_insert  # noqa: E402
+
+import aleph.config  # noqa: E402
+from aleph.db.connection import make_engine, make_session_factory  # noqa: E402
+from aleph.db.models import AlephCreditBalanceDb, AlephCreditHistoryDb  # noqa: E402
+from aleph.types.db_session import DbSessionFactory  # noqa: E402
+
+LOGGER = logging.getLogger("backfill_running_balance")
+
+
+def _list_addresses(session_factory: DbSessionFactory) -> list[str]:
+    with session_factory() as session:
+        return list(
+            session.execute(select(AlephCreditHistoryDb.address).distinct()).scalars()
+        )
+
+
+def _compute_running_balance(session_factory: DbSessionFactory, address: str) -> int:
+    with session_factory() as session:
+        result = session.execute(
+            select(func.coalesce(func.sum(AlephCreditHistoryDb.amount), 0)).where(
+                AlephCreditHistoryDb.address == address
+            )
+        ).scalar_one()
+        return int(result)
+
+
+def _upsert_running_balance(
+    session_factory: DbSessionFactory, address: str, running_balance: int
+) -> None:
+    with session_factory() as session:
+        stmt = pg_insert(AlephCreditBalanceDb).values(
+            address=address,
+            balance=0,
+            running_balance=running_balance,
+        )
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[AlephCreditBalanceDb.address],
+            set_={
+                "running_balance": stmt.excluded.running_balance,
+                "last_update": func.now(),
+            },
+        )
+        session.execute(stmt)
+        session.commit()
+
+
+def run(session_factory: DbSessionFactory, log_every: int = 100) -> None:
+    """Backfill running_balance for all addresses present in credit_history.
+
+    One transaction per address; safe to interrupt and resume.
+    """
+    addresses = _list_addresses(session_factory)
+    total = len(addresses)
+    LOGGER.info("backfilling running_balance for %d addresses", total)
+
+    for i, address in enumerate(addresses):
+        running = _compute_running_balance(session_factory, address)
+        _upsert_running_balance(session_factory, address, running)
+        if (i + 1) % log_every == 0:
+            LOGGER.info("backfilled %d / %d addresses", i + 1, total)
+
+    LOGGER.info("backfill complete (%d addresses)", total)
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        dest="config_file",
+        help="Path to the pyaleph YAML config file",
+    )
+    args = parser.parse_args()
+
+    config = aleph.config.app_config
+    if args.config_file is not None:
+        config.yaml.load(args.config_file)
+
+    engine = make_engine(config=config, application_name="backfill_running_balance")
+    session_factory = make_session_factory(engine)
+    run(session_factory)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from aleph_message.models import Chain
 from sqlalchemy import func, select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.sql import Select
 
 from aleph.db.models import AlephBalanceDb, AlephCreditBalanceDb, AlephCreditHistoryDb
@@ -550,16 +551,51 @@ def _format_csv_row(*fields) -> str:
     return output.getvalue().rstrip("\n")
 
 
+def _apply_balance_deltas(session: DbSession, deltas: Mapping[str, int]) -> None:
+    """Apply per-address signed deltas to credit_balances.running_balance atomically.
+
+    running_balance is the raw signed sum of all credit_history.amount rows for the
+    address, NOT FIFO-aware. The lazy FIFO recompute on the `balance` column remains
+    the source of truth for the API read path until the expiration cron lands.
+    See docs/superpowers/plans/2026-05-08-credit-balance-eager-cache.md.
+    """
+    if not deltas:
+        return
+
+    rows = [
+        {"address": addr, "running_balance": delta}
+        for addr, delta in deltas.items()
+        if delta != 0
+    ]
+    if not rows:
+        return
+
+    stmt = pg_insert(AlephCreditBalanceDb).values(rows)
+    stmt = stmt.on_conflict_do_update(
+        index_elements=[AlephCreditBalanceDb.address],
+        set_={
+            "running_balance": func.coalesce(AlephCreditBalanceDb.running_balance, 0)
+            + stmt.excluded.running_balance,
+            "last_update": func.now(),
+        },
+    )
+    session.execute(stmt)
+
+
 def _bulk_insert_credit_history(
     session: DbSession,
     csv_rows: Sequence[str],
+    balance_deltas: Mapping[str, int],
 ) -> None:
     """
-    Generic function to bulk insert credit history rows using temporary table.
+    Bulk insert credit history rows via temporary table, then atomically apply
+    running_balance deltas to credit_balances in the same transaction.
 
     Args:
         session: Database session
         csv_rows: List of CSV-formatted strings with credit history data
+        balance_deltas: Map of address -> signed delta to apply to
+            credit_balances.running_balance. Pass {} to skip eager cache update.
     """
 
     # Generate unique table name with timestamp and random suffix to avoid race conditions
@@ -603,6 +639,8 @@ def _bulk_insert_credit_history(
     # Drop the temporary table
     session.execute(text(f"DROP TABLE {temp_table_name}"))
 
+    _apply_balance_deltas(session, balance_deltas)
+
 
 def get_updated_credit_balance_accounts(session: DbSession, last_update: dt.datetime):
     """
@@ -633,11 +671,13 @@ def update_credit_balances_distribution(
 
     last_update = utc_now()
     csv_rows = []
+    deltas: dict[str, int] = {}
 
     for index, credit_entry in enumerate(credits_list):
         address = credit_entry["address"]
         raw_amount = int(credit_entry["amount"])
         amount = _apply_credit_precision_multiplier(raw_amount, message_timestamp)
+        deltas[address] = deltas.get(address, 0) + amount
         price = Decimal(credit_entry["price"])
         tx_hash = credit_entry["tx_hash"]
         provider = credit_entry["provider"]
@@ -677,7 +717,7 @@ def update_credit_balances_distribution(
             )
         )
 
-    _bulk_insert_credit_history(session, csv_rows)
+    _bulk_insert_credit_history(session, csv_rows, balance_deltas=deltas)
 
 
 def update_credit_balances_expense(
@@ -699,11 +739,13 @@ def update_credit_balances_expense(
 
     last_update = utc_now()
     csv_rows = []
+    deltas: dict[str, int] = {}
 
     for index, credit_entry in enumerate(credits_list):
         address = credit_entry["address"]
         raw_amount = int(credit_entry["amount"])
         amount = -_apply_credit_precision_multiplier(raw_amount, message_timestamp)
+        deltas[address] = deltas.get(address, 0) + amount
         origin_ref = credit_entry.get("ref", "")
 
         # Map new fields
@@ -733,7 +775,7 @@ def update_credit_balances_expense(
             )
         )
 
-    _bulk_insert_credit_history(session, csv_rows)
+    _bulk_insert_credit_history(session, csv_rows, balance_deltas=deltas)
 
 
 def update_credit_balances_transfer(
@@ -763,6 +805,7 @@ def update_credit_balances_transfer(
 
     last_update = utc_now()
     csv_rows = []
+    deltas: dict[str, int] = {}
     index = 0
     is_whitelisted = sender_address in whitelisted_addresses
 
@@ -800,6 +843,7 @@ def update_credit_balances_transfer(
 
         # Add positive entries for recipient (one per expiration group)
         for entry_amount, entry_expiration in entries:
+            deltas[recipient_address] = deltas.get(recipient_address, 0) + entry_amount
             csv_rows.append(
                 _format_csv_row(
                     recipient_address,
@@ -825,6 +869,7 @@ def update_credit_balances_transfer(
         # Add negative entry for sender (unless sender is in whitelisted addresses)
         # (origin = recipient, provider = ALEPH, payment_method = credit_transfer)
         if not is_whitelisted:
+            deltas[sender_address] = deltas.get(sender_address, 0) - amount
             csv_rows.append(
                 _format_csv_row(
                     sender_address,
@@ -847,7 +892,7 @@ def update_credit_balances_transfer(
             )
             index += 1
 
-    _bulk_insert_credit_history(session, csv_rows)
+    _bulk_insert_credit_history(session, csv_rows, balance_deltas=deltas)
 
 
 def validate_credit_transfer_balance(

--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -557,7 +557,6 @@ def _apply_balance_deltas(session: DbSession, deltas: Mapping[str, int]) -> None
     running_balance is the raw signed sum of all credit_history.amount rows for the
     address, NOT FIFO-aware. The lazy FIFO recompute on the `balance` column remains
     the source of truth for the API read path until the expiration cron lands.
-    See docs/superpowers/plans/2026-05-08-credit-balance-eager-cache.md.
     """
     if not deltas:
         return

--- a/src/aleph/db/models/balances.py
+++ b/src/aleph/db/models/balances.py
@@ -74,6 +74,9 @@ class AlephCreditBalanceDb(Base):
 
     address: Mapped[str] = mapped_column(String, primary_key=True, index=True)
     balance: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    running_balance: Mapped[Optional[int]] = mapped_column(
+        BigInteger, nullable=True, default=None
+    )
     last_update: Mapped[dt.datetime] = mapped_column(
         TIMESTAMP(timezone=True),
         nullable=False,

--- a/tests/db/test_backfill_credit_balances_running_balance.py
+++ b/tests/db/test_backfill_credit_balances_running_balance.py
@@ -1,0 +1,155 @@
+"""Tests for the running_balance backfill script."""
+
+import datetime as dt
+import importlib.util
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+
+from aleph.db.accessors.balances import (
+    update_credit_balances_distribution,
+    update_credit_balances_expense,
+)
+from aleph.db.models import AlephCreditBalanceDb
+from aleph.types.db_session import DbSessionFactory
+
+
+def _load_script_module():
+    """Load the backfill script as a module so we can call its `run` function."""
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = (
+        repo_root
+        / "deployment"
+        / "scripts"
+        / "backfill_credit_balances_running_balance.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "backfill_running_balance", script_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def backfill_module():
+    return _load_script_module()
+
+
+def _seed_history(session_factory: DbSessionFactory) -> None:
+    """Seed credit_history with two addresses then null out running_balance to
+    simulate a DB that pre-dates the eager-update writers."""
+    dist_ts = dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+    exp_ts = dt.datetime(2023, 1, 2, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        update_credit_balances_distribution(
+            session=session,
+            credits_list=[
+                {
+                    "address": "0xbf_a",
+                    "amount": 1000,
+                    "price": "0.1",
+                    "tx_hash": "0xtx",
+                    "provider": "p",
+                },
+                {
+                    "address": "0xbf_b",
+                    "amount": 500,
+                    "price": "0.1",
+                    "tx_hash": "0xtx",
+                    "provider": "p",
+                },
+            ],
+            token="ALEPH",
+            chain="ETH",
+            message_hash="msg_bf_dist",
+            message_timestamp=dist_ts,
+        )
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[{"address": "0xbf_a", "amount": 200, "ref": "r"}],
+            message_hash="msg_bf_exp",
+            message_timestamp=exp_ts,
+        )
+        for address in ("0xbf_a", "0xbf_b"):
+            row = session.execute(
+                select(AlephCreditBalanceDb).where(
+                    AlephCreditBalanceDb.address == address
+                )
+            ).scalar_one()
+            row.running_balance = None
+        session.commit()
+
+
+def test_backfill_populates_running_balance_from_history(
+    session_factory: DbSessionFactory, backfill_module
+):
+    _seed_history(session_factory)
+
+    backfill_module.run(session_factory)
+
+    with session_factory() as session:
+        row_a = session.execute(
+            select(AlephCreditBalanceDb).where(AlephCreditBalanceDb.address == "0xbf_a")
+        ).scalar_one()
+        row_b = session.execute(
+            select(AlephCreditBalanceDb).where(AlephCreditBalanceDb.address == "0xbf_b")
+        ).scalar_one()
+        assert row_a.running_balance == 800 * 10000
+        assert row_b.running_balance == 500 * 10000
+
+
+def test_backfill_is_idempotent(session_factory: DbSessionFactory, backfill_module):
+    _seed_history(session_factory)
+
+    backfill_module.run(session_factory)
+    backfill_module.run(session_factory)
+
+    with session_factory() as session:
+        row_a = session.execute(
+            select(AlephCreditBalanceDb).where(AlephCreditBalanceDb.address == "0xbf_a")
+        ).scalar_one()
+        assert row_a.running_balance == 800 * 10000
+
+
+def test_backfill_creates_row_for_address_with_no_credit_balance(
+    session_factory: DbSessionFactory, backfill_module
+):
+    """If credit_history has an address but credit_balances does not, backfill creates the row."""
+    dist_ts = dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        update_credit_balances_distribution(
+            session=session,
+            credits_list=[
+                {
+                    "address": "0xbf_orphan",
+                    "amount": 42,
+                    "price": "0.1",
+                    "tx_hash": "0xtx",
+                    "provider": "p",
+                }
+            ],
+            token="ALEPH",
+            chain="ETH",
+            message_hash="msg_bf_orphan",
+            message_timestamp=dist_ts,
+        )
+        session.execute(
+            AlephCreditBalanceDb.__table__.delete().where(
+                AlephCreditBalanceDb.address == "0xbf_orphan"
+            )
+        )
+        session.commit()
+
+    backfill_module.run(session_factory)
+
+    with session_factory() as session:
+        row = session.execute(
+            select(AlephCreditBalanceDb).where(
+                AlephCreditBalanceDb.address == "0xbf_orphan"
+            )
+        ).scalar_one()
+        assert row.running_balance == 42 * 10000

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -3,10 +3,11 @@ import time
 from decimal import Decimal
 from typing import Any, Dict, List
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy import update as sql_update
 
 from aleph.db.accessors.balances import (
+    _apply_balance_deltas,
     count_address_credit_history,
     get_address_credit_history,
     get_consumed_credits_by_resource,
@@ -2488,3 +2489,358 @@ def test_cursor_pagination_nullable_sort_nulls_on_last_page(
         )
         assert len(all_refs) == 5
         assert len(set(all_refs)) == 5
+
+
+# ---------------------------------------------------------------------------
+# Eager running_balance maintenance
+# ---------------------------------------------------------------------------
+
+
+def test_credit_balance_model_exposes_running_balance(
+    session_factory: DbSessionFactory,
+):
+    """The new running_balance column is mapped on the ORM and is nullable."""
+    with session_factory() as session:
+        session.add(
+            AlephCreditBalanceDb(
+                address="0xrunning",
+                balance=0,
+                running_balance=42,
+            )
+        )
+        session.commit()
+        row = session.execute(
+            select(AlephCreditBalanceDb).where(
+                AlephCreditBalanceDb.address == "0xrunning"
+            )
+        ).scalar_one()
+        assert row.running_balance == 42
+
+        session.add(AlephCreditBalanceDb(address="0xnull", balance=0))
+        session.commit()
+        row2 = session.execute(
+            select(AlephCreditBalanceDb).where(AlephCreditBalanceDb.address == "0xnull")
+        ).scalar_one()
+        assert row2.running_balance is None
+
+
+def test_apply_balance_deltas_inserts_new_row(session_factory: DbSessionFactory):
+    """Applying a delta for an unknown address creates a new row with that delta."""
+    with session_factory() as session:
+        _apply_balance_deltas(session, {"0xfresh": 1234})
+        session.commit()
+        row = session.execute(
+            select(AlephCreditBalanceDb).where(
+                AlephCreditBalanceDb.address == "0xfresh"
+            )
+        ).scalar_one()
+        assert row.running_balance == 1234
+
+
+def test_apply_balance_deltas_increments_existing_row(
+    session_factory: DbSessionFactory,
+):
+    """Applying a delta for an existing row adds to its running_balance."""
+    with session_factory() as session:
+        session.add(
+            AlephCreditBalanceDb(address="0xseed", balance=0, running_balance=1000)
+        )
+        session.commit()
+        _apply_balance_deltas(session, {"0xseed": 250})
+        session.commit()
+        row = session.execute(
+            select(AlephCreditBalanceDb).where(AlephCreditBalanceDb.address == "0xseed")
+        ).scalar_one()
+        assert row.running_balance == 1250
+
+
+def test_apply_balance_deltas_handles_negative_delta(
+    session_factory: DbSessionFactory,
+):
+    """Negative deltas reduce running_balance, including below zero."""
+    with session_factory() as session:
+        session.add(
+            AlephCreditBalanceDb(address="0xspend", balance=0, running_balance=100)
+        )
+        session.commit()
+        _apply_balance_deltas(session, {"0xspend": -150})
+        session.commit()
+        row = session.execute(
+            select(AlephCreditBalanceDb).where(
+                AlephCreditBalanceDb.address == "0xspend"
+            )
+        ).scalar_one()
+        assert row.running_balance == -50
+
+
+def test_apply_balance_deltas_initialises_running_balance_when_null(
+    session_factory: DbSessionFactory,
+):
+    """A row whose running_balance is NULL (pre-backfill) gets initialised."""
+    with session_factory() as session:
+        session.add(
+            AlephCreditBalanceDb(address="0xnull2", balance=99, running_balance=None)
+        )
+        session.commit()
+        _apply_balance_deltas(session, {"0xnull2": 7})
+        session.commit()
+        row = session.execute(
+            select(AlephCreditBalanceDb).where(
+                AlephCreditBalanceDb.address == "0xnull2"
+            )
+        ).scalar_one()
+        assert row.running_balance == 7
+
+
+def test_apply_balance_deltas_no_op_on_empty(session_factory: DbSessionFactory):
+    """Empty mapping produces no SQL and no rows."""
+    with session_factory() as session:
+        _apply_balance_deltas(session, {})
+        session.commit()
+        count = session.execute(
+            select(func.count()).select_from(AlephCreditBalanceDb)
+        ).scalar_one()
+        assert count == 0
+
+
+def test_apply_balance_deltas_skips_zero_delta(session_factory: DbSessionFactory):
+    """A delta of zero does not create or modify a row."""
+    with session_factory() as session:
+        _apply_balance_deltas(session, {"0xzero": 0})
+        session.commit()
+        row = session.execute(
+            select(AlephCreditBalanceDb).where(AlephCreditBalanceDb.address == "0xzero")
+        ).scalar_one_or_none()
+        assert row is None
+
+
+def test_distribution_updates_running_balance(
+    session_factory: DbSessionFactory,
+):
+    """A distribution writes credits to credit_history AND increments running_balance."""
+    credits_list = [
+        {
+            "address": "0xrecipient1",
+            "amount": 100,
+            "price": "0.1",
+            "tx_hash": "0xtx1",
+            "provider": "test_provider",
+        },
+        {
+            "address": "0xrecipient2",
+            "amount": 250,
+            "price": "0.1",
+            "tx_hash": "0xtx1",
+            "provider": "test_provider",
+        },
+    ]
+    message_timestamp = dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        update_credit_balances_distribution(
+            session=session,
+            credits_list=credits_list,
+            token="ALEPH",
+            chain="ETH",
+            message_hash="msg_dist_eager_1",
+            message_timestamp=message_timestamp,
+        )
+        session.commit()
+
+        row1 = session.execute(
+            select(AlephCreditBalanceDb).where(
+                AlephCreditBalanceDb.address == "0xrecipient1"
+            )
+        ).scalar_one()
+        row2 = session.execute(
+            select(AlephCreditBalanceDb).where(
+                AlephCreditBalanceDb.address == "0xrecipient2"
+            )
+        ).scalar_one()
+        assert row1.running_balance == 100 * 10000
+        assert row2.running_balance == 250 * 10000
+
+
+def test_distribution_with_repeated_address_sums_deltas(
+    session_factory: DbSessionFactory,
+):
+    """Two entries to the same address in one distribution add up."""
+    credits_list = [
+        {
+            "address": "0xsame",
+            "amount": 100,
+            "price": "0.1",
+            "tx_hash": "0xtx",
+            "provider": "p",
+        },
+        {
+            "address": "0xsame",
+            "amount": 50,
+            "price": "0.1",
+            "tx_hash": "0xtx",
+            "provider": "p",
+        },
+    ]
+    message_timestamp = dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        update_credit_balances_distribution(
+            session=session,
+            credits_list=credits_list,
+            token="ALEPH",
+            chain="ETH",
+            message_hash="msg_dist_eager_repeat",
+            message_timestamp=message_timestamp,
+        )
+        session.commit()
+
+        row = session.execute(
+            select(AlephCreditBalanceDb).where(AlephCreditBalanceDb.address == "0xsame")
+        ).scalar_one()
+        assert row.running_balance == 150 * 10000
+
+
+def test_expense_updates_running_balance(session_factory: DbSessionFactory):
+    """An expense decrements running_balance, even when no row pre-exists."""
+    credits_list = [
+        {"address": "0xspender", "amount": 75, "ref": "exp_ref"},
+    ]
+    message_timestamp = dt.datetime(2023, 1, 2, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        update_credit_balances_expense(
+            session=session,
+            credits_list=credits_list,
+            message_hash="msg_expense_eager_1",
+            message_timestamp=message_timestamp,
+        )
+        session.commit()
+
+        row = session.execute(
+            select(AlephCreditBalanceDb).where(
+                AlephCreditBalanceDb.address == "0xspender"
+            )
+        ).scalar_one()
+        assert row.running_balance == -75 * 10000
+
+
+def test_expense_decrements_existing_running_balance(
+    session_factory: DbSessionFactory,
+):
+    """An expense applied after a distribution leaves the correct net running_balance."""
+    address = "0xnet"
+    dist_ts = dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+    exp_ts = dt.datetime(2023, 1, 2, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        update_credit_balances_distribution(
+            session=session,
+            credits_list=[
+                {
+                    "address": address,
+                    "amount": 1000,
+                    "price": "0.1",
+                    "tx_hash": "0xt",
+                    "provider": "p",
+                }
+            ],
+            token="ALEPH",
+            chain="ETH",
+            message_hash="msg_dist_net",
+            message_timestamp=dist_ts,
+        )
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[{"address": address, "amount": 300, "ref": "r"}],
+            message_hash="msg_exp_net",
+            message_timestamp=exp_ts,
+        )
+        session.commit()
+
+        row = session.execute(
+            select(AlephCreditBalanceDb).where(AlephCreditBalanceDb.address == address)
+        ).scalar_one()
+        assert row.running_balance == (1000 - 300) * 10000
+
+
+def test_transfer_updates_running_balance_for_sender_and_recipient(
+    session_factory: DbSessionFactory,
+):
+    """A transfer subtracts from the sender's running_balance and adds to recipients."""
+    sender = "0xtsender"
+    recipient = "0xtrecipient"
+
+    dist_ts = dt.datetime(2023, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+    transfer_ts = dt.datetime(2023, 1, 3, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        update_credit_balances_distribution(
+            session=session,
+            credits_list=[
+                {
+                    "address": sender,
+                    "amount": 500,
+                    "price": "1.0",
+                    "tx_hash": "0xfund",
+                    "provider": "p",
+                }
+            ],
+            token="ALEPH",
+            chain="ETH",
+            message_hash="msg_seed_transfer",
+            message_timestamp=dist_ts,
+        )
+
+        update_credit_balances_transfer(
+            session=session,
+            credits_list=[{"address": recipient, "amount": 200}],
+            sender_address=sender,
+            whitelisted_addresses=[],
+            message_hash="msg_transfer_eager",
+            message_timestamp=transfer_ts,
+        )
+        session.commit()
+
+        sender_row = session.execute(
+            select(AlephCreditBalanceDb).where(AlephCreditBalanceDb.address == sender)
+        ).scalar_one()
+        recipient_row = session.execute(
+            select(AlephCreditBalanceDb).where(
+                AlephCreditBalanceDb.address == recipient
+            )
+        ).scalar_one()
+
+        assert sender_row.running_balance == (500 - 200) * 10000
+        assert recipient_row.running_balance == 200 * 10000
+
+
+def test_transfer_from_whitelisted_only_credits_recipient(
+    session_factory: DbSessionFactory,
+):
+    """Whitelisted senders are not debited; recipient still receives."""
+    sender = "0xwhitelisted"
+    recipient = "0xrecv_w"
+    transfer_ts = dt.datetime(2023, 1, 3, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        update_credit_balances_transfer(
+            session=session,
+            credits_list=[{"address": recipient, "amount": 75}],
+            sender_address=sender,
+            whitelisted_addresses=[sender],
+            message_hash="msg_wl_transfer",
+            message_timestamp=transfer_ts,
+        )
+        session.commit()
+
+        sender_row = session.execute(
+            select(AlephCreditBalanceDb).where(AlephCreditBalanceDb.address == sender)
+        ).scalar_one_or_none()
+        recipient_row = session.execute(
+            select(AlephCreditBalanceDb).where(
+                AlephCreditBalanceDb.address == recipient
+            )
+        ).scalar_one()
+
+        assert sender_row is None
+        assert recipient_row.running_balance == 75 * 10000


### PR DESCRIPTION
## Summary
- Add `running_balance` column to `credit_balances`, maintained atomically by the three `credit_history` writers (distribution, expense, transfer) via a new `_apply_balance_deltas` UPSERT helper inside the existing `_bulk_insert_credit_history` chokepoint.
- The existing FIFO-derived `balance` column and the lazy recompute in `get_credit_balance` are left untouched, so the `/api/v0/addresses/{address}/balance` read-path semantics are preserved during this groundwork commit.
- Add `deployment/scripts/backfill_credit_balances_running_balance.py` to populate `running_balance` for existing addresses from `credit_history` (one transaction per address, idempotent via UPSERT).

## Motivation
The current balance endpoint triggers an O(N^2) Python FIFO recompute over every `credit_history` row for the address on every cache miss, which is why CLI lookups for VM-heavy addresses are slow. This PR is step 1 of the rework: eager-maintain a per-address running sum on every write, so a follow-up can switch the read path to an O(1) cache lookup once expiration handling is added.

Full design and migration order: `docs/superpowers/plans/2026-05-08-credit-balance-eager-cache.md`.

## Scope of this PR
- Migration `0057_c7d8e9f0a1b2_add_credit_balances_running_balance` adds the nullable `running_balance` BIGINT column.
- Model `AlephCreditBalanceDb` maps the new column.
- `_apply_balance_deltas(session, deltas)` performs a `pg_insert ... ON CONFLICT DO UPDATE` against `credit_balances`, summing into the existing `running_balance` (with `COALESCE(running_balance, 0)` to handle pre-backfill rows).
- The three writer functions accumulate per-address signed deltas while building their CSV rows and pass them to `_bulk_insert_credit_history`, which applies them in the same transaction as the history insert.

## Out of scope (next PR)
- Expiration cron / `next_expiration_at` column.
- Switching `get_credit_balance` to read from `running_balance`.
- Removing the FIFO recompute from the read path.
- Behaviour of `validate_credit_transfer_balance`.

## Test plan
- [ ] `tests/db/test_credit_balances.py` covers the new helper (insert, increment, negative delta, null initial, empty mapping, zero delta) and the eager updates from each writer (distribution, repeated-address, expense, dist-then-expense, non-whitelisted transfer, whitelisted transfer).
- [ ] `tests/db/test_backfill_credit_balances_running_balance.py` covers backfill from history, idempotence, and creation of `credit_balances` rows for addresses that don't yet have one.
- [ ] Pre-existing balance/credit/transfer tests should remain green (no behaviour change on read path).
- [ ] Manual: run the backfill script against staging once the migration is applied; verify the resulting `running_balance` matches what the existing FIFO recompute would produce for a sample of addresses.