### PR TITLE
fix(jobs): handle SIGTERM cleanly in subprocess entry points

### DIFF
--- a/src/aleph/jobs/fetch_pending_messages.py
+++ b/src/aleph/jobs/fetch_pending_messages.py
@@ -24,6 +24,7 @@ from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
 from aleph.services.storage.fileystem_engine import FileSystemStorageEngine
 from aleph.storage import StorageService
+from aleph.toolkit.lifecycle import install_signal_handlers
 from aleph.toolkit.logging import setup_logging
 from aleph.toolkit.monitoring import setup_sentry
 from aleph.toolkit.timestamp import utc_now
@@ -355,7 +356,6 @@ def fetch_pending_messages_subprocess(config_values: Dict):
     """
 
     faulthandler.enable(file=sys.stderr)
-
     setproctitle("aleph.jobs.fetch_messages")
     loop, config = prepare_loop(config_values)
 
@@ -366,8 +366,16 @@ def fetch_pending_messages_subprocess(config_values: Dict):
         max_log_file_size=config.logging.max_log_file_size.value,
     )
 
+    async def _runner():
+        task = asyncio.create_task(fetch_messages_task(config=config))
+        install_signal_handlers(asyncio.get_running_loop(), task.cancel)
+        try:
+            await task
+        except asyncio.CancelledError:
+            LOGGER.info("Fetch messages subprocess cancelled by signal")
+
     try:
-        asyncio.run(fetch_messages_task(config=config))
+        asyncio.run(_runner())
     except KeyboardInterrupt:
         LOGGER.info("Fetch messages subprocess interrupted")
     except SystemExit:

--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -21,6 +21,7 @@ from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
 from aleph.services.storage.fileystem_engine import FileSystemStorageEngine
 from aleph.storage import StorageService
+from aleph.toolkit.lifecycle import install_signal_handlers
 from aleph.toolkit.logging import setup_logging
 from aleph.toolkit.monitoring import setup_sentry
 from aleph.toolkit.timestamp import utc_now
@@ -236,8 +237,13 @@ def pending_messages_subprocess(config_values: Dict):
         max_log_file_size=config.logging.max_log_file_size.value,
     )
 
+    task = loop.create_task(fetch_and_process_messages_task(config=config))
+    install_signal_handlers(loop, task.cancel)
+
     try:
-        loop.run_until_complete(fetch_and_process_messages_task(config=config))
+        loop.run_until_complete(task)
+    except asyncio.CancelledError:
+        LOGGER.info("Process messages subprocess cancelled by signal")
     except KeyboardInterrupt:
         LOGGER.info("Process messages subprocess interrupted")
     except SystemExit:
@@ -245,3 +251,5 @@ def pending_messages_subprocess(config_values: Dict):
     except BaseException:
         LOGGER.critical("Fatal error in process messages subprocess", exc_info=True)
         raise
+    finally:
+        loop.close()

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -21,6 +21,7 @@ from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs.service import IpfsService
 from aleph.services.storage.fileystem_engine import FileSystemStorageEngine
 from aleph.storage import StorageService
+from aleph.toolkit.lifecycle import install_signal_handlers
 from aleph.toolkit.logging import setup_logging
 from aleph.toolkit.monitoring import setup_sentry
 from aleph.toolkit.rabbitmq import make_mq_conn
@@ -190,8 +191,13 @@ def pending_txs_subprocess(config_values: Dict):
         max_log_file_size=config.logging.max_log_file_size.value,
     )
 
+    task = loop.create_task(handle_txs_task(config))
+    install_signal_handlers(loop, task.cancel)
+
     try:
-        loop.run_until_complete(handle_txs_task(config))
+        loop.run_until_complete(task)
+    except asyncio.CancelledError:
+        LOGGER.info("Pending txs subprocess cancelled by signal")
     except KeyboardInterrupt:
         LOGGER.info("Pending txs subprocess interrupted")
     except SystemExit:
@@ -199,3 +205,5 @@ def pending_txs_subprocess(config_values: Dict):
     except BaseException:
         LOGGER.critical("Fatal error in pending txs subprocess", exc_info=True)
         raise
+    finally:
+        loop.close()

--- a/src/aleph/toolkit/lifecycle.py
+++ b/src/aleph/toolkit/lifecycle.py
@@ -1,0 +1,32 @@
+import asyncio
+import logging
+import signal
+from typing import Awaitable, Callable
+
+LOGGER = logging.getLogger(__name__)
+
+
+def install_signal_handlers(
+    loop: asyncio.AbstractEventLoop, callback: Callable[[], object]
+) -> None:
+    """Register SIGINT and SIGTERM handlers that invoke `callback`.
+
+    Re-registering replaces the previous handler. Silently no-ops on
+    platforms that do not support `loop.add_signal_handler` (Windows).
+    """
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, callback)
+        except NotImplementedError:
+            LOGGER.debug("Signal handler for %s not available on this platform", sig)
+
+
+async def safe_async_cleanup(name: str, awaitable: Awaitable[object]) -> None:
+    """Await a cleanup coroutine, logging but never re-raising on failure.
+
+    Cleanup paths run during shutdown and must not mask the shutdown signal.
+    """
+    try:
+        await awaitable
+    except Exception:
+        LOGGER.exception("Error during cleanup of %s", name)

--- a/tests/toolkit/test_lifecycle.py
+++ b/tests/toolkit/test_lifecycle.py
@@ -1,0 +1,44 @@
+import asyncio
+import os
+import signal
+
+import pytest
+
+from aleph.toolkit.lifecycle import install_signal_handlers, safe_async_cleanup
+
+
+@pytest.mark.asyncio
+async def test_install_signal_handlers_invokes_callback_on_sigterm():
+    loop = asyncio.get_running_loop()
+    called = asyncio.Event()
+    install_signal_handlers(loop, called.set)
+    try:
+        os.kill(os.getpid(), signal.SIGTERM)
+        await asyncio.wait_for(called.wait(), timeout=1.0)
+    finally:
+        loop.remove_signal_handler(signal.SIGTERM)
+        loop.remove_signal_handler(signal.SIGINT)
+
+
+@pytest.mark.asyncio
+async def test_safe_async_cleanup_swallows_exceptions(caplog):
+    async def boom():
+        raise RuntimeError("boom")
+
+    await safe_async_cleanup("test resource", boom())  # must not raise
+
+    assert "test resource" in caplog.text
+    assert "boom" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_safe_async_cleanup_runs_coroutine_to_completion():
+    completed = False
+
+    async def slow():
+        nonlocal completed
+        await asyncio.sleep(0)
+        completed = True
+
+    await safe_async_cleanup("slow", slow())
+    assert completed


### PR DESCRIPTION
Part **1/8** of the clean-shutdown audit. Closes **Finding 8**.

## Problem

The three jobs subprocesses (`fetch_pending_messages_subprocess`, `pending_messages_subprocess`, `pending_txs_subprocess`) only catch `KeyboardInterrupt`. A parent-initiated `Process.terminate()` (SIGTERM) is unhandled, so they exit abruptly without closing RabbitMQ / SQLAlchemy / HTTP resources.

## Fix

- New module `aleph.toolkit.lifecycle` with two helpers (`install_signal_handlers`, `safe_async_cleanup`) used by this PR and subsequent ones in the series.
- Each subprocess wraps its root coroutine in a task, installs SIGTERM/SIGINT handlers that call `task.cancel()`, and catches `asyncio.CancelledError` so the existing async-context `finally` blocks run cleanly.

## Tests

3 new tests in `tests/toolkit/test_lifecycle.py` (signal handler invocation + `safe_async_cleanup` exception swallowing + completion).

---

Base: `main`. Subsequent PRs in this chain must be merged in order (1→2→…→8).