### PR TITLE
feat(api): filter account files by hash

### DIFF
--- a/src/aleph/db/accessors/files.py
+++ b/src/aleph/db/accessors/files.py
@@ -237,6 +237,7 @@ def get_address_files_for_api(
     after_time: Optional[dt.datetime] = None,
     after_hash: Optional[str] = None,
     cursor_mode: bool = False,
+    file_hash: Optional[str] = None,
 ) -> Iterable[Row]:
     select_stmt = (
         select(
@@ -249,6 +250,9 @@ def get_address_files_for_api(
         .join(StoredFileDb, MessageFilePinDb.file_hash == StoredFileDb.hash)
         .where(MessageFilePinDb.owner == owner)
     )
+
+    if file_hash is not None:
+        select_stmt = select_stmt.where(MessageFilePinDb.file_hash == file_hash)
 
     if sort_order == SortOrder.DESCENDING:
         order_by_columns: Tuple[UnaryExpression[Any], UnaryExpression[Any]] = (

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -56,6 +56,11 @@ class GetAccountFilesQueryParams(BaseModel):
     cursor: Optional[str] = Field(
         default=None, description="Opaque cursor for cursor-based pagination."
     )
+    file_hash: Optional[str] = Field(
+        default=None,
+        description="If set, only return the file with this hash (if owned by the address). "
+        "Useful for looking up the STORE message item_hash(es) referencing a specific file.",
+    )
 
 
 class GetBalancesChainsQueryParams(BaseModel):

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -629,6 +629,11 @@ async def get_account_files(request: web.Request) -> web.Response:
           type: integer
           enum: [-1, 1]
           default: -1
+      - name: file_hash
+        in: query
+        description: If set, only return the file with this hash (if owned by the address).
+        schema:
+          type: string
     responses:
       '200':
         description: Account files
@@ -674,6 +679,7 @@ async def get_account_files(request: web.Request) -> web.Response:
                     after_time=after_time,
                     after_hash=after_hash,
                     cursor_mode=True,
+                    file_hash=query_params.file_hash,
                 )
             )
             _nb_files, total_size = get_address_files_stats(
@@ -712,6 +718,7 @@ async def get_account_files(request: web.Request) -> web.Response:
                 pagination=query_params.pagination,
                 page=query_params.page,
                 sort_order=query_params.sort_order,
+                file_hash=query_params.file_hash,
             )
         )
         nb_files, total_size = get_address_files_stats(session=session, owner=address)

--- a/tests/api/test_account_files.py
+++ b/tests/api/test_account_files.py
@@ -1,0 +1,96 @@
+import datetime as dt
+
+import pytest
+import pytz
+
+from aleph.db.accessors.files import insert_message_file_pin
+from aleph.db.models import StoredFileDb
+from aleph.types.db_session import DbSessionFactory
+from aleph.types.files import FileType
+
+OWNER = "0xfilteraddress"
+OTHER_OWNER = "0xotheraddress"
+
+FILE_A = "QmaaaTm7g1Mh3BhrQPjnedVQ5g67DR7cwhyMN3MvFt1JPP"
+FILE_B = "QmbbbTm7g1Mh3BhrQPjnedVQ5g67DR7cwhyMN3MvFt1JPP"
+FILE_C = "QmcccTm7g1Mh3BhrQPjnedVQ5g67DR7cwhyMN3MvFt1JPP"
+
+STORE_A = "11" * 32
+STORE_B = "22" * 32
+STORE_C = "33" * 32
+
+
+@pytest.fixture
+def fixture_account_files(session_factory: DbSessionFactory) -> None:
+    created = pytz.utc.localize(dt.datetime(2024, 1, 1))
+    with session_factory() as session:
+        for file_hash, size in [(FILE_A, 10), (FILE_B, 20), (FILE_C, 30)]:
+            session.add(StoredFileDb(hash=file_hash, size=size, type=FileType.FILE))
+        session.flush()
+
+        insert_message_file_pin(
+            session=session,
+            file_hash=FILE_A,
+            owner=OWNER,
+            item_hash=STORE_A,
+            ref=None,
+            created=created,
+        )
+        insert_message_file_pin(
+            session=session,
+            file_hash=FILE_B,
+            owner=OWNER,
+            item_hash=STORE_B,
+            ref=None,
+            created=created + dt.timedelta(seconds=1),
+        )
+        # Same file_hash as FILE_A but pinned by a different owner.
+        insert_message_file_pin(
+            session=session,
+            file_hash=FILE_C,
+            owner=OTHER_OWNER,
+            item_hash=STORE_C,
+            ref=None,
+            created=created,
+        )
+        session.commit()
+
+
+@pytest.mark.asyncio
+async def test_account_files_filter_by_hash_returns_matching_pin(
+    ccn_api_client, fixture_account_files
+):
+    response = await ccn_api_client.get(
+        f"/api/v0/addresses/{OWNER}/files",
+        params={"file_hash": FILE_A},
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    files = data["files"]
+    assert len(files) == 1
+    assert files[0]["file_hash"] == FILE_A
+    assert files[0]["item_hash"] == STORE_A
+
+
+@pytest.mark.asyncio
+async def test_account_files_filter_by_hash_unknown_returns_404(
+    ccn_api_client, fixture_account_files
+):
+    response = await ccn_api_client.get(
+        f"/api/v0/addresses/{OWNER}/files",
+        params={"file_hash": "Qm" + "0" * 44},
+    )
+    assert response.status == 404
+
+
+@pytest.mark.asyncio
+async def test_account_files_filter_by_hash_other_owner_returns_404(
+    ccn_api_client, fixture_account_files
+):
+    # FILE_C exists and is pinned, but by OTHER_OWNER, not OWNER.
+    response = await ccn_api_client.get(
+        f"/api/v0/addresses/{OWNER}/files",
+        params={"file_hash": FILE_C},
+    )
+    assert response.status == 404


### PR DESCRIPTION
## Summary

- Add an optional `file_hash` query param to `GET /api/v0/addresses/{address}/files` so callers can look up a single file owned by an address without paginating through every pin.
- The response shape is unchanged; the result is just narrowed to the matching pin. Each item already includes `item_hash` (the STORE message hash), which is useful for follow-up actions like forgetting the message.
- Returns `404` when no pin matches (consistent with the existing behavior when an address has no pins).

## Test plan

- [x] New `tests/api/test_account_files.py` covers: match returns the right `item_hash`, unknown hash returns 404, hash pinned by a different owner returns 404.
- [x] `pytest tests/api/test_account_files.py tests/db/test_files.py tests/api/test_cursor_pagination.py` passes (17/17) against a local postgres.
- [x] `black`, `isort`, `ruff`, `mypy` clean on touched files.