### PR TITLE
typing: narrow JSONB content fields and credit-handler signatures

### DIFF
--- a/src/aleph/db/models/aggregates.py
+++ b/src/aleph/db/models/aggregates.py
@@ -1,5 +1,5 @@
 import datetime as dt
-from typing import Any
+from typing import Any, Dict
 
 from sqlalchemy import TIMESTAMP, Boolean, ForeignKey, Index, String
 from sqlalchemy.dialects.postgresql import JSONB
@@ -22,7 +22,7 @@ class AggregateElementDb(Base):
     item_hash: Mapped[str] = mapped_column(String, primary_key=True)
     key: Mapped[str] = mapped_column(String, nullable=False)
     owner: Mapped[str] = mapped_column(String, nullable=False)
-    content: Mapped[Any] = mapped_column(JSONB, nullable=False)
+    content: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False)
     creation_datetime: Mapped[dt.datetime] = mapped_column(
         TIMESTAMP(timezone=True), nullable=False
     )
@@ -44,7 +44,7 @@ class AggregateDb(Base):
 
     key: Mapped[str] = mapped_column(String, primary_key=True)
     owner: Mapped[str] = mapped_column(String, primary_key=True)
-    content: Mapped[Any] = mapped_column(JSONB, nullable=False)
+    content: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False)
     creation_datetime: Mapped[dt.datetime] = mapped_column(
         TIMESTAMP(timezone=True), nullable=False
     )

--- a/src/aleph/db/models/messages.py
+++ b/src/aleph/db/models/messages.py
@@ -161,7 +161,7 @@ class MessageDb(Base):
     signature: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     item_type: Mapped[ItemType] = mapped_column(ChoiceType(ItemType), nullable=False)
     item_content: Mapped[Optional[str]] = mapped_column(String, nullable=True)
-    content: Mapped[Any] = mapped_column(JSONB, nullable=False)
+    content: Mapped[Dict[str, Any]] = mapped_column(JSONB, nullable=False)
     time: Mapped[dt.datetime] = mapped_column(
         TIMESTAMP(timezone=True), nullable=False, index=True
     )

--- a/src/aleph/handlers/content/post.py
+++ b/src/aleph/handlers/content/post.py
@@ -1,9 +1,9 @@
 import datetime as dt
 import logging
-from typing import Any, Dict, List, Mapping, Optional, Set, Union
+from typing import Any, Dict, List, Mapping, Optional, Set, Type, TypeVar, Union
 
 from aleph_message.models import Chain, ChainRef, PostContent
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 from sqlalchemy import update
 
 from aleph.db.accessors.balances import get_credit_balance
@@ -79,18 +79,25 @@ def update_balances(session: DbSession, content: Mapping[str, Any]) -> None:
     )
 
 
+T = TypeVar("T", bound=BaseModel)
+
+
+def _parse_credit_content(
+    model_cls: Type[T], content: Mapping[str, Any], *, kind: str
+) -> T:
+    try:
+        return model_cls.model_validate(content)
+    except ValidationError as e:
+        raise InvalidMessageFormat(f"Invalid credit {kind} content: {e.errors()}")
+
+
 def update_credit_balances_distribution(
     session: DbSession,
-    content: Mapping[str, Any],
+    content: CreditDistributionContent,
     message_hash: str,
     message_timestamp: dt.datetime,
 ) -> None:
