### PR TITLE
fix(tests): pass scoring_* args to PostMessageHandler in forget fixture

### DIFF
--- a/tests/permissions/test_forget_permissions.py
+++ b/tests/permissions/test_forget_permissions.py
@@ -134,6 +134,9 @@ def forget_handler(mocker) -> ForgetMessageHandler:
             credit_balances_addresses=["nope"],
             credit_balances_post_types=["no-balances-in-tests"],
             credit_balances_channels=["nope"],
+            scoring_addresses=[],
+            scoring_channel="not-a-scoring-channel",
+            scoring_metrics_post_type="not-a-scoring-post-type",
         ),
         MessageType.program: vm_handler,
         MessageType.store: StoreMessageHandler(


### PR DESCRIPTION
## Summary
- `main`'s `code-quality` job is failing mypy:
  ```
  tests/permissions/test_forget_permissions.py:131:27: error: Missing positional arguments "scoring_addresses", "scoring_channel", "scoring_metrics_post_type" in call to "PostMessageHandler"
  ```
- PR #1150 added required `scoring_*` args to `PostMessageHandler.__init__`. PR #1156 introduced the `forget_handler` fixture without passing them.
- Pass placeholder values matching the equivalent fixture in `tests/message_processing/test_process_forgets.py`.

## Test plan
- [x] `ruff` / `black --check` / `isort --check` clean
- [x] `python -c "import ast; ast.parse(...)"` parses
- [ ] CI mypy passes