### PR TITLE
typing: introduce SignableMessage protocol for signature verifiers

### DIFF
--- a/src/aleph/chains/abc.py
+++ b/src/aleph/chains/abc.py
@@ -1,13 +1,29 @@
 import abc
+import datetime as dt
+from typing import Optional, Protocol
 
+from aleph_message.models import Chain, MessageType
 from configmanager import Config
 
-from aleph.schemas.pending_messages import BasePendingMessage
+
+class SignableMessage(Protocol):
+    """
+    Structural type for messages that carry the fields needed for signature
+    verification. Both `BasePendingMessage` (Pydantic) and `PendingMessageDb`
+    (SQLAlchemy) satisfy this Protocol without sharing a common base class.
+    """
+
+    chain: Chain
+    sender: str
+    type: MessageType
+    item_hash: str
+    signature: Optional[str]
+    time: dt.datetime
 
 
 class Verifier(abc.ABC):
     @abc.abstractmethod
-    async def verify_signature(self, message: BasePendingMessage) -> bool: ...
+    async def verify_signature(self, message: SignableMessage) -> bool: ...
 
 
 class ChainReader(abc.ABC):

--- a/src/aleph/chains/abc.py
+++ b/src/aleph/chains/abc.py
@@ -11,14 +11,23 @@ class SignableMessage(Protocol):
     Structural type for messages that carry the fields needed for signature
     verification. Both `BasePendingMessage` (Pydantic) and `PendingMessageDb`
     (SQLAlchemy) satisfy this Protocol without sharing a common base class.