-    try:
-        parsed = CreditDistributionContent.model_validate(content)
-    except ValidationError as e:
-        raise InvalidMessageFormat(f"Invalid credit distribution content: {e.errors()}")
-
-    dist = parsed.distribution
+    dist = content.distribution
     LOGGER.info("Updating credit balances for %d addresses", len(dist.credits))
 
     update_credit_balances_distribution_db(
@@ -105,16 +112,11 @@ def update_credit_balances_distribution(
 
 def update_credit_balances_expense(
     session: DbSession,
-    content: Mapping[str, Any],
+    content: CreditExpenseContent,
     message_hash: str,
     message_timestamp: dt.datetime,
 ) -> None:
-    try:
-        parsed = CreditExpenseContent.model_validate(content)
-    except ValidationError as e:
-        raise InvalidMessageFormat(f"Invalid credit expense content: {e.errors()}")
-
-    expense = parsed.expense
+    expense = content.expense
     LOGGER.info(
         "Updating credit balances expense for %d addresses", len(expense.credits)
     )
@@ -129,19 +131,13 @@ def update_credit_balances_expense(
 
 def update_credit_balances_transfer(
     session: DbSession,
-    content: Mapping[str, Any],
+    content: CreditTransferContent,
     message_hash: str,
     message_timestamp: dt.datetime,
     sender_address: str,
     whitelisted_addresses: List[str],
 ) -> None:
-
-    try:
-        parsed = CreditTransferContent.model_validate(content)
-    except ValidationError as e:
-        raise InvalidMessageFormat(f"Invalid credit transfer content: {e.errors()}")
-
-    credits_list = parsed.transfer.credits
+    credits_list = content.transfer.credits
 
     # Reject self-transfers
     for entry in credits_list:
@@ -305,7 +301,11 @@ class PostMessageHandler(ContentHandler):
             ):
                 update_credit_balances_distribution(
                     session=session,
-                    content=content.content,
+                    content=_parse_credit_content(
+                        CreditDistributionContent,
+                        content.content,
+                        kind="distribution",
+                    ),
                     message_hash=message.item_hash,
                     message_timestamp=creation_datetime,
                 )
@@ -315,14 +315,18 @@ class PostMessageHandler(ContentHandler):
             ):
                 update_credit_balances_expense(
                     session=session,
-                    content=content.content,
+                    content=_parse_credit_content(
+                        CreditExpenseContent, content.content, kind="expense"
+                    ),
                     message_hash=message.item_hash,
                     message_timestamp=creation_datetime,
                 )
             elif content.type == "aleph_credit_transfer":
                 update_credit_balances_transfer(
                     session=session,
-                    content=content.content,
+                    content=_parse_credit_content(
+                        CreditTransferContent, content.content, kind="transfer"
+                    ),
                     message_hash=message.item_hash,
                     message_timestamp=creation_datetime,
                     sender_address=content.address,

--- a/src/aleph/handlers/content/post.py
+++ b/src/aleph/handlers/content/post.py
@@ -1,6 +1,17 @@
 import datetime as dt
 import logging
-from typing import Any, Dict, List, Mapping, Optional, Set, Type, TypeVar, Union
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Set,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from aleph_message.models import Chain, ChainRef, PostContent
 from pydantic import BaseModel, ValidationError
@@ -83,7 +94,10 @@ T = TypeVar("T", bound=BaseModel)
 
 
 def _parse_credit_content(
-    model_cls: Type[T], content: Mapping[str, Any], *, kind: str
+    model_cls: Type[T],
+    content: Mapping[str, Any],
+    *,
+    kind: Literal["distribution", "expense", "transfer"],
 ) -> T:
     try:
         return model_cls.model_validate(content)


### PR DESCRIPTION
Item (2) of the type-hint audit. Two related tightening passes that remove `Any` from places where the real type is known.

## JSONB content columns

`MessageDb.content`, `AggregateElementDb.content`, and `AggregateDb.content` were declared `Mapped[Any]` while the underlying JSONB columns store dict shapes at the top level in every Aleph message variant. Narrow them to `Mapped[Dict[str, Any]]`. Callers that read `.content` now see a dict statically, eliminating an entire category of accidental scalar-access bugs.

## Credit-handler signatures

`update_credit_balances_distribution`, `update_credit_balances_expense`, and `update_credit_balances_transfer` each took `content: Mapping[str, Any]` and immediately ran `CreditDistributionContent.model_validate(content)` (and friends). The signature claimed an untyped dict, but the body required a specific Pydantic shape and raised `InvalidMessageFormat` on mismatch. The signature was lying.

Move the parsing into the `PostMessageHandler.process_post` dispatcher via a small `_parse_credit_content` helper (TypeVar-generic, raises `InvalidMessageFormat` with a kind-tagged message). The three handler signatures now take the parsed model directly. This:

- removes three try/except blocks of duplicate error handling
- makes the handlers self-documenting via their parameter type
- centralizes parsing in the dispatcher where the dispatch decision is made

`update_balances` (the non-credit balance updater) does raw dict access and never parses into a Pydantic model, so it's left as `Mapping[str, Any]`.

## Out of scope

The original audit also flagged `chain_data_service.py`'s `list[dict[str, Any]]` returns. On closer inspection, only the smart-contract protocol path normalizes the dict shape; the on-chain and off-chain protocol paths pass arbitrary JSON through. Introducing a `TxMessageDict` TypedDict honestly there requires normalizing those legacy paths too, which is a larger refactor. Deferred to a follow-up.

## Test plan

- [x] `venv/bin/python -m pytest tests/message_processing/test_process_posts.py tests/db/test_credit_balances.py tests/balances/test_balances.py -q` — 60 passed
- [x] `venv/bin/isort` + `venv/bin/black` clean on changed files
- [x] Smoke import: `from aleph.handlers.content.post import update_credit_balances_distribution, _parse_credit_content` resolves; signature is `(session, content: CreditDistributionContent, message_hash, message_timestamp) -> None`