### PR TITLE
fix(p2p): close P2P client (and shared MQ connection) on shutdown

### DIFF
--- a/src/aleph/api_entrypoint.py
+++ b/src/aleph/api_entrypoint.py
@@ -96,6 +96,10 @@ async def configure_aiohttp_app(
         async def _on_cleanup(_app: web.Application):
             await message_broadcaster.shutdown()
             await status_broadcaster.shutdown()
+            # mq_channel borrows from p2p_client's connection; close it first.
+            await safe_async_cleanup("mq channel", mq_channel.close())
+            # Closing the p2p client also closes the underlying mq connection.
+            await safe_async_cleanup("p2p client", p2p_client.close())
             await safe_async_cleanup("p2p HTTP sessions", close_sessions())
             engine.dispose()
 

--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -214,6 +214,7 @@ async def main(args: List[str]) -> None:
             ipfs_service=ipfs_service,
             node_cache=node_cache,
         )
+        stack.push_async_callback(safe_async_cleanup, "p2p client", p2p_client.close())
         tasks += p2p_tasks
         LOGGER.debug("Initialized p2p")
 


### PR DESCRIPTION
Part **7/8** of the clean-shutdown audit. Closes **Finding 7**.

## Problem

`aleph_p2p_client.AlephP2PServiceClient.close()` is never awaited on shutdown. In the API process this matters doubly because the client owns the RabbitMQ connection used by `mq_channel` and `MessageBroadcaster`.

## Fix

- `commands.py`: `stack.push_async_callback(safe_async_cleanup, \"p2p client\", p2p_client.close())` after `init_p2p` returns.
- `api_entrypoint.py`: extends `_on_cleanup` with TWO new lines — `mq_channel.close()` first, then `p2p_client.close()`. The order is required because `mq_channel` borrows from the connection owned by `p2p_client`; closing the client closes the connection, so the channel must close first.

## Tests

No new tests (wiring change). Comments added in `_on_cleanup` documenting the channel-before-client ordering.

---

Base: `fix/shutdown-dispose-engines`.