### PR TITLE
fix(api): enforce balance check on all authenticated uploads

### DIFF
--- a/src/aleph/web/controllers/ipfs.py
+++ b/src/aleph/web/controllers/ipfs.py
@@ -131,11 +131,11 @@ async def ipfs_add_file(request: web.Request):
                 max_size=max_unauthenticated_upload_file_size,
             )
 
-        # Validate the signed message BEFORE pinning so a bad signature
-        # cannot leave an orphan pin on the IPFS daemon. Note: by this
-        # point the file is already buffered to a temp file (multipart
-        # parts are consumed in arrival order); we gate the pin step,
-        # not the multipart read.
+        # Validate the signed message and balance BEFORE pinning so neither
+        # a bad signature nor an underfunded account leaves an orphan pin on
+        # the IPFS daemon. By this point the file is already buffered to a
+        # temp file (multipart parts are consumed in arrival order); we gate
+        # the pin step, not the multipart read.
         message = None
         message_content = None
         sync = False
@@ -173,7 +173,11 @@ async def ipfs_add_file(request: web.Request):
                     )
                 )
 
-        # Pin to IPFS — side effect: file is now on the local IPFS node.
+            message_content.estimated_size_mib = math.ceil(uploaded_file.size / MiB)
+            with session_factory() as session:
+                _verify_user_balance(session=session, content=message_content)
+
+        # Pin to IPFS, side effect: file is now on the local IPFS node.
         temp_file = await uploaded_file.open_temp_file()
         file_content = await temp_file.read()
         if isinstance(file_content, str):
@@ -181,7 +185,7 @@ async def ipfs_add_file(request: web.Request):
 
         cid = await ipfs_service.add_bytes(file_content)
 
-        # Post-pin: stat, CID match, balance check, persist.
+        # Post-pin: stat, CID match, persist.
         # Failures from this point on must leave the pin covered by the
         # 24 h grace period so the GC doesn't strand it.
         try:
@@ -194,23 +198,13 @@ async def ipfs_add_file(request: web.Request):
                 raise web.HTTPGatewayTimeout(reason="Timed out waiting for IPFS stat")
             size = stats["Size"]
 
