### PR TITLE
fix(commands): close RabbitMQ channel and connection on shutdown

### DIFF
--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -140,7 +140,9 @@ async def main(args: List[str]) -> None:
         session_factory = make_session_factory(engine)
 
         mq_conn = await make_mq_conn(config)
+        stack.push_async_callback(safe_async_cleanup, "mq connection", mq_conn.close())
         mq_channel = await mq_conn.channel()
+        stack.push_async_callback(safe_async_cleanup, "mq channel", mq_channel.close())
 
         node_cache = await init_node_cache(config)
         await stack.enter_async_context(node_cache)


### PR DESCRIPTION
Part **5/8** of the clean-shutdown audit. Closes **Finding 5**.

## Problem

`commands.main()` opens `mq_conn = await make_mq_conn(config)` and `mq_channel = await mq_conn.channel()` but never closes either. aio-pika logs "connection still open" on exit.

## Fix

Two `stack.push_async_callback(safe_async_cleanup, ...)` registrations in `main()`, one for each. LIFO ordering: the channel close (registered second) runs first, then the connection close — channels live on connections.

This PR only covers the main process. The API process reuses `p2p_client.mq_client.connection`; its RabbitMQ cleanup is handled by PR 7 (when we close `p2p_client`).

## Tests

No new tests (2-line wiring change).

---

Base: `fix/shutdown-close-p2p-sessions`.