### PR TITLE
deps: drop direct requests dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ dependencies = [
   "pytz==2026.2",
   "pyyaml==6.0.3",
   "redis[hiredis]==7.4.0",
-  "requests==2.33.1",
   "sentry-sdk==2.58.0",
   "setproctitle==1.3.7",
   "setuptools>=70.3",
@@ -169,7 +168,6 @@ dependencies = [
   "types-protobuf",
   "types-pytz",
   "types-redis",
-  "types-requests",
   "types-setuptools",
 ]
 [tool.hatch.envs.linting.scripts]

--- a/src/aleph/web/controllers/metrics.py
+++ b/src/aleph/web/controllers/metrics.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import platform
 from dataclasses import asdict, dataclass, replace
@@ -10,8 +9,7 @@ import aiohttp
 from aiocache import cached
 from aleph_message.models import Chain
 from dataclasses_json import DataClassJsonMixin
-from requests import HTTPError
-from web3 import Web3
+from web3 import AsyncHTTPProvider, AsyncWeb3
 
 from aleph.config import get_config
 from aleph.db.accessors.chains import get_last_height
@@ -157,16 +155,17 @@ async def fetch_eth_height() -> Optional[int]:
     LOGGER.debug("Fetching ETH height")
     config = get_config()
 
+    if not config.ethereum.enabled.value:
+        return None
+
+    provider = AsyncHTTPProvider(config.ethereum.api_url.value)
     try:
-        if config.ethereum.enabled.value:
-            w3 = Web3(Web3.HTTPProvider(config.ethereum.api_url.value))
-            return await asyncio.get_event_loop().run_in_executor(
-                None, getattr, w3.eth, "block_number"
-            )
-        else:
-            return None
-    except HTTPError:
-        return -1  # We got a boggus value!
+        w3 = AsyncWeb3(provider)
+        return await w3.eth.block_number
+    except aiohttp.ClientResponseError:
+        return -1
+    finally:
+        await provider.disconnect()
 
 
 # Cache metrics for 10 seconds by default


### PR DESCRIPTION
## Summary
- Migrate `fetch_eth_height` in `src/aleph/web/controllers/metrics.py` from the sync `Web3.HTTPProvider` (wrapped in `run_in_executor`) to `AsyncWeb3` + `AsyncHTTPProvider`, matching `chains/ethereum.py`.
- Catch `aiohttp.ClientResponseError` instead of `requests.HTTPError`, mirroring the file's other aiohttp path (`fetch_reference_total_messages`). Provider is closed in `finally` to avoid leaking aiohttp sessions.
- Remove `requests==2.33.1` and `types-requests` from `pyproject.toml`. The only remaining `requests` user is `deployment/scripts/sync_initial_messages.py`, which keeps working off web3's transitive dep.

## Test plan
- [x] `ruff check src/ tests/` clean
- [x] `black --check` / `isort --check` clean on `metrics.py`
- [x] `pytest tests/web/controllers/test_metrics.py` (3 passed)
- [ ] CI green