### PR TITLE
fix(message-handler): reject pending messages with missing signature early

### DIFF
--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -191,6 +191,20 @@ class MessagePublisher(BaseMessageHandler):
                 session.commit()
                 return None
 
+            if check_message and not message.signature:
+                error = InvalidSignature("Missing signature")
+                LOGGER.warning(
+                    "Rejecting message %s: missing signature", message.item_hash
+                )
+                reject_new_pending_message(
+                    session=session,
+                    pending_message=message_dict,
+                    exception=error,
+                    tx_hash=tx_hash,
+                )
+                session.commit()
+                return None
+
             pending_message = PendingMessageDb.from_obj(
                 message,
                 reception_time=reception_time,

--- a/tests/message_processing/test_process_pending_messages.py
+++ b/tests/message_processing/test_process_pending_messages.py
@@ -1,12 +1,13 @@
 import pytest
 from configmanager import Config
 
-from aleph.db.models import PendingMessageDb
+from aleph.db.accessors.messages import get_message_status
+from aleph.db.models import PendingMessageDb, RejectedMessageDb
 from aleph.handlers.message_handler import MessagePublisher
 from aleph.storage import StorageService
 from aleph.toolkit.timestamp import utc_now
 from aleph.types.db_session import DbSessionFactory
-from aleph.types.message_status import MessageOrigin
+from aleph.types.message_status import ErrorCode, MessageOrigin, MessageStatus
 
 from .load_fixtures import load_fixture_message
 
@@ -46,3 +47,40 @@ async def test_duplicated_pending_message(
     with session_factory() as session:
         pending_messages = session.query(PendingMessageDb).count()
         assert pending_messages == 1
+
+
+@pytest.mark.asyncio
+async def test_add_pending_message_rejects_null_signature(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+    test_storage_service: StorageService,
+):
+    message = load_fixture_message("test-data-pending-messaging.json")
+    message["signature"] = None
+
+    message_publisher = MessagePublisher(
+        session_factory=session_factory,
+        storage_service=test_storage_service,
+        config=mock_config,
+        pending_message_exchange=mocker.AsyncMock(),
+    )
+
+    result = await message_publisher.add_pending_message(
+        message_dict=message,
+        reception_time=utc_now(),
+        origin=MessageOrigin.P2P,
+    )
+
+    assert result is None
+
+    with session_factory() as session:
+        assert session.query(PendingMessageDb).count() == 0
+
+        status = get_message_status(session, message["item_hash"])
+        assert status is not None
+        assert status.status == MessageStatus.REJECTED
+
+        rejected = session.get(RejectedMessageDb, message["item_hash"])
+        assert rejected is not None
+        assert rejected.error_code == ErrorCode.INVALID_SIGNATURE


### PR DESCRIPTION
## Summary

When a P2P pending message arrives with a null `signature` (and `check_message=True`, which is the default), `MessagePublisher.add_pending_message` now rejects it before reaching the DB. Previously the row was caught by the `signature_not_null_if_check_message` CHECK constraint at INSERT time, which:

- raised `IntegrityError` and was misreported as "Duplicate pending message detected" in logs (the `except IntegrityError` block in `message_handler.py` only narrates the unique-conflict case),
- left no `RejectedMessageDb` record, so the sender got no signal,
- wasted the upstream `load_fetched_content` work (inline content deserialization, content-handler `is_related_content_fetched` check) before the failed insert.

The new path calls `reject_new_pending_message` with `InvalidSignature("Missing signature")` so the message is recorded as `REJECTED` with `ErrorCode.INVALID_SIGNATURE`. On-chain ingestion (`check_message=False`) is unaffected and continues to accept a null signature, since the on-chain tx itself is the proof of origin.

## Test plan

- [x] `tests/message_processing/test_process_pending_messages.py::test_add_pending_message_rejects_null_signature` (new): fails on `main`, passes with the fix; checks return value, absence of pending row, REJECTED status, and `INVALID_SIGNATURE` error code.
- [x] `test_duplicated_pending_message` still passes.
- [x] `black`, `isort`, `ruff` clean on changed files.