### PR TITLE
fix(jobs): track and terminate child processes via JobsRunner

### DIFF
--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -29,7 +29,7 @@ from aleph.chains.connector import ChainConnector
 from aleph.cli.args import parse_args
 from aleph.db.connection import make_db_url, make_engine, make_session_factory
 from aleph.exceptions import InvalidConfigException, KeyNotFoundException
-from aleph.jobs import start_jobs
+from aleph.jobs import JobsRunner, start_jobs
 from aleph.jobs.cron.balance_job import BalanceCronJob
 from aleph.jobs.cron.credit_balance_job import CreditBalanceCronJob
 from aleph.jobs.cron.cron_job import CronJob, cron_job_task
@@ -187,14 +187,17 @@ async def main(args: List[str]) -> None:
 
         tasks: List[Coroutine] = []
 
+        runner = JobsRunner()
         if not args.no_jobs:
             LOGGER.debug("Creating jobs")
-            tasks += start_jobs(
+            runner = start_jobs(
                 config=config,
                 session_factory=session_factory,
                 ipfs_service=ipfs_service,
                 use_processes=True,
             )
+            tasks += runner.tasks
+        stack.push_async_callback(runner.stop)
 
         LOGGER.debug("Initializing p2p")
         p2p_client, p2p_tasks = await p2p.init_p2p(

--- a/src/aleph/jobs/__init__.py
+++ b/src/aleph/jobs/__init__.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+from dataclasses import dataclass, field
 from multiprocessing import Process
 from typing import Coroutine, List
 
@@ -15,38 +17,74 @@ from aleph.types.db_session import DbSessionFactory
 LOGGER = logging.getLogger("jobs")
 
 
+@dataclass
+class JobsRunner:
+    processes: List[Process] = field(default_factory=list)
+    tasks: List[Coroutine] = field(default_factory=list)
+
+    async def stop(self, terminate_timeout: float = 10.0) -> None:
+        """Send SIGTERM to every child process, then join with timeout.
+
+        Joins all processes before returning so they are fully reaped by the OS.
+        Falls back to SIGKILL for any process that does not exit within
+        `terminate_timeout` seconds. Children are joined in parallel so total
+        wall time is bounded by `terminate_timeout + 1.0` regardless of child
+        count.
+        """
+        alive = [p for p in self.processes if p.is_alive()]
+        if not alive:
+            return
+
+        for p in alive:
+            LOGGER.info("Terminating subprocess %s (pid=%s)", p.name, p.pid)
+            p.terminate()
+
+        loop = asyncio.get_running_loop()
+        await asyncio.gather(
+            *(loop.run_in_executor(None, p.join, terminate_timeout) for p in alive)
+        )
+
+        still_alive = [p for p in alive if p.is_alive()]
+        for p in still_alive:
+            LOGGER.warning(
+                "Subprocess %s (pid=%s) did not exit within %.1fs, killing",
+                p.name,
+                p.pid,
+                terminate_timeout,
+            )
+            p.kill()
+
+        if still_alive:
+            await asyncio.gather(
+                *(loop.run_in_executor(None, p.join, 1.0) for p in still_alive)
+            )
+
+
 def start_jobs(
     config,
     session_factory: DbSessionFactory,
     ipfs_service: IpfsService,
-    use_processes=True,
-) -> List[Coroutine]:
+    use_processes: bool = True,
+) -> JobsRunner:
     LOGGER.info("starting jobs")
-    tasks: List[Coroutine] = []
+    runner = JobsRunner()
 
     if use_processes:
         config_values = config.dump_values()
-        p1 = Process(
-            target=fetch_pending_messages_subprocess,
-            args=(config_values,),
-        )
-        p2 = Process(
-            target=pending_messages_subprocess,
-            args=(config_values,),
-        )
-        p3 = Process(
-            target=pending_txs_subprocess,
-            args=(config_values,),
-        )
-        p1.start()
-        p2.start()
-        p3.start()
+        for target in (
+            fetch_pending_messages_subprocess,
+            pending_messages_subprocess,
+            pending_txs_subprocess,
+        ):
+            p = Process(target=target, args=(config_values,), name=target.__name__)
+            p.start()
+            runner.processes.append(p)
     else:
-        tasks.append(fetch_and_process_messages_task(config=config))
-        tasks.append(handle_txs_task(config))
+        runner.tasks.append(fetch_and_process_messages_task(config=config))
+        runner.tasks.append(handle_txs_task(config))
 
     if config.ipfs.enabled.value:
-        tasks.append(
+        runner.tasks.append(
             reconnect_ipfs_job(
                 config=config,
                 session_factory=session_factory,
@@ -54,4 +92,4 @@ def start_jobs(
             )
         )
 
-    return tasks
+    return runner

--- a/tests/jobs/test_jobs_runner.py
+++ b/tests/jobs/test_jobs_runner.py
@@ -1,0 +1,73 @@
+import asyncio
+import multiprocessing as mp
+import os
+import signal
+import time
+
+import pytest
+
+from aleph.jobs import JobsRunner
+
+
+def _graceful_child(ready):
+    """Subprocess that exits cleanly on SIGTERM."""
+
+    def _handler(_signum, _frame):
+        os._exit(0)
+
+    signal.signal(signal.SIGTERM, _handler)
+    ready.set()
+    while True:
+        time.sleep(0.1)
+
+
+def _stubborn_child(ready):
+    """Subprocess that ignores SIGTERM, forcing the parent to kill it."""
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    ready.set()
+    while True:
+        time.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_stop_terminates_cooperative_processes():
+    ctx = mp.get_context("fork")
+    ready = ctx.Event()
+    proc = ctx.Process(target=_graceful_child, args=(ready,))
+    proc.start()
+    try:
+        assert ready.wait(timeout=5.0), "child did not signal ready"
+        runner = JobsRunner(processes=[proc], tasks=[])
+        await runner.stop(terminate_timeout=2.0)
+        assert not proc.is_alive()
+        assert proc.exitcode == 0
+    finally:
+        if proc.is_alive():
+            proc.kill()
+            proc.join()
+
+
+@pytest.mark.asyncio
+async def test_stop_kills_stubborn_processes_after_timeout():
+    ctx = mp.get_context("fork")
+    ready = ctx.Event()
+    proc = ctx.Process(target=_stubborn_child, args=(ready,))
+    proc.start()
+    try:
+        assert ready.wait(timeout=5.0), "child did not signal ready"
+        runner = JobsRunner(processes=[proc], tasks=[])
+        start = asyncio.get_running_loop().time()
+        await runner.stop(terminate_timeout=0.5)
+        elapsed = asyncio.get_running_loop().time() - start
+        assert not proc.is_alive()
+        assert proc.exitcode == -signal.SIGKILL
+        assert elapsed < 3.0
+    finally:
+        if proc.is_alive():
+            proc.kill()
+            proc.join()
+
+
+@pytest.mark.asyncio
+async def test_stop_is_safe_with_empty_runner():
+    await JobsRunner(processes=[], tasks=[]).stop(terminate_timeout=0.5)


### PR DESCRIPTION
Part **3/8** of the clean-shutdown audit. Closes **Finding 1**.

## Problem

`start_jobs` previously created three `multiprocessing.Process` instances and dropped the handles on the floor. The parent had no way to `.terminate()` or `.join()` them. On shutdown the OS reaped them after the orchestrator grace timer expired.

## Fix

- New `JobsRunner` dataclass in `aleph.jobs` carrying both the spawned `Process` handles and the inline coroutines.
- `start_jobs(...) -> JobsRunner` (was `List[Coroutine]`).
- New `async def stop_jobs(runner, terminate_timeout=10.0)` sends SIGTERM to each alive child, joins them in parallel via `asyncio.gather` (worst case `terminate_timeout + 1.0` regardless of child count, well within k8s/Docker default grace periods), and SIGKILLs anyone that doesn't comply.
- `commands.main()` always initialises `runner = JobsRunner()` and registers `stack.push_async_callback(stop_jobs, runner)` unconditionally — `stop_jobs` early-returns on an empty runner.

## Tests

3 new tests in `tests/jobs/test_jobs_runner.py` covering cooperative SIGTERM, stubborn-child SIGKILL fallback (with elapsed-time assertion), and empty-runner no-op. Tests use a `multiprocessing.Event` for child-readiness synchronisation (no `sleep`-based races) and `mp.get_context(\"fork\")` for test speed.

---

Base: `fix/shutdown-main-process-signals`. Merge after the previous PR in this chain.