### PR TITLE
perf: speed up v0 /posts/ listing for filtered queries

### DIFF
--- a/deployment/migrations/versions/0058_4f1e8d2a6c3b_posts_owner_type_channel_index.py
+++ b/deployment/migrations/versions/0058_4f1e8d2a6c3b_posts_owner_type_channel_index.py
@@ -1,0 +1,69 @@
+"""Add composite partial index posts(owner, type, channel) WHERE amends IS NULL
+
+Revision ID: 4f1e8d2a6c3b
+Revises: a8c3d9f1b2e4
+Create Date: 2026-05-13
+
+Both /posts/ endpoints filter posts by (owner, type, channel) inside a
+subquery gated on ``amends IS NULL``. The planner currently has to
+``BitmapAnd`` ``ix_posts_owner`` and ``ix_posts_type``, then recheck the
+channel and amends predicates from the heap, which on high-volume
+owners scans many thousands of unrelated rows.
+
+This partial composite index covers the three equality predicates in
+one lookup and excludes amend rows entirely, since the query throws
+them away.
+"""
+
+import logging
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "4f1e8d2a6c3b"
+down_revision = "a8c3d9f1b2e4"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    was_in_transaction = connection.in_transaction()
+    if was_in_transaction:
+        connection.execute(text("COMMIT"))
+
+    engine = connection.engine
+    with engine.connect() as conn:
+        conn = conn.execution_options(isolation_level="AUTOCOMMIT")
+        conn.execute(
+            text(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+                "ix_posts_owner_type_channel "
+                "ON posts (owner, type, channel) "
+                "WHERE amends IS NULL"
+            )
+        )
+
+    if was_in_transaction:
+        connection.execute(text("BEGIN"))
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+
+    was_in_transaction = connection.in_transaction()
+    if was_in_transaction:
+        connection.execute(text("COMMIT"))
+
+    engine = connection.engine
+    with engine.connect() as conn:
+        conn = conn.execution_options(isolation_level="AUTOCOMMIT")
+        conn.execute(
+            text("DROP INDEX CONCURRENTLY IF EXISTS ix_posts_owner_type_channel")
+        )
+
+    if was_in_transaction:
+        connection.execute(text("BEGIN"))

--- a/src/aleph/db/accessors/posts.py
+++ b/src/aleph/db/accessors/posts.py
@@ -104,24 +104,23 @@ def make_select_merged_post_stmt() -> Select:
     return select_merged_post_stmt
 
 
-def make_select_merged_post_with_message_info_stmt() -> Select:
+def _make_select_merged_post_v0_base_stmt() -> Select:
     """
-    Combines posts and their latest amends according to the v0 /posts/ endpoint spec.
+    Originals + their latest amends, projected with the post-side
+    columns needed by the v0 /posts/ endpoint.
+
+    Unlike :func:`make_select_merged_post_stmt` the result also exposes
+    ``latest_amend`` and the amend-aware ``type``, which lets callers
+    defer the ``messages`` joins until *after* applying filters and
+    LIMIT instead of paying for them on every candidate row.
     """
 
