### PR TITLE
feat: drain credit lots soonest-expiring first

### DIFF
--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -274,18 +274,23 @@ def _consume_address_credits(
     amount: int,
     message_timestamp: dt.datetime,
 ) -> List[Tuple[int, Optional[dt.datetime]]]:
-    """Drain ``amount`` from the address's still-valid lots in emission order.
+    """Drain ``amount`` from the address's still-valid lots, soonest-expiring first.
 
     Returns ``(consumed_amount, source_expiration)`` per touched lot in
     consumption order. Each touched lot has its ``amount_remaining`` decremented
     in place.
 
-    Emission order matches the historical FIFO: ``(message_timestamp, credit_ref,
-    credit_index) ASC``. ``message_timestamp`` is the cutoff for "still valid":
-    only lots with ``expiration_date IS NULL OR expiration_date > message_timestamp``
-    are eligible. Using the message timestamp (not wall-clock now) keeps eager
-    writes consistent with the repair replay, which uses the historical timestamp
-    when reconstructing state from ``credit_history``.
+    Drain order is ``expiration_date ASC NULLS LAST``, with emission order
+    (``message_timestamp, credit_ref, credit_index``) ASC as the tiebreaker so
+    two lots sharing an expiration drain in a deterministic, replay-stable
+    sequence. Spending the soonest-expiring credit first preserves longer-lived
+    credits and matches the user-facing "use it or lose it" model.
+
+    ``message_timestamp`` is the cutoff for "still valid": only lots with
+    ``expiration_date IS NULL OR expiration_date > message_timestamp`` are
+    eligible. Using the message timestamp (not wall-clock now) keeps eager
+    writes consistent with the repair replay, which uses the historical
+    timestamp when reconstructing state from ``credit_history``.
 
     Lots are locked ``FOR UPDATE`` to serialise concurrent writers for the same
     address. Over-draw silently drops the excess, matching the prior FIFO
