### PR TITLE
fix(api): close NodeCache and IpfsService on shutdown

### DIFF
--- a/src/aleph/api_entrypoint.py
+++ b/src/aleph/api_entrypoint.py
@@ -51,10 +51,7 @@ async def configure_aiohttp_app(
             redis_port=config.redis.port.value,
             message_count_cache_ttl=config.perf.message_count_cache_ttl.value,
         )
-        # TODO: find a way to close the node cache when exiting the API process, not closing it causes
-        #       a warning.
         await node_cache.open()
-        # TODO: same, find a way to call await ipfs_service.close() on shutdown
         ipfs_service = IpfsService.new(config)
 
         storage_service = StorageService(
@@ -100,6 +97,8 @@ async def configure_aiohttp_app(
             await safe_async_cleanup("mq channel", mq_channel.close())
             # Closing the p2p client also closes the underlying mq connection.
             await safe_async_cleanup("p2p client", p2p_client.close())
+            await safe_async_cleanup("ipfs service", ipfs_service.close())
+            await safe_async_cleanup("node cache", node_cache.close())
             await safe_async_cleanup("p2p HTTP sessions", close_sessions())
             engine.dispose()
 


### PR DESCRIPTION
Part **8/8** of the clean-shutdown audit. Closes **Finding 6**.

## Problem

`api_entrypoint.py` creates `node_cache` and `ipfs_service` eagerly but never closes them. Two `# TODO` comments already document this gap.

## Fix

- Append `safe_async_cleanup(\"ipfs service\", ipfs_service.close())` and `safe_async_cleanup(\"node cache\", node_cache.close())` to `_on_cleanup`, between the `p2p client` close and `close_sessions`.
- Remove the two TODO comments.

After this PR (the last in the series), shutdown of the API process closes: broadcasters → mq_channel → p2p_client (which closes the shared mq_conn) → ipfs_service → node_cache → P2P HTTP sessions → engine.dispose(). The main process closes: p2p_client → P2P HTTP sessions → stop_jobs (children) → ipfs_service → node_cache → mq_channel → mq_conn → engine.dispose() (LIFO via AsyncExitStack).

## Tests

No new tests (wiring change). The series is end-to-end validated via the manual smoke test in `docs/superpowers/plans/2026-05-18-clean-shutdown.md` Appendix A.

---

Base: `fix/shutdown-close-p2p-client`. **Final PR in the series.**