-            if message_content is not None:
-                message_content.estimated_size_mib = math.ceil(uploaded_file.size / MiB)
-                if message_content.item_hash != cid:
-                    raise web.HTTPUnprocessableEntity(
-                        reason=(
-                            f"File hash does not match "
-                            f"({cid} != {message_content.item_hash})"
-                        )
+            if message_content is not None and message_content.item_hash != cid:
+                raise web.HTTPUnprocessableEntity(
+                    reason=(
+                        f"File hash does not match "
+                        f"({cid} != {message_content.item_hash})"
                     )
-                with session_factory() as session:
-                    _verify_user_balance(
-                        session=session,
-                        content=message_content,
-                        max_unauthenticated_upload_file_size=(
-                            max_unauthenticated_upload_file_size
-                        ),
-                    )
+                )
 
             with session_factory() as session:
                 upsert_file(

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -153,21 +153,15 @@ async def _verify_message_signature(
 def _verify_user_balance(
     session: DbSession,
     content: CostEstimationStoreContent,
-    max_unauthenticated_upload_file_size: int,
 ) -> None:
-    if content.estimated_size_mib and content.estimated_size_mib > (
-        max_unauthenticated_upload_file_size / MiB
-    ):
-        current_balance = get_total_balance(session=session, address=content.address)
-        current_cost = get_total_cost_for_address(
-            session=session, address=content.address
-        )
-        message_cost, _ = get_total_and_detailed_costs(session, content, "")
+    current_balance = get_total_balance(session=session, address=content.address)
+    current_cost = get_total_cost_for_address(session=session, address=content.address)
+    message_cost, _ = get_total_and_detailed_costs(session, content, "")
 
-        required_balance = current_cost + message_cost
+    required_balance = current_cost + message_cost
 
-        if current_balance < required_balance:
-            raise web.HTTPPaymentRequired()
+    if current_balance < required_balance:
+        raise web.HTTPPaymentRequired()
 
 
 class StorageMetadata(pydantic.BaseModel):
@@ -269,7 +263,6 @@ async def _check_and_add_file(
     message: Optional[PendingStoreMessage],
     uploaded_file: UploadedFile,
     grace_period: int,
-    max_unauthenticated_upload_file_size: int,
 ) -> str:
     file_hash = uploaded_file.get_hash()
     # Perform authentication and balance checks
@@ -299,7 +292,6 @@ async def _check_and_add_file(
             _verify_user_balance(
                 session=session,
                 content=message_content,
-                max_unauthenticated_upload_file_size=max_unauthenticated_upload_file_size,
             )
     else:
         message_content = None
@@ -467,7 +459,6 @@ async def storage_add_file(request: web.Request):
             message=message,
             uploaded_file=uploaded_file,
             grace_period=grace_period,
-            max_unauthenticated_upload_file_size=max_unauthenticated_upload_file_size,
         )
         if message:
             broadcast_status = await broadcast_and_process_message(

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -15,8 +15,6 @@ from aleph_message.models import ItemHash, ItemType
 from pydantic import ValidationError
 
 from aleph.chains.signature_verifier import SignatureVerifier
-from aleph.db.accessors.balances import get_total_balance
-from aleph.db.accessors.cost import get_total_cost_for_address
 from aleph.db.accessors.files import (
     count_file_pins,
     get_file,
@@ -31,12 +29,17 @@ from aleph.schemas.pending_messages import (
     PendingInlineStoreMessage,
     PendingStoreMessage,
 )
-from aleph.services.cost import get_total_and_detailed_costs
+from aleph.services.cost import get_payment_type, get_total_and_detailed_costs
+from aleph.services.cost_validation import validate_balance_for_payment
 from aleph.storage import StorageService
 from aleph.toolkit.constants import MiB
 from aleph.types.db_session import DbSession, DbSessionFactory
 from aleph.types.files import FileTag, FileType
-from aleph.types.message_status import InvalidSignature
+from aleph.types.message_status import (
+    InsufficientBalanceException,
+    InsufficientCreditException,
+    InvalidSignature,
+)
 from aleph.utils import item_type_from_hash, run_in_executor
 from aleph.web.controllers.app_state_getters import (
     get_config_from_request,
@@ -154,13 +157,16 @@ def _verify_user_balance(
     session: DbSession,
     content: CostEstimationStoreContent,
 ) -> None:
-    current_balance = get_total_balance(session=session, address=content.address)
-    current_cost = get_total_cost_for_address(session=session, address=content.address)
+    payment_type = get_payment_type(content)
     message_cost, _ = get_total_and_detailed_costs(session, content, "")
-
-    required_balance = current_cost + message_cost
-
-    if current_balance < required_balance:
+    try:
+        validate_balance_for_payment(
+            session=session,
+            address=content.address,
+            message_cost=message_cost,
+            payment_type=payment_type,
+        )
+    except (InsufficientBalanceException, InsufficientCreditException):
         raise web.HTTPPaymentRequired()
 
 

--- a/tests/api/test_ipfs.py
+++ b/tests/api/test_ipfs.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import json
 from decimal import Decimal
 from io import BytesIO
@@ -12,7 +13,7 @@ from in_memory_storage_engine import InMemoryStorageEngine
 
 from aleph.chains.signature_verifier import SignatureVerifier
 from aleph.db.accessors.files import get_file
-from aleph.db.models import AlephBalanceDb, GracePeriodFilePinDb
+from aleph.db.models import AlephBalanceDb, AlephCreditBalanceDb, GracePeriodFilePinDb
 from aleph.storage import StorageService
 from aleph.types.db_session import DbSessionFactory
 from aleph.types.files import FileType
@@ -51,6 +52,24 @@ IPFS_MESSAGE_DICT: dict[str, Any] = {
         }
     ),
     "item_hash": "6e717bf3296372a4d7b470a1a29ec2694a78a338002f33c94cb2f518e0c1fdb8",
+}
+
+# Same message but credit-paid. Used to exercise the credit-tier branch in
+# the API-level balance check.
+IPFS_MESSAGE_DICT_CREDIT: dict[str, Any] = {
+    **IPFS_MESSAGE_DICT,
+    "item_content": json.dumps(
+        {
+            "address": "0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+            "time": 1692193373.714271,
+            "item_type": "ipfs",
+            "item_hash": EXPECTED_FILE_CID,
+            "mime_type": "application/octet-stream",
+            "payment": {"type": "credit", "chain": "ETH"},
+        }
+    ),
+    # Outer item_hash = sha256(item_content), required by pydantic.
+    "item_hash": "f87f7b55a8398d8980ef00267b5df574b22dfeb6e6ecf41ee219bf4da00d8217",
 }
 
 
@@ -451,3 +470,106 @@ async def test_auth_upload_stat_timeout_applies_grace(
         file = get_file(session=session, file_hash=EXPECTED_FILE_CID)
         assert file is not None
         assert _has_grace_period(session, EXPECTED_FILE_CID)
+
+
+@pytest.mark.asyncio
+async def test_auth_credit_upload_insufficient_credit_balance(
+    api_client,
+    session_factory: DbSessionFactory,
+    mocker,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """
+    Credit-paid STORE with zero credit balance is rejected pre-pin with 402.
+    An ALEPH token balance is irrelevant: the credit branch reads credits
+    only. The address gets a large ALEPH balance to make this explicit.
+    """
+    mocker.patch(
+        "aleph.web.controllers.ipfs._verify_message_signature",
+        new_callable=mocker.AsyncMock,
+    )
+    ipfs_service = _get_ipfs_service_mock(api_client)
+
+    # ALEPH balance must not satisfy a credit-paid request.
+    with session_factory() as session:
+        session.add(
+            AlephBalanceDb(
+                address="0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+                chain=Chain.ETH,
+                balance=Decimal(1_000_000),
+                eth_height=0,
+            )
+        )
+        session.commit()
+
+    form_data = aiohttp.FormData()
+    form_data.add_field("file", BytesIO(FILE_CONTENT))
+    form_data.add_field(
+        "metadata",
+        json.dumps({"message": IPFS_MESSAGE_DICT_CREDIT, "sync": False}),
+        content_type="application/json",
+    )
+
+    response = await api_client.post(IPFS_ADD_FILE_URI, data=form_data)
+    assert response.status == 402, await response.text()
+
+    ipfs_service.add_bytes.assert_not_called()
+    with session_factory() as session:
+        assert get_file(session=session, file_hash=EXPECTED_FILE_CID) is None
+        assert not _has_grace_period(session, EXPECTED_FILE_CID)
+
+
+@pytest.mark.asyncio
+async def test_auth_credit_upload_sufficient_credit_balance(
+    api_client,
+    session_factory: DbSessionFactory,
+    mocker,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """
+    Credit-paid STORE with enough credits to cover the 1-day minimum
+    runtime passes the API check and the file is pinned.
+    """
+    mocker.patch(
+        "aleph.web.controllers.ipfs._verify_message_signature",
+        new_callable=mocker.AsyncMock,
+    )
+    mocker.patch(
+        "aleph.web.controllers.ipfs.broadcast_and_process_message",
+        new_callable=mocker.AsyncMock,
+        return_value=BroadcastStatus(
+            publication_status=PublicationStatus.from_failures([]),
+            message_status=MessageStatus.PROCESSED,
+        ),
+    )
+
+    # Seed the credit cache directly. The amount is well above one day of
+    # storage cost for a 34-byte file, so the 1-day minimum runtime check
+    # in validate_balance_for_payment is satisfied.
+    with session_factory() as session:
+        session.add(
+            AlephCreditBalanceDb(
+                address="0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+                credit_ref="test-credit-ref",
+                credit_index=0,
+                amount_remaining=1_000_000_000,
+                expiration_date=None,
+                message_timestamp=dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc),
+            )
+        )
+        session.commit()
+
+    form_data = aiohttp.FormData()
+    form_data.add_field("file", BytesIO(FILE_CONTENT))
+    form_data.add_field(
+        "metadata",
+        json.dumps({"message": IPFS_MESSAGE_DICT_CREDIT, "sync": True}),
+        content_type="application/json",
+    )
+
+    response = await api_client.post(IPFS_ADD_FILE_URI, data=form_data)
+    assert response.status == 200, await response.text()
+    payload = await response.json()
+    assert payload["hash"] == EXPECTED_FILE_CID

--- a/tests/api/test_ipfs.py
+++ b/tests/api/test_ipfs.py
@@ -302,6 +302,17 @@ async def test_auth_upload_cid_mismatch(
         new_callable=mocker.AsyncMock,
     )
 
+    with session_factory() as session:
+        session.add(
+            AlephBalanceDb(
+                address="0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+                chain=Chain.ETH,
+                balance=Decimal(1000),
+                eth_height=0,
+            )
+        )
+        session.commit()
+
     # Message claims a different CID than the fixture's mocked add_bytes.
     mismatched = {
         **IPFS_MESSAGE_DICT,
@@ -314,7 +325,7 @@ async def test_auth_upload_cid_mismatch(
                 "mime_type": "application/octet-stream",
             }
         ),
-        # Outer item_hash = sha256(item_content) — required by pydantic.
+        # Outer item_hash = sha256(item_content), required by pydantic.
         "item_hash": "dcaa4ab4374b11084ca2fea61d9235f06d658f97adb18af8b4bd659adf0377af",
     }
 
@@ -350,21 +361,20 @@ async def test_auth_upload_insufficient_balance(
     fixture_settings_aggregate_in_db,
 ):
     """
-    File above the unauth threshold with insufficient balance returns 402
-    and leaves the pinned file under a 24 h grace period.
+    Authenticated upload with insufficient balance returns 402 BEFORE the
+    file is pinned, regardless of size. No IPFS write, no file row, no
+    grace-period side effect.
     """
     mocker.patch(
         "aleph.web.controllers.ipfs._verify_message_signature",
         new_callable=mocker.AsyncMock,
     )
+    ipfs_service = _get_ipfs_service_mock(api_client)
 
-    # 26 MiB payload > 25 MiB unauth cap, so balance check fires.
-    payload = b"x" * (26 * 1024 * 1024)
-
-    # No balance row inserted → balance is zero.
-
+    # No balance row inserted; balance is zero. File is tiny, well under
+    # the legacy 25 MiB unauth threshold, to prove size doesn't matter.
     form_data = aiohttp.FormData()
-    form_data.add_field("file", BytesIO(payload))
+    form_data.add_field("file", BytesIO(FILE_CONTENT))
     form_data.add_field(
         "metadata",
         json.dumps({"message": IPFS_MESSAGE_DICT, "sync": False}),
@@ -374,50 +384,10 @@ async def test_auth_upload_insufficient_balance(
     response = await api_client.post(IPFS_ADD_FILE_URI, data=form_data)
     assert response.status == 402, await response.text()
 
+    ipfs_service.add_bytes.assert_not_called()
     with session_factory() as session:
-        file = get_file(session=session, file_hash=EXPECTED_FILE_CID)
-        assert file is not None
-        assert _has_grace_period(session, EXPECTED_FILE_CID)
-
-
-@pytest.mark.asyncio
-async def test_auth_upload_small_file_skips_balance_check(
-    api_client, session_factory: DbSessionFactory, mocker
-):
-    """
-    For files below max_unauthenticated_upload_file_size, the balance check
-    short-circuits even when balance is zero. Matches /storage/add_file's
-    rule: anything you could have uploaded unauth for free doesn't need a
-    balance check.
-
-    We deliberately do NOT mock _verify_user_balance: its internal threshold
-    short-circuit is exactly what we want to exercise. Zero balance + tiny
-    file → request must succeed.
-    """
-    mocker.patch(
-        "aleph.web.controllers.ipfs._verify_message_signature",
-        new_callable=mocker.AsyncMock,
-    )
-    mocker.patch(
-        "aleph.web.controllers.ipfs.broadcast_and_process_message",
-        new_callable=mocker.AsyncMock,
-        return_value=BroadcastStatus(
-            publication_status=PublicationStatus.from_failures([]),
-            message_status=MessageStatus.PROCESSED,
-        ),
-    )
-
-    # No balance inserted — balance is zero. File is 34 bytes << 25 MiB.
-    form_data = aiohttp.FormData()
-    form_data.add_field("file", BytesIO(FILE_CONTENT))
-    form_data.add_field(
-        "metadata",
-        json.dumps({"message": IPFS_MESSAGE_DICT, "sync": True}),
-        content_type="application/json",
-    )
-
-    response = await api_client.post(IPFS_ADD_FILE_URI, data=form_data)
-    assert response.status == 200, await response.text()
+        assert get_file(session=session, file_hash=EXPECTED_FILE_CID) is None
+        assert not _has_grace_period(session, EXPECTED_FILE_CID)
 
 
 @pytest.mark.asyncio
@@ -454,6 +424,17 @@ async def test_auth_upload_stat_timeout_applies_grace(
     ipfs_service.pinning_client.files.stat = mocker.AsyncMock(
         side_effect=TimeoutError()
     )
+
+    with session_factory() as session:
+        session.add(
+            AlephBalanceDb(
+                address="0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+                chain=Chain.ETH,
+                balance=Decimal(1000),
+                eth_height=0,
+            )
+        )
+        session.commit()
 
     form_data = aiohttp.FormData()
     form_data.add_field("file", BytesIO(FILE_CONTENT))

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -296,7 +296,7 @@ async def test_storage_add_file_raw_upload(
             b"Hello Aleph.im\n",
             "0214e5578f5acb5d36ea62255cbf1157a4bdde7b9612b5db4899b2175e310b6f",
             None,
-            "200",
+            "402",
             "0",
         ),
         (


### PR DESCRIPTION
## Summary

`_verify_user_balance` had two independent bugs that together let underfunded uploads through the API and into the message pipeline:

1. **Size-threshold gate.** The check short-circuited whenever the file size sat at or below `max_unauthenticated_upload_file_size` (25 MiB by default). The gate was meant to keep anonymous uploads free; it accidentally applied to authenticated uploads too. For any STORE attached to a sub-25 MiB upload the API returned success without checking that the sender could pay.
2. **Hold-only balance math.** Even when the gate did fire, the check called `get_total_balance` (ALEPH tokens) and `get_total_cost_for_address` with the default `payment_type=PaymentType.hold`, but `get_total_and_detailed_costs` returned the message cost in whatever payment type the content declared. For a credit-paid STORE that compared ALEPH holdings against credit costs, which is incoherent both ways: users with credits but no ALEPH were falsely rejected, and users with ALEPH but no credits were falsely accepted (the message then died downstream).

This PR makes the API-level check unconditional whenever a STORE message accompanies the upload, and routes it through `validate_balance_for_payment`, the same helper `StoreMessageHandler.check_balance` already uses. That helper branches on the content's payment type, reads the right balance and cost columns, and enforces the 1-day minimum runtime requirement on the credit branch (credit storage cost is a per-second rate, mirrored from the pipeline's own model). The internal `InsufficientBalanceException` / `InsufficientCreditException` are translated to HTTP 402 at the controller boundary.

In `ipfs_add_file` the balance check also moves above `ipfs_service.add_bytes`, so an underfunded request leaves no pin on the IPFS daemon. The CID match check stays post-pin since it depends on the daemon's output.

The unauthenticated size cap remains as the entry gate for the anonymous path, but it no longer doubles as a "skip balance" condition. The API is now stricter than the message pipeline (which still has a legacy `PaymentType.hold + small file` carve-out); that asymmetry is acceptable while hold payments are phased out.

## Changes

- `storage.py`: drop the size-threshold gate in `_verify_user_balance`; rewrite the body to delegate to `validate_balance_for_payment` and translate internal exceptions to `HTTPPaymentRequired`. Drop the now-unused `max_unauthenticated_upload_file_size` plumbing in `_check_and_add_file` and `storage_add_file`.
- `ipfs.py`: move balance check to before `ipfs_service.add_bytes`.

## Test plan

- [x] `tests/api/test_ipfs.py`: strict pre-pin balance test asserts 402 + `add_bytes` not called + no file row + no grace period. `cid_mismatch` and `stat_timeout` now seed a balance row since they previously rode on the size-threshold skip. New tests cover credit-paid STORE both ways: zero credits with large ALEPH balance returns 402 with no pin; sufficient credits returns 200.
- [x] `tests/api/test_storage.py`: the `balance=0` parametrize case for `test_storage_add_file_with_message` now expects 402.
- [x] Full `tests/api/` suite: 177 passed, 6 skipped.
- [x] `ruff` + `black` clean.