@@ -306,6 +311,7 @@ def _consume_address_credits(
                 ),
             )
             .order_by(
+                AlephCreditBalanceDb.expiration_date.asc().nullslast(),
                 AlephCreditBalanceDb.message_timestamp.asc(),
                 AlephCreditBalanceDb.credit_ref.asc(),
                 AlephCreditBalanceDb.credit_index.asc(),

--- a/src/aleph/repair.py
+++ b/src/aleph/repair.py
@@ -54,12 +54,13 @@ def _rebuild_credit_lots_for_address(session: DbSession, address: str) -> None:
     Idempotent: clears existing lots for the address first, then rebuilds. Safe
     to interrupt at address granularity (callers commit per-address).
 
-    Replays in emission order ``(message_timestamp, credit_ref, credit_index)
-    ASC``, the same ordering the eager writers see. Each positive history row
-    becomes a lot; each negative row drains lots in emission order, skipping
-    any whose expiration is at or before the negative row's
-    ``message_timestamp`` (so an expense from the past does not drain a lot
-    that had already expired at that moment).
+    Walks history in emission order ``(message_timestamp, credit_ref,
+    credit_index) ASC``. Each positive row becomes a lot. Each negative row
+    drains lots soonest-expiring first (ties broken by emission order),
+    skipping any lot whose expiration is at or before the negative row's
+    ``message_timestamp`` so an expense from the past does not drain a lot
+    that had already expired at that moment. This matches the eager writer's
+    drain policy in ``_consume_address_credits``.
     """
     session.execute(
         delete(AlephCreditBalanceDb).where(AlephCreditBalanceDb.address == address)
@@ -80,6 +81,18 @@ def _rebuild_credit_lots_for_address(session: DbSession, address: str) -> None:
     )
 
     lots: list[dict] = []
+
+    def _drain_order_key(lot: dict) -> tuple:
+        # expiration_date ASC NULLS LAST, then emission tiebreakers
+        exp = lot["expiration_date"]
+        return (
+            exp is None,
+            exp,
+            lot["message_timestamp"],
+            lot["credit_ref"],
+            lot["credit_index"],
+        )
+
     for record in records:
         if record.amount > 0:
             lots.append(
@@ -93,7 +106,7 @@ def _rebuild_credit_lots_for_address(session: DbSession, address: str) -> None:
             )
         else:
             remaining = -int(record.amount)
-            for lot in lots:
+            for lot in sorted(lots, key=_drain_order_key):
                 if remaining <= 0:
                     break
                 if lot["amount_remaining"] <= 0:

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -619,19 +619,21 @@ def test_balance_fix_doesnt_affect_valid_credits(session_factory: DbSessionFacto
         assert balance > 0
 
 
-def test_fifo_scenario_1_non_expiring_first_equals_0_remaining(
+def test_drain_consumes_soonest_expiring_first_non_expiring_arrives_first(
     session_factory: DbSessionFactory,
 ):
     """
-    FIFO Scenario 1: Non-expiring credits received FIRST → Result: 0 remaining
+    Expiration-first drain, when the non-expiring lot arrives first:
 
     Setup:
-    - 1000 non-expiring credits (received FIRST at T1)
-    - 1000 expiring credits (received SECOND at T2, expire at T4)
+    - 1000 non-expiring credits (received at T1, FIRST in emission order)
+    - 1000 expiring credits (received at T2, SECOND in emission order; expire at T4)
     - 1500 expense at T3 (before expiration at T4)
 
-    FIFO Consumption: 1000 (non-expiring) + 500 (expiring) = 1500 total consumed
-    Final Balance: 0 (non-expiring remaining) + 500 (expiring remaining but expired) = 0
+    Drain order is by expiration-date ASC NULLS LAST, so the expiring lot is
+    spent first even though it arrived later: 1000 (expiring) + 500
+    (non-expiring) = 1500 consumed. After T4, the expiring lot is past its
+    expiration so it no longer counts, and 500 non-expiring credits survive.
     """
 
     # Use fixed timestamps before the credit precision cutoff (2026-02-02)
@@ -722,26 +724,29 @@ def test_fifo_scenario_1_non_expiring_first_equals_0_remaining(
             session, "0xcorner_case_user", now_time
         )
 
-        # Expected: 0 remaining (all non-expiring consumed, expiring remainder expired)
-        expected_balance = 0
+        # Expected: 500 non-expiring credits survive (5_000_000 with the
+        # 10_000 precision multiplier applied to pre-cutoff messages).
+        expected_balance = 5_000_000
         assert (
             balance_after_expiration == expected_balance
-        ), f"Scenario 1: Expected {expected_balance} remaining credits, got {balance_after_expiration}"
+        ), f"Expected {expected_balance} remaining credits, got {balance_after_expiration}"
 
 
-def test_fifo_scenario_2_expiring_first_equals_500_remaining(
+def test_drain_consumes_soonest_expiring_first_expiring_arrives_first(
     session_factory: DbSessionFactory,
 ):
     """
-    FIFO Scenario 2: Expiring credits received FIRST → Result: 500 remaining
+    Expiration-first drain, when the expiring lot arrives first:
 
     Setup:
-    - 1000 expiring credits (received FIRST at T1, expire at T4)
-    - 1000 non-expiring credits (received SECOND at T2)
+    - 1000 expiring credits (received at T1, FIRST in emission order; expire at T4)
+    - 1000 non-expiring credits (received at T2, SECOND in emission order)
     - 1500 expense at T3 (before expiration at T4)
 
-    FIFO Consumption: 1000 (expiring) + 500 (non-expiring) = 1500 total consumed
-    Final Balance: 0 (expiring remaining but expired) + 500 (non-expiring remaining) = 500
+    Drain order is by expiration-date ASC NULLS LAST, so the expiring lot is
+    still spent first: 1000 (expiring) + 500 (non-expiring) = 1500 consumed.
+    After T4, the expiring remainder is past its expiration so it no longer
+    counts, and 500 non-expiring credits survive.
     """
 
     # Use fixed timestamps before the credit precision cutoff (2026-02-02)
@@ -832,11 +837,12 @@ def test_fifo_scenario_2_expiring_first_equals_500_remaining(
             session, "0xscenario2_user", now_time
         )
 
-        # Expected: 5000000 remaining (500 * 10000 multiplier - expiring consumed and expired, non-expiring remainder survives)
-        expected_balance = 5000000
+        # Expected: 500 non-expiring credits survive (5_000_000 with the
+        # 10_000 precision multiplier applied to pre-cutoff messages).
+        expected_balance = 5_000_000
         assert (
             balance_after_expiration == expected_balance
-        ), f"Scenario 2: Expected {expected_balance} remaining credits, got {balance_after_expiration}"
+        ), f"Expected {expected_balance} remaining credits, got {balance_after_expiration}"
 
 
 def test_cache_invalidation_on_credit_expiration(session_factory: DbSessionFactory):
@@ -1650,12 +1656,12 @@ def test_credit_balance_details_mixed_expiration(session_factory: DbSessionFacto
 
 
 def test_credit_balance_details_partial_consumption(session_factory: DbSessionFactory):
-    """Details are accurate after FIFO partial consumption."""
+    """Details are accurate after partial consumption (expiration-first drain)."""
     ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
     exp1 = dt.datetime(2026, 9, 1, tzinfo=dt.timezone.utc)
 
     entries = [
-        # Non-expiring credit (oldest, consumed first by FIFO)
+        # Non-expiring credit (oldest in emission order)
         {
             "address": "0xdetails3",
             "amount": 1000,
@@ -1665,7 +1671,8 @@ def test_credit_balance_details_partial_consumption(session_factory: DbSessionFa
             "last_update": ts,
             "expiration_date": None,
         },
-        # Expiring credit
+        # Expiring credit (newer in emission order, but drained first because
+        # its expiration is soonest).
         {
             "address": "0xdetails3",
             "amount": 500,
@@ -1675,7 +1682,8 @@ def test_credit_balance_details_partial_consumption(session_factory: DbSessionFa
             "last_update": ts,
             "expiration_date": exp1,
         },
-        # Expense consuming 700 from the oldest (non-expiring) credit
+        # Expense consuming 700: drains the 500 expiring lot first, then 200
+        # from the non-expiring lot.
         {
             "address": "0xdetails3",
             "amount": -700,
@@ -1695,13 +1703,11 @@ def test_credit_balance_details_partial_consumption(session_factory: DbSessionFa
         total, details = get_credit_balance_with_details(
             session=session, address="0xdetails3"
         )
-        # 1000 - 700 = 300 non-expiring remaining, 500 expiring remaining
+        # 1000 - 200 = 800 non-expiring remaining, 500 - 500 = 0 expiring
         assert total == 800
-        assert len(details) == 2
+        assert len(details) == 1
         assert details[0].expiration_date is None
-        assert details[0].amount == 300
-        assert details[1].expiration_date == exp1
-        assert details[1].amount == 500
+        assert details[0].amount == 800
 
 
 def test_credit_balance_details_fully_consumed(session_factory: DbSessionFactory):
@@ -1841,7 +1847,8 @@ def test_credit_balance_details_matches_total(session_factory: DbSessionFactory)
             "last_update": ts,
             "expiration_date": exp2,
         },
-        # Expense consuming 1200 total (FIFO: 1000 from non-expiring, 200 from exp1)
+        # Expense consuming 1200 total: drains soonest-expiring first → 800
+        # from exp1, then 400 from exp2; non-expiring lot is preserved.
         {
             "address": "0xdetails6",
             "amount": -1200,
@@ -1861,16 +1868,16 @@ def test_credit_balance_details_matches_total(session_factory: DbSessionFactory)
         total, details = get_credit_balance_with_details(
             session=session, address="0xdetails6"
         )
-        # 1000 - 1000 = 0 non-expiring, 800 - 200 = 600 exp1, 600 exp2
+        # 1000 non-expiring untouched, 800 - 800 = 0 exp1, 600 - 400 = 200 exp2
         assert total == 1200
         details_sum = sum(d.amount for d in details)
         assert details_sum == total
 
         assert len(details) == 2
-        assert details[0].expiration_date == exp1
-        assert details[0].amount == 600
+        assert details[0].expiration_date is None
+        assert details[0].amount == 1000
         assert details[1].expiration_date == exp2
-        assert details[1].amount == 600
+        assert details[1].amount == 200
 
 
 # ── Volume (origin_ref) consumed credits tests ───────────────────────


### PR DESCRIPTION
## Summary

Follow-up to #1122 (the eager-write lot cache). Switches the drain policy from emission-order to expiration-order:

- `_consume_address_credits` now drains lots `ORDER BY expiration_date ASC NULLS LAST, message_timestamp ASC, credit_ref ASC, credit_index ASC`. Emission order remains the tiebreaker for replay stability.
- `_rebuild_credit_lots_for_address` mirrors the same drain policy when replaying history.

This is the end state #1121 was aiming for, but on top of the per-lot keying we already shipped instead of the bucket-per-expiration shape. Reads (`get_credit_balance`, `get_credit_balance_with_details`, paginated listings) are unchanged: they already sum over still-valid lots regardless of order.

## Behavioural change

User-facing: a spend now consumes the credit lot that is closest to expiring first, before touching longer-lived (or non-expiring) credits. This matches the "use it or lose it" model end-users expect.

## ⚠️ Consensus risk to discuss before merging

The switch is unconditional — there is no time gate. After this PR ships:

- All future expense / transfer messages are processed under expiration-first.
- The startup repair (`_rebuild_credit_lots_for_address`) replays the entire `credit_history` under the new policy, so per-address lot states **derived from history may differ** from what was actually used to validate past transfers (which were processed under emission-first).

In practice every node converges on the same balances after restart because they all replay the same `credit_history` with the same code. But any consumer that observed pre-deploy balances and acted on them under the old policy is no longer reproducible from the post-deploy node.

If we want a hard cutover that preserves historical state byte-for-byte, the alternative is to gate on `message_timestamp` with a new `CREDIT_EXPIRATION_FIRST_CUTOFF_TIMESTAMP` (mirroring `CREDIT_PRECISION_CUTOFF_TIMESTAMP`): emission-first for `< cutoff`, expiration-first for `>= cutoff`. Happy to add that gate before merge — say the word.

## Test plan

- [ ] CI green (postgres-backed tests cover the eager-write drain order)
- [ ] Verify the two renamed scenario tests pass under the new policy
- [ ] Verify the details breakdown tests pass with the updated expectations
- [ ] Manual spot-check: distribute mixed lots, spend, confirm the soonest-expiring lot is drained first