### PR TITLE
refactor(jobs): unify subprocess entry points on asyncio.run

### DIFF
--- a/src/aleph/jobs/fetch_pending_messages.py
+++ b/src/aleph/jobs/fetch_pending_messages.py
@@ -31,7 +31,7 @@ from aleph.toolkit.timestamp import utc_now
 from aleph.types.db_session import DbSessionFactory
 
 from ..toolkit.rabbitmq import make_mq_conn
-from .job_utils import MessageJob, make_pending_message_queue, prepare_loop
+from .job_utils import MessageJob, make_pending_message_queue, prepare_config
 
 LOGGER = getLogger(__name__)
 
@@ -357,7 +357,7 @@ def fetch_pending_messages_subprocess(config_values: Dict):
 
     faulthandler.enable(file=sys.stderr)
     setproctitle("aleph.jobs.fetch_messages")
-    loop, config = prepare_loop(config_values)
+    config = prepare_config(config_values)
 
     setup_sentry(config)
     setup_logging(

--- a/src/aleph/jobs/job_utils.py
+++ b/src/aleph/jobs/job_utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import datetime as dt
 import logging
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Optional, Union
 
 import aio_pika
 from configmanager import Config
@@ -123,22 +123,18 @@ def schedule_next_attempt(
     pending_message.retries += 1
 
 
-def prepare_loop(config_values: Dict) -> Tuple[asyncio.AbstractEventLoop, Config]:
+def prepare_config(config_values: Dict) -> Config:
     """
-    Prepares all the global variables (sigh) needed to run an Aleph subprocess.
+    Loads the application config from values forwarded by the main process.
 
     :param config_values: Dictionary of config values, as provided by the main process.
-    :returns: A preconfigured event loop, and the application config for convenience.
-              Use the event loop as event loop of the process as it is used by Motor. Using another
-              event loop will cause DB calls to fail.
+    :returns: The hydrated application config.
     """
-
-    loop = asyncio.get_event_loop()
 
     config = aleph.config.app_config
     config.load_values(config_values)
 
-    return loop, config
+    return config
 
 
 class MqWatcher:

--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -29,7 +29,7 @@ from aleph.types.db_session import DbSessionFactory
 from aleph.types.message_processing_result import MessageProcessingResult
 
 from ..types.message_status import MessageOrigin
-from .job_utils import MessageJob, prepare_loop
+from .job_utils import MessageJob, prepare_config
 
 LOGGER = getLogger(__name__)
 
@@ -226,9 +226,8 @@ def pending_messages_subprocess(config_values: Dict):
     """
 
     faulthandler.enable(file=sys.stderr)
-
     setproctitle("aleph.jobs.messages_task_loop")
-    loop, config = prepare_loop(config_values)
+    config = prepare_config(config_values)
 
     setup_sentry(config)
     setup_logging(
@@ -237,13 +236,16 @@ def pending_messages_subprocess(config_values: Dict):
         max_log_file_size=config.logging.max_log_file_size.value,
     )
 
-    task = loop.create_task(fetch_and_process_messages_task(config=config))
-    install_signal_handlers(loop, task.cancel)
+    async def _runner():
+        task = asyncio.create_task(fetch_and_process_messages_task(config=config))
+        install_signal_handlers(asyncio.get_running_loop(), task.cancel)
+        try:
+            await task
+        except asyncio.CancelledError:
+            LOGGER.info("Process messages subprocess cancelled by signal")
 
     try:
-        loop.run_until_complete(task)
-    except asyncio.CancelledError:
-        LOGGER.info("Process messages subprocess cancelled by signal")
+        asyncio.run(_runner())
     except KeyboardInterrupt:
         LOGGER.info("Process messages subprocess interrupted")
     except SystemExit:
@@ -251,5 +253,3 @@ def pending_messages_subprocess(config_values: Dict):
     except BaseException:
         LOGGER.critical("Fatal error in process messages subprocess", exc_info=True)
         raise
-    finally:
-        loop.close()

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -30,7 +30,7 @@ from aleph.types.chain_sync import ChainSyncProtocol
 from aleph.types.db_session import DbSessionFactory
 
 from ..types.message_status import MessageOrigin
-from .job_utils import MqWatcher, make_pending_tx_queue, prepare_loop
+from .job_utils import MqWatcher, make_pending_tx_queue, prepare_config
 
 LOGGER = logging.getLogger(__name__)
 
@@ -180,9 +180,8 @@ async def handle_txs_task(config: Config):
 
 def pending_txs_subprocess(config_values: Dict):
     faulthandler.enable(file=sys.stderr)
-
     setproctitle("aleph.jobs.txs_task_loop")
-    loop, config = prepare_loop(config_values)
+    config = prepare_config(config_values)
 
     setup_sentry(config)
     setup_logging(
@@ -191,13 +190,16 @@ def pending_txs_subprocess(config_values: Dict):
         max_log_file_size=config.logging.max_log_file_size.value,
     )
 
-    task = loop.create_task(handle_txs_task(config))
-    install_signal_handlers(loop, task.cancel)
+    async def _runner():
+        task = asyncio.create_task(handle_txs_task(config))
+        install_signal_handlers(asyncio.get_running_loop(), task.cancel)
+        try:
+            await task
+        except asyncio.CancelledError:
+            LOGGER.info("Pending txs subprocess cancelled by signal")
 
     try:
-        loop.run_until_complete(task)
-    except asyncio.CancelledError:
-        LOGGER.info("Pending txs subprocess cancelled by signal")
+        asyncio.run(_runner())
     except KeyboardInterrupt:
         LOGGER.info("Pending txs subprocess interrupted")
     except SystemExit:
@@ -205,5 +207,3 @@ def pending_txs_subprocess(config_values: Dict):
     except BaseException:
         LOGGER.critical("Fatal error in pending txs subprocess", exc_info=True)
         raise
-    finally:
-        loop.close()


### PR DESCRIPTION
Follow-up to #1138 addressing the consistency nit raised in review.

## Problem

After #1138, the three jobs subprocesses installed SIGTERM handlers via two different idioms:

- `fetch_pending_messages_subprocess` used `asyncio.run(_runner())` with an inner coroutine because `asyncio.run` requires handler installation to happen on the running loop.
- `pending_messages_subprocess` and `pending_txs_subprocess` used `loop.create_task(...) + install_signal_handlers(loop, ...) + loop.run_until_complete(task)` inline because they had a pre-built loop from `prepare_loop()`.

Both work, but the asymmetry is needless noise for a future reader.

## Fix

All three subprocesses now share the same shape:

```python
config = prepare_config(config_values)
...
async def _runner():
    task = asyncio.create_task(<job_task>(config))
    install_signal_handlers(asyncio.get_running_loop(), task.cancel)
    try:
        await task
    except asyncio.CancelledError:
        LOGGER.info("<name> subprocess cancelled by signal")

try:
    asyncio.run(_runner())
except KeyboardInterrupt:
    ...
```

`prepare_loop()` is renamed to `prepare_config()` since it no longer creates the loop. This also removes the `asyncio.get_event_loop()` call which is deprecated in Python 3.12+ when no loop is running and emits a DeprecationWarning. `Tuple` is dropped from the `job_utils` typing imports along with the now-stale Motor docstring.

## Tests

No new tests. The 3 existing `tests/toolkit/test_lifecycle.py` tests still pass; behavior is unchanged across all three subprocesses.