### PR TITLE
fix(db): dispose SQLAlchemy engines on shutdown

### DIFF
--- a/src/aleph/api_entrypoint.py
+++ b/src/aleph/api_entrypoint.py
@@ -97,6 +97,7 @@ async def configure_aiohttp_app(
             await message_broadcaster.shutdown()
             await status_broadcaster.shutdown()
             await safe_async_cleanup("p2p HTTP sessions", close_sessions())
+            engine.dispose()
 
         app.on_cleanup.append(_on_cleanup)
 

--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -137,6 +137,7 @@ async def main(args: List[str]) -> None:
             echo=args.loglevel == logging.DEBUG,
             application_name="aleph-conn-manager",
         )
+        stack.callback(engine.dispose)
         session_factory = make_session_factory(engine)
 
         mq_conn = await make_mq_conn(config)


### PR DESCRIPTION
Part **6/8** of the clean-shutdown audit. Closes **Finding 4**.

## Problem

`make_engine(...)` is called in both long-lived processes (`commands.py` and `api_entrypoint.py`); neither ever calls `engine.dispose()`. Connection-pool worker threads stay alive past `asyncio.run()` exit.

## Fix

- `commands.py`: `stack.callback(engine.dispose)` (sync variant of `push_async_callback`; `Engine.dispose()` is not a coroutine) registered immediately after `make_engine(...)`. LIFO places it last among AsyncExitStack callbacks, so the engine outlives every async cleanup that might still issue SQL.
- `api_entrypoint.py`: bare `engine.dispose()` appended as the final line of `_on_cleanup`, after all the async cleanups.

## Tests

No new tests (2-line wiring change).

---

Base: `fix/shutdown-close-mq-main`.