### PR TITLE
fix(p2p): close cached aiohttp sessions on shutdown

### DIFF
--- a/src/aleph/api_entrypoint.py
+++ b/src/aleph/api_entrypoint.py
@@ -11,8 +11,10 @@ from aleph.db.connection import make_engine, make_session_factory
 from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
 from aleph.services.p2p import init_p2p_client
+from aleph.services.p2p.http import close_sessions
 from aleph.services.storage.fileystem_engine import FileSystemStorageEngine
 from aleph.storage import StorageService
+from aleph.toolkit.lifecycle import safe_async_cleanup
 from aleph.toolkit.monitoring import setup_sentry
 from aleph.web import create_aiohttp_app
 from aleph.web.controllers.app_state_getters import (
@@ -94,6 +96,7 @@ async def configure_aiohttp_app(
         async def _on_cleanup(_app: web.Application):
             await message_broadcaster.shutdown()
             await status_broadcaster.shutdown()
+            await safe_async_cleanup("p2p HTTP sessions", close_sessions())
 
         app.on_cleanup.append(_on_cleanup)
 

--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -39,13 +39,14 @@ from aleph.services import p2p
 from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
 from aleph.services.keys import generate_keypair, save_keys
+from aleph.services.p2p.http import close_sessions
 from aleph.services.storage.fileystem_engine import FileSystemStorageEngine
 from aleph.services.storage.garbage_collector import (
     GarbageCollector,
     garbage_collector_task,
 )
 from aleph.storage import StorageService
-from aleph.toolkit.lifecycle import install_signal_handlers
+from aleph.toolkit.lifecycle import install_signal_handlers, safe_async_cleanup
 from aleph.toolkit.logging import setup_logging
 from aleph.toolkit.monitoring import setup_sentry
 
@@ -198,6 +199,9 @@ async def main(args: List[str]) -> None:
             )
             tasks += runner.tasks
         stack.push_async_callback(runner.stop)
+        stack.push_async_callback(
+            safe_async_cleanup, "p2p HTTP sessions", close_sessions()
+        )
 
         LOGGER.debug("Initializing p2p")
         p2p_client, p2p_tasks = await p2p.init_p2p(

--- a/src/aleph/services/p2p/http.py
+++ b/src/aleph/services/p2p/http.py
@@ -12,7 +12,7 @@ import aiohttp
 
 LOGGER = logging.getLogger("P2P.HTTP")
 
-SESSIONS = dict()
+SESSIONS: dict[int, aiohttp.ClientSession] = {}
 
 
 async def api_get_request(base_uri, method, timeout=1):
@@ -68,3 +68,17 @@ async def request_hash(
             return content
 
     return None  # Nothing found...
+
+
+async def close_sessions() -> None:
+    """Close and forget every cached aiohttp ClientSession.
+
+    Safe to call multiple times. Closing a session also closes its
+    TCPConnector, releasing connection pool sockets.
+    """
+    while SESSIONS:
+        _timeout, session = SESSIONS.popitem()
+        try:
+            await session.close()
+        except Exception:
+            LOGGER.exception("Error closing P2P HTTP session")

--- a/tests/services/test_p2p_http.py
+++ b/tests/services/test_p2p_http.py
@@ -1,0 +1,33 @@
+import pytest
+import pytest_asyncio
+
+from aleph.services.p2p import http as p2p_http
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _reset_p2p_sessions():
+    """Ensure tests start and end with an empty SESSIONS dict."""
+    await p2p_http.close_sessions()
+    yield
+    await p2p_http.close_sessions()
+
+
+@pytest.mark.asyncio
+async def test_close_sessions_clears_cache_and_closes_sessions():
+    # Force a session into the module-level cache by calling the request helper
+    # against a deliberately unreachable URI (the helper swallows errors).
+    await p2p_http.api_get_request("http://127.0.0.1:1", "ignored", timeout=2)
+    assert 2 in p2p_http.SESSIONS
+    session = p2p_http.SESSIONS[2]
+    assert not session.closed
+
+    await p2p_http.close_sessions()
+
+    assert p2p_http.SESSIONS == {}
+    assert session.closed
+
+
+@pytest.mark.asyncio
+async def test_close_sessions_is_idempotent():
+    await p2p_http.close_sessions()
+    await p2p_http.close_sessions()


### PR DESCRIPTION
Part **4/8** of the clean-shutdown audit. Closes **Finding 3**.

## Problem

`src/aleph/services/p2p/http.py` keeps a module-level `SESSIONS: dict[int, aiohttp.ClientSession]` populated lazily per timeout value. Sessions are never closed, producing "Unclosed client session" / "Unclosed connector" warnings at shutdown.

## Fix

- New `close_sessions()` helper in `services/p2p/http.py` that drains the cache via `popitem()`, closing each session inside its own `try/except` so a single failure does not prevent the rest from closing.
- Wired into both processes:
  - `commands.py`: `stack.push_async_callback(safe_async_cleanup, \"p2p HTTP sessions\", close_sessions())` after the `stop_jobs` registration.
  - `api_entrypoint.py`: appended to `_on_cleanup` via `safe_async_cleanup`.
- `SESSIONS = dict()` retyped to `SESSIONS: dict[int, aiohttp.ClientSession] = {}`.

## Tests

2 new tests in `tests/services/test_p2p_http.py` (cache cleared and sessions closed; idempotency). Tests are isolated with an `autouse` fixture that resets `SESSIONS` before/after each test.

---

Base: `fix/shutdown-track-child-processes`.