### PR TITLE
fix(auth): unwrap configmanager Items in require_auth_token

### DIFF
--- a/src/aleph/toolkit/ecdsa.py
+++ b/src/aleph/toolkit/ecdsa.py
@@ -132,8 +132,8 @@ def require_auth_token(handler):
         # Get configuration
         config = get_config()
         auth_config = config.aleph.auth
-        public_key = auth_config.public_key
-        max_age = auth_config.max_token_age
+        public_key = auth_config.public_key.value
+        max_age = auth_config.max_token_age.value
 
         # Verify the token
         if not verify_auth_token(auth_token, public_key, max_age):

--- a/tests/toolkit/test_ecdsa.py
+++ b/tests/toolkit/test_ecdsa.py
@@ -2,10 +2,16 @@ import base64
 import time
 from unittest.mock import patch
 
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+from configmanager import Config
+
 from aleph.toolkit.ecdsa import (
     create_auth_token,
     generate_key_pair,
     generate_key_pair_from_private_key,
+    require_auth_token,
     sign_message,
     verify_auth_token,
     verify_signature,
@@ -216,3 +222,57 @@ def test_token_roundtrip_with_known_values():
     _, wrong_key = generate_key_pair()
     is_valid_wrong = verify_auth_token(token, wrong_key)
     assert is_valid_wrong is False
+
+
+@pytest.mark.asyncio
+async def test_require_auth_token_unwraps_configmanager_items(monkeypatch):
+    """Regression: require_auth_token must unwrap configmanager Item wrappers.
+
+    In production, ``config.aleph.auth.public_key`` and ``max_token_age`` are
+    ``configmanager.Item`` objects, not raw ``str``/``int``. Passing them
+    straight into ``verify_auth_token`` made ``bytes.fromhex`` and ``int``
+    comparisons raise ``TypeError`` — silently swallowed by the
+    ``except Exception: return False`` — so every token validation
+    returned False.
+    """
+    private_key, public_key = generate_key_pair()
+
+    fake_config = Config(
+        schema={"aleph": {"auth": {"public_key": public_key, "max_token_age": 300}}}
+    )
+    monkeypatch.setattr("aleph.toolkit.ecdsa.get_config", lambda: fake_config)
+
+    @require_auth_token
+    async def handler(request):
+        return web.Response(text="ok")
+
+    token = create_auth_token(private_key)
+    request = make_mocked_request("POST", "/", headers={"X-Auth-Token": token})
+
+    response = await handler(request)
+    assert response.status == 200
+
+
+@pytest.mark.asyncio
+async def test_require_auth_token_rejects_invalid_token_with_item_wrappers(
+    monkeypatch,
+):
+    """Invalid tokens must still be rejected once Item wrappers are unwrapped."""
+    _, public_key = generate_key_pair()
+    other_private_key, _ = generate_key_pair()
+
+    fake_config = Config(
+        schema={"aleph": {"auth": {"public_key": public_key, "max_token_age": 300}}}
+    )
+    monkeypatch.setattr("aleph.toolkit.ecdsa.get_config", lambda: fake_config)
+
+    @require_auth_token
+    async def handler(request):
+        return web.Response(text="ok")
+
+    # Token signed by a different private key — must be rejected as 401.
+    token = create_auth_token(other_private_key)
+    request = make_mocked_request("POST", "/", headers={"X-Auth-Token": token})
+
+    with pytest.raises(web.HTTPUnauthorized):
+        await handler(request)


### PR DESCRIPTION
 ## Summary

  Follow-up to #884.

  `require_auth_token` was passing `configmanager.Item` wrappers straight into `verify_auth_token`, which then forwarded them to `bytes.fromhex(public_key_hex)` and the `current_time - timestamp > max_age_seconds` comparison. Both raise `TypeError` on non-primitive arguments:

  ```python
  public_key = auth_config.public_key      # → <Item public_key '02…389'>, NOT str
  max_age    = auth_config.max_token_age   # → <Item max_token_age 300>, NOT int
  ```

  Those errors were swallowed by the `except Exception: return False` inside `verify_auth_token`, so every token validation silently returned False — the endpoint `/api/v0/price/{hash}/recalculate` (and any future `@require_auth_token`-decorated route) was effectively dead even after #884 fixed the `PublicKey.from_hex` AttributeError.

  ## Fix

  Call `.value` on the two `Item` accessors in `require_auth_token` before handing them to `verify_auth_token`:

  ```diff
           config = get_config()
           auth_config = config.aleph.auth
  -        public_key = auth_config.public_key
  -        max_age = auth_config.max_token_age
  +        public_key = auth_config.public_key.value
  +        max_age = auth_config.max_token_age.value
  ```

  ## Tests

  The existing tests in `tests/toolkit/test_ecdsa.py` exercised `verify_signature` / `verify_auth_token` with raw strings — that's why this bug slipped through. Added two regression tests that drive the `require_auth_token` decorator with a real `configmanager.Config` (so `Item` wrappers are present, matching the production case):

  - `test_require_auth_token_unwraps_configmanager_items` — valid token → 200
  - `test_require_auth_token_rejects_invalid_token_with_item_wrappers` — token signed by a different key → 401

  ## Test plan

  - [x] `hatch run linting:all` — passes
  - [x] `hatch run testing:test tests/toolkit/test_ecdsa.py -v` — 13/13 passed
  - [ ] Manual verification against a patched CCN: `POST /api/v0/price/{hash}/recalculate` with a valid token returns 200 and updates `cost_credit` from 0 to a non-zero value.

  ## Out of scope

  - Reworking `verify_auth_token` / `verify_signature` to coerce inputs (kept strict — the contract is "primitives in, bool out").
  - Replacing the catch-all `except Exception: return False` (would have surfaced this as a 500 instead of 401, but is a bigger discussion).
  - Auditing `.value` defensively elsewhere — only `require_auth_token` was in scope here.