### PR TITLE
Speed up get_unconfirmed_messages with denormalized first_confirmed_at

### DIFF
--- a/src/aleph/chains/ethereum.py
+++ b/src/aleph/chains/ethereum.py
@@ -411,7 +411,6 @@ class EthereumConnector(ChainWriter):
                                 session=session,
                                 limit=500,
                                 offset=offset,
-                                chain=Chain.ETH,
                             )
                         )
                         if not batch:

--- a/src/aleph/chains/nuls2.py
+++ b/src/aleph/chains/nuls2.py
@@ -208,7 +208,7 @@ class Nuls2Connector(ChainWriter):
                 while True:
                     batch = list(
                         get_unconfirmed_messages(
-                            session=session, limit=500, offset=offset, chain=Chain.NULS2
+                            session=session, limit=500, offset=offset
                         )
                     )
                     if not batch:

--- a/src/aleph/db/accessors/messages.py
+++ b/src/aleph/db/accessors/messages.py
@@ -419,28 +419,11 @@ def get_message_stats_by_address(
 # TODO: declare a type that will match the result (something like UnconfirmedMessageDb)
 #       and translate the time field to epoch.
 def get_unconfirmed_messages(
-    session: DbSession, limit: int = 100, offset: int = 0, chain: Optional[Chain] = None
+    session: DbSession, limit: int = 100, offset: int = 0
 ) -> Iterable[MessageDb]:
-
-    if chain is None:
-        select_message_confirmations = select(message_confirmations.c.item_hash).where(
-            message_confirmations.c.item_hash == MessageDb.item_hash
-        )
-    else:
-        select_message_confirmations = (
-            select(message_confirmations.c.item_hash)
-            .join(ChainTxDb, message_confirmations.c.tx_hash == ChainTxDb.hash)
-            .where(
-                (message_confirmations.c.item_hash == MessageDb.item_hash)
-                & (ChainTxDb.chain == chain)
-            )
-        )
-
     select_stmt = (
         select(MessageDb)
-        .where(
-            MessageDb.signature.isnot(None) & (~select_message_confirmations.exists())
-        )
+        .where(MessageDb.signature.isnot(None) & MessageDb.first_confirmed_at.is_(None))
         .order_by(MessageDb.reception_time.asc())
     )
 

--- a/tests/db/test_messages.py
+++ b/tests/db/test_messages.py
@@ -366,21 +366,8 @@ async def test_get_unconfirmed_messages(
         unconfirmed_messages = list(get_unconfirmed_messages(session))
         assert unconfirmed_messages == []
 
-        # Check that it is also ignored when the chain parameter is specified
-        unconfirmed_messages = list(get_unconfirmed_messages(session, chain=tx.chain))
-        assert unconfirmed_messages == []
-
-        # Check that it reappears if we specify a different chain
-        unconfirmed_messages = list(
-            get_unconfirmed_messages(session, chain=Chain.TEZOS)
-        )
-        assert len(unconfirmed_messages) == 1
-        assert_messages_equal(fixture_message, unconfirmed_messages[0])
-
         # Check that the limit parameter is respected
-        unconfirmed_messages = list(
-            get_unconfirmed_messages(session, chain=Chain.TEZOS, limit=0)
-        )
+        unconfirmed_messages = list(get_unconfirmed_messages(session, limit=0))
         assert unconfirmed_messages == []
 
 


### PR DESCRIPTION
## Summary
- Replace the `NOT EXISTS` anti-join against `message_confirmations` + `chain_txs` in `get_unconfirmed_messages` with a direct check on `messages.first_confirmed_at IS NULL`. The column is already trigger-maintained (migration 0049), so no schema change is needed.
- Drop the now-unused `chain` parameter and update the two callers (`chains/ethereum.py`, `chains/nuls2.py`) accordingly.

## Performance
Measured against a production-sized dataset (~22k unconfirmed signed messages):

Before (anti-join): ~10s
After (denorm column, using existing `ix_messages_first_confirmed`): ~300ms cold, ~50ms warm. No new index needed.

```
Limit  (cost=26259.44..26260.69 rows=500 width=1275) (actual time=48.696..48.796 rows=500 loops=1)
  ->  Sort  (Sort Key: reception_time, Sort Method: top-N heapsort  Memory: 738kB)
        ->  Bitmap Heap Scan on messages (Recheck Cond: first_confirmed_at IS NULL, Filter: signature IS NOT NULL)
              ->  Bitmap Index Scan on ix_messages_first_confirmed (Index Cond: first_confirmed_at IS NULL)
Execution Time: 48.856 ms
```

## Semantic note
The previous implementation filtered confirmations by chain (e.g. `chain=Chain.ETH` for the ETH packer). `first_confirmed_at` is set by a confirmation on any chain. In production only ETH confirmations are recorded, so the behavior is equivalent today. If multi-chain confirmations are reintroduced, the unconfirmed query will need to reconsider this.

## Test plan
- [ ] `hatch run testing:test tests/db/test_messages.py::test_get_unconfirmed_messages tests/db/test_messages.py::test_get_unconfirmed_messages_trusted_messages -v`
- [ ] Spot-check ETH and NULS2 packer paths still call `get_unconfirmed_messages` without `chain=`.