+
+    Fields are read-only properties so subclasses can narrow them
+    (e.g. `PendingPostMessage.type: Literal[MessageType.post]`).
     """
 
-    chain: Chain
-    sender: str
-    type: MessageType
-    item_hash: str
-    signature: Optional[str]
-    time: dt.datetime
+    @property
+    def chain(self) -> Chain: ...
+    @property
+    def sender(self) -> str: ...
+    @property
+    def type(self) -> MessageType: ...
+    @property
+    def item_hash(self) -> str: ...
+    @property
+    def signature(self) -> Optional[str]: ...
+    @property
+    def time(self) -> dt.datetime: ...
 
 
 class Verifier(abc.ABC):

--- a/src/aleph/chains/avalanche.py
+++ b/src/aleph/chains/avalanche.py
@@ -7,9 +7,8 @@ import bech32
 from coincurve.keys import PublicKey
 
 from aleph.chains.common import get_verification_buffer
-from aleph.schemas.pending_messages import BasePendingMessage
 
-from .abc import Verifier
+from .abc import SignableMessage, Verifier
 
 LOGGER = logging.getLogger("chains.avalanche")
 CHAIN_NAME = "AVAX"
@@ -53,7 +52,7 @@ async def get_chain_info(address):
 
 
 class AvalancheConnector(Verifier):
-    async def verify_signature(self, message: BasePendingMessage) -> bool:
+    async def verify_signature(self, message: SignableMessage) -> bool:
         """Verifies a signature of a message, return True if verified, false if not"""
 
         if message.signature is None:

--- a/src/aleph/chains/common.py
+++ b/src/aleph/chains/common.py
@@ -1,11 +1,11 @@
 import logging
 
-from aleph.schemas.pending_messages import BasePendingMessage
+from aleph.chains.abc import SignableMessage
 
 LOGGER = logging.getLogger("chains.common")
 
 
-def get_verification_buffer(message: BasePendingMessage) -> bytes:
+def get_verification_buffer(message: SignableMessage) -> bytes:
     """
     Returns the serialized string that was signed by the user when sending an Aleph message.
     """

--- a/src/aleph/chains/cosmos.py
+++ b/src/aleph/chains/cosmos.py
@@ -9,15 +9,14 @@ from cosmospy import pubkey_to_address
 from ecdsa import BadSignatureError
 
 from aleph.chains.common import get_verification_buffer
-from aleph.schemas.pending_messages import BasePendingMessage
 
-from .abc import Verifier
+from .abc import SignableMessage, Verifier
 
 LOGGER = logging.getLogger("chains.cosmos")
 CHAIN_NAME = "CSDK"
 
 
-async def get_signable_message(message: BasePendingMessage) -> Dict:
+async def get_signable_message(message: SignableMessage) -> Dict:
     signable = (get_verification_buffer(message)).decode("utf-8")
     content_message = {
         "type": "signutil/MsgSignText",
@@ -42,7 +41,7 @@ async def get_signable_message(message: BasePendingMessage) -> Dict:
     }
 
 
-async def get_verification_string(message: BasePendingMessage) -> str:
+async def get_verification_string(message: SignableMessage) -> str:
     value = await get_signable_message(message)
     return json.dumps(value, separators=(",", ":"), sort_keys=True)
 
@@ -53,7 +52,7 @@ async def get_hrp(address):
 
 
 class CosmosConnector(Verifier):
-    async def verify_signature(self, message: BasePendingMessage) -> bool:
+    async def verify_signature(self, message: SignableMessage) -> bool:
         """Verifies a signature of a message, return True if verified, false if not"""
 
         if message.signature is None:

--- a/src/aleph/chains/evm.py
+++ b/src/aleph/chains/evm.py
@@ -5,16 +5,15 @@ from eth_account import Account
 from eth_account.messages import encode_defunct
 
 from aleph.chains.common import get_verification_buffer
-from aleph.schemas.pending_messages import BasePendingMessage
 from aleph.utils import run_in_executor
 
-from .abc import Verifier
+from .abc import SignableMessage, Verifier
 
 LOGGER = logging.getLogger("chains.evm")
 
 
 class EVMVerifier(Verifier):
-    async def verify_signature(self, message: BasePendingMessage) -> bool:
+    async def verify_signature(self, message: SignableMessage) -> bool:
         """Verifies a signature of a message, return True if verified, false if not"""
 
         verification = get_verification_buffer(message)

--- a/src/aleph/chains/nuls.py
+++ b/src/aleph/chains/nuls.py
@@ -2,10 +2,9 @@ import logging
 import struct
 
 from aleph.chains.common import get_verification_buffer
-from aleph.schemas.pending_messages import BasePendingMessage
 from aleph.utils import run_in_executor
 
-from .abc import Verifier
+from .abc import SignableMessage, Verifier
 from .nuls_aleph_sdk import (
     NulsSignature,
     address_from_hash,
@@ -18,7 +17,7 @@ CHAIN_NAME = "NULS"
 
 
 class NulsConnector(Verifier):
-    async def verify_signature(self, message: BasePendingMessage) -> bool:
+    async def verify_signature(self, message: SignableMessage) -> bool:
         """Verifies a signature of a message, return True if verified, false if not"""
 
         if message.signature is None:

--- a/src/aleph/chains/nuls2.py
+++ b/src/aleph/chains/nuls2.py
@@ -27,14 +27,13 @@ from aleph.db.accessors.messages import get_unconfirmed_messages
 from aleph.db.accessors.pending_messages import count_pending_messages
 from aleph.db.accessors.pending_txs import count_pending_txs
 from aleph.schemas.chains.tx_context import TxContext
-from aleph.schemas.pending_messages import BasePendingMessage
 from aleph.toolkit.timestamp import utc_now
 from aleph.types.db_session import DbSessionFactory
 from aleph.utils import run_in_executor
 
 from ..db.models import ChainTxDb
 from ..types.chain_sync import ChainEventType
-from .abc import ChainWriter, Verifier
+from .abc import ChainWriter, SignableMessage, Verifier
 from .chain_data_service import ChainDataService, PendingTxPublisher
 
 LOGGER = logging.getLogger("chains.nuls2")
@@ -42,7 +41,7 @@ CHAIN_NAME = "NULS2"
 
 
 class Nuls2Verifier(Verifier):
-    async def verify_signature(self, message: BasePendingMessage) -> bool:
+    async def verify_signature(self, message: SignableMessage) -> bool:
         """Verifies a signature of a message, return True if verified, false if not"""
 
         if message.signature is None:

--- a/src/aleph/chains/signature_verifier.py
+++ b/src/aleph/chains/signature_verifier.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from aleph_message.models import Chain
 
-from aleph.chains.abc import Verifier
+from aleph.chains.abc import SignableMessage, Verifier
 from aleph.chains.avalanche import AvalancheConnector
 from aleph.chains.cosmos import CosmosConnector
 from aleph.chains.ethereum import EthereumVerifier
@@ -12,7 +12,6 @@ from aleph.chains.nuls2 import Nuls2Verifier
 from aleph.chains.solana import SolanaConnector
 from aleph.chains.substrate import SubstrateConnector
 from aleph.chains.tezos import TezosVerifier
-from aleph.schemas.pending_messages import BasePendingMessage
 from aleph.types.message_status import InvalidMessageFormat, InvalidSignature
 
 
@@ -54,7 +53,7 @@ class SignatureVerifier:
             Chain.ZORA: EVMVerifier(),
         }
 
-    async def verify_signature(self, message: BasePendingMessage) -> None:
+    async def verify_signature(self, message: SignableMessage) -> None:
         try:
             verifier = self.verifiers[message.chain]
         except KeyError:

--- a/src/aleph/chains/solana.py
+++ b/src/aleph/chains/solana.py
@@ -6,16 +6,15 @@ from nacl.exceptions import BadSignatureError
 from nacl.signing import VerifyKey
 
 from aleph.chains.common import get_verification_buffer
-from aleph.schemas.pending_messages import BasePendingMessage
 
-from .abc import Verifier
+from .abc import SignableMessage, Verifier
 
 LOGGER = logging.getLogger("chains.solana")
 CHAIN_NAME = "SOL"
 
 
 class SolanaConnector(Verifier):
-    async def verify_signature(self, message: BasePendingMessage) -> bool:
+    async def verify_signature(self, message: SignableMessage) -> bool:
         """Verifies a signature of a message, return True if verified, false if not"""
 
         if message.signature is None:

--- a/src/aleph/chains/substrate.py
+++ b/src/aleph/chains/substrate.py
@@ -4,15 +4,14 @@ import logging
 from substrateinterface import Keypair
 
 from aleph.chains.common import get_verification_buffer
-from aleph.schemas.pending_messages import BasePendingMessage
 
-from .abc import Verifier
+from .abc import SignableMessage, Verifier
 
 LOGGER = logging.getLogger("chains.substrate")
 
 
 class SubstrateConnector(Verifier):
-    async def verify_signature(self, message: BasePendingMessage) -> bool:
+    async def verify_signature(self, message: SignableMessage) -> bool:
         """Verifies a signature of a message, return True if verified, false if not"""
 
         if message.signature is None:

--- a/src/aleph/chains/tezos.py
+++ b/src/aleph/chains/tezos.py
@@ -11,7 +11,7 @@ from nacl.exceptions import BadSignatureError
 from pytezos_crypto.key import Key
 
 import aleph.toolkit.json as aleph_json
-from aleph.chains.abc import ChainReader, Verifier
+from aleph.chains.abc import ChainReader, SignableMessage, Verifier
 from aleph.chains.chain_data_service import PendingTxPublisher
 from aleph.chains.common import get_verification_buffer
 from aleph.db.accessors.chains import get_last_height, upsert_chain_sync_status
@@ -21,7 +21,6 @@ from aleph.schemas.chains.tezos_indexer_response import (
     IndexerResponse,
     SyncStatus,
 )
-from aleph.schemas.pending_messages import BasePendingMessage
 from aleph.toolkit.timestamp import utc_now
 from aleph.types.chain_sync import ChainEventType, ChainSyncProtocol
 from aleph.types.db_session import DbSession, DbSessionFactory
@@ -86,7 +85,7 @@ def micheline_verification_buffer(
 
 
 def get_tezos_verification_buffer(
-    message: BasePendingMessage, signature_type: TezosSignatureType, dapp_url: str
+    message: SignableMessage, signature_type: TezosSignatureType, dapp_url: str
 ) -> bytes:
     verification_buffer = get_verification_buffer(message)
 
@@ -190,7 +189,7 @@ async def extract_aleph_messages_from_indexer_response(
 
 
 class TezosVerifier(Verifier):
-    async def verify_signature(self, message: BasePendingMessage) -> bool:
+    async def verify_signature(self, message: SignableMessage) -> bool:
         """
         Verifies the cryptographic signature of a message signed with a Tezos key.
         """

--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -90,10 +90,9 @@ class BaseMessageHandler:
     def get_content_handler(self, message_type: MessageType) -> ContentHandler:
         return self.content_handlers[message_type]
 
-    async def verify_signature(self, pending_message: PendingMessageDb):
+    async def verify_signature(self, pending_message: PendingMessageDb) -> None:
         if pending_message.check_message:
-            # TODO: remove type: ignore by deciding the pending message type
-            await self._signature_verifier.verify_signature(pending_message)  # type: ignore
+            await self._signature_verifier.verify_signature(pending_message)
 
     async def fetch_pending_message(
         self, pending_message: PendingMessageDb
@@ -313,10 +312,9 @@ class MessageHandler(BaseMessageHandler):
         super().__init__(storage_service=storage_service, config=config)
         self._signature_verifier = signature_verifier
 
-    async def verify_signature(self, pending_message: PendingMessageDb):
+    async def verify_signature(self, pending_message: PendingMessageDb) -> None:
         if pending_message.check_message:
-            # TODO: remove type: ignore by deciding the pending message type
-            await self._signature_verifier.verify_signature(pending_message)  # type: ignore[arg-type]
+            await self._signature_verifier.verify_signature(pending_message)
 
     @staticmethod
     async def confirm_existing_message(

--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -90,10 +90,6 @@ class BaseMessageHandler:
     def get_content_handler(self, message_type: MessageType) -> ContentHandler:
         return self.content_handlers[message_type]
 
-    async def verify_signature(self, pending_message: PendingMessageDb) -> None:
-        if pending_message.check_message:
-            await self._signature_verifier.verify_signature(pending_message)
-
     async def fetch_pending_message(
         self, pending_message: PendingMessageDb
     ) -> MessageDb:


### PR DESCRIPTION
## Problem

`Verifier.verify_signature` was declared to take `BasePendingMessage` (Pydantic), but the only callers in `BaseMessageHandler.verify_signature` / `MessageHandler.verify_signature` pass a `PendingMessageDb` (SQLAlchemy). The two classes share no base, so the mismatch was silenced with two `# type: ignore` comments and an open TODO:

```python
# TODO: remove type: ignore by deciding the pending message type
await self._signature_verifier.verify_signature(pending_message)  # type: ignore
```

This affected `handlers/message_handler.py` lines 96 and 319.

## Fix

Both classes expose exactly the same six fields the verification path touches: `chain`, `sender`, `type`, `item_hash`, `signature`, `time`. Define a structural `SignableMessage` Protocol over those fields and use it throughout the verification chain:

- `Verifier` ABC and `SignatureVerifier` orchestrator
- `get_verification_buffer` in `chains/common`
- every per-chain Verifier (EVM, Ethereum, Solana, Cosmos, Avalanche, Nuls, Nuls2, Substrate, Tezos) and their helpers (`get_signable_message`, `get_verification_string`, `get_tezos_verification_buffer`)

Both `BasePendingMessage` and `PendingMessageDb` satisfy the Protocol structurally with no runtime change, so the two `# type: ignore` comments and TODOs in `handlers/message_handler.py` are removed, and the two `verify_signature` overrides now declare `-> None` explicitly.

## Test plan

- [x] `venv/bin/python -m pytest tests/chains/ --deselect tests/chains/test_ethereum.py -q` (34 passed, 3 skipped). `test_ethereum.py` requires anvil on `127.0.0.1:8545`.
- [x] `venv/bin/python -m pytest tests/message_processing/ -q` (44 passed; the 20 errors in `test_process_stores.py` are pre-existing fixture failures unrelated to this PR).
- [x] `venv/bin/isort` + `venv/bin/black` on the 12 modified files report no changes.
- [x] Smoke import: `from aleph.chains.abc import SignableMessage, Verifier; from aleph.chains.signature_verifier import SignatureVerifier` resolves.

## Out of scope

This is item (1) of a broader type-hint audit. Other findings (Any-leakage in JSONB content columns, missing return annotations on async functions, generic helpers that should be `TypeVar`-parametrized, etc.) will follow in separate PRs.