-    select_merged_post_stmt = (
+    return (
         select(
             Original.item_hash.label("original_item_hash"),
             func.coalesce(Amend.item_hash, Original.item_hash).label("item_hash"),
-            OriginalMessage.chain,
+            Original.latest_amend.label("latest_amend"),
             func.coalesce(Amend.content, Original.content).label("content"),
-            case(
-                (AmendMessage.item_type.is_(None), OriginalMessage.item_content),
-                else_=AmendMessage.item_content,
-            ).label("item_content"),
-            func.coalesce(AmendMessage.item_type, OriginalMessage.item_type).label(
-                "item_type"
-            ),
             Original.owner.label("owner"),
             Original.ref.label("ref"),
             func.coalesce(Amend.creation_datetime, Original.creation_datetime).label(
@@ -131,18 +130,6 @@ def make_select_merged_post_with_message_info_stmt() -> Select:
             Original.creation_datetime.label("created"),
             func.coalesce(Amend.type, Original.type).label("type"),
             Original.type.label("original_type"),
-            func.coalesce(Amend.item_hash, Original.item_hash).label("hash"),
-            func.coalesce(AmendMessage.signature, OriginalMessage.signature).label(
-                "signature"
-            ),
-            OriginalMessage.signature.label("original_signature"),
-            func.coalesce(AmendMessage.size, OriginalMessage.size).label("size"),
-            sqla_cast(
-                extract(
-                    "epoch", func.coalesce(AmendMessage.time, OriginalMessage.time)
-                ),
-                Float,
-            ).label("time"),
             func.coalesce(Amend.tags, Original.tags).label("tags"),
         )
         .join(
@@ -150,11 +137,8 @@ def make_select_merged_post_with_message_info_stmt() -> Select:
             Original.latest_amend == Amend.item_hash,
             isouter=True,
         )
-        .join(OriginalMessage, Original.item_hash == OriginalMessage.item_hash)
-        .join(AmendMessage, Amend.item_hash == AmendMessage.item_hash, isouter=True)
-    ).where(Original.amends.is_(None))
-
-    return select_merged_post_stmt
+        .where(Original.amends.is_(None))
+    )
 
 
 def get_post(session: DbSession, item_hash: str) -> Optional[MergedPost]:
@@ -356,9 +340,110 @@ def get_matching_posts_legacy(
     # Same as make_matching_posts_query
     **kwargs,
 ) -> List[MergedPostV0]:
-    select_stmt = make_select_merged_post_with_message_info_stmt()
-    filtered_select_stmt = filter_post_select_stmt(select_stmt, **kwargs)
-    return cast(List[MergedPostV0], session.execute(filtered_select_stmt).all())
+    """
+    v0 /posts/ list query. Filters and LIMITs on ``posts`` first, then
+    joins ``messages`` on the bounded result so we never fetch message
+    fields for rows that get discarded by pagination.
+    """
+    base_stmt = _make_select_merged_post_v0_base_stmt()
+    limited_stmt = filter_post_select_stmt(base_stmt, **kwargs)
+    limited = limited_stmt.subquery()
+
+    final_stmt = (
+        select(
+            limited.c.original_item_hash,
+            limited.c.item_hash,
+            OriginalMessage.chain.label("chain"),
+            limited.c.content,
+            case(
+                (AmendMessage.item_type.is_(None), OriginalMessage.item_content),
+                else_=AmendMessage.item_content,
+            ).label("item_content"),
+            func.coalesce(AmendMessage.item_type, OriginalMessage.item_type).label(
+                "item_type"
+            ),
+            limited.c.owner,
+            limited.c.ref,
+            limited.c.last_updated,
+            limited.c.channel,
+            limited.c.created,
+            limited.c.type,
+            limited.c.original_type,
+            func.coalesce(AmendMessage.signature, OriginalMessage.signature).label(
+                "signature"
+            ),
+            OriginalMessage.signature.label("original_signature"),
+            func.coalesce(AmendMessage.size, OriginalMessage.size).label("size"),
+            sqla_cast(
+                extract(
+                    "epoch", func.coalesce(AmendMessage.time, OriginalMessage.time)
+                ),
+                Float,
+            ).label("time"),
+            limited.c.tags,
+        )
+        .select_from(limited)
+        .join(
+            OriginalMessage,
+            OriginalMessage.item_hash == limited.c.original_item_hash,
+        )
+        .join(
+            AmendMessage,
+            AmendMessage.item_hash == limited.c.latest_amend,
+            isouter=True,
+        )
+    )
+
+    # The inner subquery applies the LIMIT, but wrapping it discards row
+    # order, so re-apply ORDER BY on the bounded set (cheap, at most a
+    # few hundred rows).
+    sort_by: Optional[SortBy] = kwargs.get("sort_by")
+    sort_order: Optional[SortOrder] = kwargs.get("sort_order")
+    if sort_order is not None:
+        if sort_by == SortBy.TX_TIME:
+            select_earliest_confirmation = (
+                select(
+                    message_confirmations.c.item_hash,
+                    func.min(ChainTxDb.datetime).label("earliest_confirmation"),
+                )
+                .join(ChainTxDb, message_confirmations.c.tx_hash == ChainTxDb.hash)
+                .group_by(message_confirmations.c.item_hash)
+            ).subquery()
+            final_stmt = final_stmt.join(
+                select_earliest_confirmation,
+                select_earliest_confirmation.c.item_hash
+                == limited.c.original_item_hash,
+                isouter=True,
+            )
+            if sort_order == SortOrder.DESCENDING:
+                final_stmt = final_stmt.order_by(
+                    nullsfirst(
+                        select_earliest_confirmation.c.earliest_confirmation.desc()
+                    ),
+                    limited.c.created.desc(),
+                    limited.c.item_hash.asc(),
+                )
+            else:
+                final_stmt = final_stmt.order_by(
+                    nullslast(
+                        select_earliest_confirmation.c.earliest_confirmation.asc()
+                    ),
+                    limited.c.created.asc(),
+                    limited.c.item_hash.asc(),
+                )
+        else:
+            if sort_order == SortOrder.DESCENDING:
+                final_stmt = final_stmt.order_by(
+                    limited.c.last_updated.desc(),
+                    limited.c.original_item_hash.asc(),
+                )
+            else:
+                final_stmt = final_stmt.order_by(
+                    limited.c.last_updated.asc(),
+                    limited.c.original_item_hash.asc(),
+                )
+
+    return cast(List[MergedPostV0], session.execute(final_stmt).all())
 
 
 def get_matching_posts(


### PR DESCRIPTION
## Summary

A `(owner, type, channel)` filter on `/api/v0/posts.json` was logging at ~3s on cold cache (~80ms hot). Two changes together collapse both:

- **Partial composite index** `ix_posts_owner_type_channel ON posts (owner, type, channel) WHERE amends IS NULL` (`deployment/migrations/versions/0058_4f1e8d2a6c3b_*.py`). Built `CONCURRENTLY` so it ships without taking a write lock on `posts`.
- **Restructured `get_matching_posts_legacy`**: filter + sort + LIMIT the originals+amend subquery first, then join `messages` on the bounded result. Previously the planner materialised the full posts+messages product before applying LIMIT, doing 5000+ messages probes to keep 100 rows.

## Diagnosis

From `EXPLAIN (ANALYZE, BUFFERS)` on the slow query (hot cache, 80ms total):

| Step | Buffers | % | Time |
|---|---|---|---|
| Bitmap heap scan on `posts_1` (5,015 rows after recheck) | 7,971 | 24% | 25 ms |
| `messages_1` join × 5,015 loops | **25,075** | **76%** | 35 ms |
| Top-N sort 5,015 → 100 | - | - | 3 ms |

The bitmap scan was `BitmapAnd(ix_posts_owner=212k rows, ix_posts_type=9k rows)`, then heap recheck for `channel` and `amends IS NULL`. The new partial composite goes straight to the 5,015-row set. The messages joins now run on 100 rows instead of 5,015.

Sort is fine at ~3ms for 5,015 rows; not worth indexing for.

## Implementation notes

- `make_select_merged_post_with_message_info_stmt` is gone; replaced by private `_make_select_merged_post_v0_base_stmt` that returns only post-side columns plus `latest_amend` so callers can join `messages` after LIMIT.
- v1 path (`get_matching_posts`) is unchanged.
- ORDER BY is re-applied on the outer wrap so the wrap-around does not lose the inner sort. The `TX_TIME` branch re-joins `chain_tx` confirmations on the LIMITed set (cheap since at most a few hundred rows).
- New `hash` column was previously aliased on top of `item_hash` in the v0 SELECT but never read (the controller uses `original_item_hash` as `hash`). Dropped from the projection.

## Test plan

- [x] `tests/db/test_posts.py` (9 tests pass)
- [x] `tests/api/test_posts.py` (5 tests pass)
- [x] `tests/message_processing/test_process_posts.py` (11 tests pass)
- [ ] Apply migration on staging and `EXPLAIN ANALYZE` the original slow query to confirm:
  - Bitmap heap scan replaced by an Index Scan on `ix_posts_owner_type_channel`
  - Messages joins run with `loops=100` instead of `loops=5015`

🤖 Generated with [Claude Code](https://claude.com/claude-code)