### PR TITLE
Add STORE file-fetch metrics for IPFS herd measurement

### DIFF
--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -201,6 +201,10 @@ class StoreMessageHandler(ContentHandler):
             if ipfs_enabled and _should_pin_on_ipfs(
                 file_stats=file_stats, min_file_size_for_pinning=1024 * 1024
             ):
+                # Counted before the fetch so every attempt is represented. A crash
+                # between here and the success/failure path leaves the total without a
+                # matching duration or failure entry, marginally skewing the mean — an
+                # acceptable tradeoff for approximate monitoring counters.
                 await self.storage_service.node_cache.incr(STORE_FETCH_TOTAL_KEY)
                 try:
                     with Timer() as timer:
@@ -208,9 +212,10 @@ class StoreMessageHandler(ContentHandler):
                 except Exception:
                     await self.storage_service.node_cache.incr(STORE_FETCH_FAILED_KEY)
                     LOGGER.warning(
-                        "ipfs_fetch hash=%s type=ipfs path=pin size=%s outcome=fail",
+                        "ipfs_fetch hash=%s type=ipfs path=pin size=%s duration=%.2f outcome=fail",
                         file_hash,
                         file_stats.size,
+                        timer.elapsed(),
                     )
                     raise
                 await self.storage_service.node_cache.incrby(
@@ -246,9 +251,10 @@ class StoreMessageHandler(ContentHandler):
         except AlephStorageException:
             await self.storage_service.node_cache.incr(STORE_FETCH_FAILED_KEY)
             LOGGER.warning(
-                "ipfs_fetch hash=%s type=%s path=http outcome=unavailable",
+                "ipfs_fetch hash=%s type=%s path=http duration=%.2f outcome=unavailable",
                 file_hash,
                 item_type,
+                timer.elapsed(),
             )
             raise FileUnavailable("Could not retrieve file from storage at this time")
 

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -214,7 +214,7 @@ class StoreMessageHandler(ContentHandler):
                     )
                     raise
                 await self.storage_service.node_cache.incrby(
-                    STORE_FETCH_DURATION_MS_SUM_KEY, int(timer.elapsed() * 1000)
+                    STORE_FETCH_DURATION_MS_SUM_KEY, round(timer.elapsed() * 1000)
                 )
                 LOGGER.info(
                     "ipfs_fetch hash=%s type=ipfs path=pin size=%s duration=%.2f outcome=ok",
@@ -253,7 +253,7 @@ class StoreMessageHandler(ContentHandler):
             raise FileUnavailable("Could not retrieve file from storage at this time")
 
         await self.storage_service.node_cache.incrby(
-            STORE_FETCH_DURATION_MS_SUM_KEY, int(timer.elapsed() * 1000)
+            STORE_FETCH_DURATION_MS_SUM_KEY, round(timer.elapsed() * 1000)
         )
         LOGGER.info(
             "ipfs_fetch hash=%s type=%s path=http size=%s duration=%.2f outcome=ok",

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -42,6 +42,7 @@ from aleph.services.ipfs import IpfsService
 from aleph.storage import StorageService
 from aleph.toolkit.constants import MiB
 from aleph.toolkit.costs import are_store_and_program_free, is_credit_only_required
+from aleph.toolkit.timer import Timer
 from aleph.toolkit.timestamp import timestamp_to_datetime, utc_now
 from aleph.types.db_session import DbSession
 from aleph.types.files import FileType
@@ -56,6 +57,15 @@ from aleph.types.message_status import (
 from aleph.utils import item_type_from_hash, make_file_tag
 
 LOGGER = logging.getLogger(__name__)
+
+# Redis keys for STORE file-fetch metrics, surfaced at /metrics and shared across
+# workers. Used to measure the IPFS thundering-herd fetch behaviour. Filter the
+# `ipfs_fetch` log lines by `type=ipfs` for IPFS-specific timing.
+STORE_FETCH_TOTAL_KEY = "pyaleph_store_fetch_total"
+STORE_FETCH_FAILED_KEY = "pyaleph_store_fetch_failed_total"
+# Sum of successful-fetch durations (milliseconds). Divide by the count of
+# successful fetches (total - failed) for the mean fetch time in Grafana.
+STORE_FETCH_DURATION_MS_SUM_KEY = "pyaleph_store_fetch_duration_ms_sum"
 
 
 def _get_store_content(message: MessageDb) -> StoreContent:
@@ -191,7 +201,27 @@ class StoreMessageHandler(ContentHandler):
             if ipfs_enabled and _should_pin_on_ipfs(
                 file_stats=file_stats, min_file_size_for_pinning=1024 * 1024
             ):
-                await ipfs_service.pin_add(cid=file_hash)
+                await self.storage_service.node_cache.incr(STORE_FETCH_TOTAL_KEY)
+                try:
+                    with Timer() as timer:
+                        await ipfs_service.pin_add(cid=file_hash)
+                except Exception:
+                    await self.storage_service.node_cache.incr(STORE_FETCH_FAILED_KEY)
+                    LOGGER.warning(
+                        "ipfs_fetch hash=%s type=ipfs path=pin size=%s outcome=fail",
+                        file_hash,
+                        file_stats.size,
+                    )
+                    raise
+                await self.storage_service.node_cache.incrby(
+                    STORE_FETCH_DURATION_MS_SUM_KEY, int(timer.elapsed() * 1000)
+                )
+                LOGGER.info(
+                    "ipfs_fetch hash=%s type=ipfs path=pin size=%s duration=%.2f outcome=ok",
+                    file_hash,
+                    file_stats.size,
+                    timer.elapsed(),
+                )
                 upsert_file(
                     session=session,
                     file_hash=file_hash,
@@ -201,19 +231,37 @@ class StoreMessageHandler(ContentHandler):
                 return
 
         # Otherwise, fetch content directly from the Aleph network storage API
+        await self.storage_service.node_cache.incr(STORE_FETCH_TOTAL_KEY)
         try:
-            file_content = await self.storage_service.get_hash_content(
-                file_hash,
-                engine=item_type,
-                tries=4,
-                timeout=15,  # We only end up here for files < 1MB, a short timeout is okay
-                use_network=True,
-                use_ipfs=True,
-                store_value=config.storage.store_files.value,
-            )
+            with Timer() as timer:
+                file_content = await self.storage_service.get_hash_content(
+                    file_hash,
+                    engine=item_type,
+                    tries=4,
+                    timeout=15,  # We only end up here for files < 1MB, a short timeout is okay
+                    use_network=True,
+                    use_ipfs=True,
+                    store_value=config.storage.store_files.value,
+                )
         except AlephStorageException:
+            await self.storage_service.node_cache.incr(STORE_FETCH_FAILED_KEY)
+            LOGGER.warning(
+                "ipfs_fetch hash=%s type=%s path=http outcome=unavailable",
+                file_hash,
+                item_type,
+            )
             raise FileUnavailable("Could not retrieve file from storage at this time")
 
+        await self.storage_service.node_cache.incrby(
+            STORE_FETCH_DURATION_MS_SUM_KEY, int(timer.elapsed() * 1000)
+        )
+        LOGGER.info(
+            "ipfs_fetch hash=%s type=%s path=http size=%s duration=%.2f outcome=ok",
+            file_hash,
+            item_type,
+            len(file_content),
+            timer.elapsed(),
+        )
         upsert_file(
             session=session,
             file_hash=file_hash,

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -42,6 +42,7 @@ from aleph.services.ipfs import IpfsService
 from aleph.storage import StorageService
 from aleph.toolkit.constants import MiB
 from aleph.toolkit.costs import are_store_and_program_free, is_credit_only_required
+from aleph.toolkit.metrics_keys import store_fetch_keys
 from aleph.toolkit.timer import Timer
 from aleph.toolkit.timestamp import timestamp_to_datetime, utc_now
 from aleph.types.db_session import DbSession
@@ -57,33 +58,6 @@ from aleph.types.message_status import (
 from aleph.utils import item_type_from_hash, make_file_tag
 
 LOGGER = logging.getLogger(__name__)
-
-# Redis keys for STORE file-fetch metrics, surfaced at /metrics and shared across
-# workers. Split by item type because the fetch source differs: `storage` files
-# are pulled from CCN HTTP APIs, `ipfs` files come through the IPFS (Kubo) daemon.
-# Tracking them separately lets us compare the two and tell disk-bound from
-# network-bound regressions. Mean = duration_ms_sum / (total - failed) per type.
-STORE_FETCH_IPFS_TOTAL_KEY = "pyaleph_store_fetch_ipfs_total"
-STORE_FETCH_IPFS_FAILED_KEY = "pyaleph_store_fetch_ipfs_failed_total"
-STORE_FETCH_IPFS_DURATION_MS_SUM_KEY = "pyaleph_store_fetch_ipfs_duration_ms_sum"
-STORE_FETCH_STORAGE_TOTAL_KEY = "pyaleph_store_fetch_storage_total"
-STORE_FETCH_STORAGE_FAILED_KEY = "pyaleph_store_fetch_storage_failed_total"
-STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY = "pyaleph_store_fetch_storage_duration_ms_sum"
-
-
-def _store_fetch_keys(item_type: ItemType) -> tuple[str, str, str]:
-    """Return the (total, failed, duration_ms_sum) Redis keys for an item type."""
-    if item_type == ItemType.ipfs:
-        return (
-            STORE_FETCH_IPFS_TOTAL_KEY,
-            STORE_FETCH_IPFS_FAILED_KEY,
-            STORE_FETCH_IPFS_DURATION_MS_SUM_KEY,
-        )
-    return (
-        STORE_FETCH_STORAGE_TOTAL_KEY,
-        STORE_FETCH_STORAGE_FAILED_KEY,
-        STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY,
-    )
 
 
 def _get_store_content(message: MessageDb) -> StoreContent:
@@ -207,7 +181,7 @@ class StoreMessageHandler(ContentHandler):
                 f"Item hash '{file_hash}' is not of the expected type ('{item_type}')"
             )
 
-        total_key, failed_key, duration_key = _store_fetch_keys(item_type)
+        total_key, failed_key, duration_key = store_fetch_keys(item_type)
 
         # For CIDs, pin directories and files > 1MiB
         if item_type == ItemType.ipfs:

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -59,13 +59,31 @@ from aleph.utils import item_type_from_hash, make_file_tag
 LOGGER = logging.getLogger(__name__)
 
 # Redis keys for STORE file-fetch metrics, surfaced at /metrics and shared across
-# workers. Used to measure the IPFS thundering-herd fetch behaviour. Filter the
-# `ipfs_fetch` log lines by `type=ipfs` for IPFS-specific timing.
-STORE_FETCH_TOTAL_KEY = "pyaleph_store_fetch_total"
-STORE_FETCH_FAILED_KEY = "pyaleph_store_fetch_failed_total"
-# Sum of successful-fetch durations (milliseconds). Divide by the count of
-# successful fetches (total - failed) for the mean fetch time in Grafana.
-STORE_FETCH_DURATION_MS_SUM_KEY = "pyaleph_store_fetch_duration_ms_sum"
+# workers. Split by item type because the fetch source differs: `storage` files
+# are pulled from CCN HTTP APIs, `ipfs` files come through the IPFS (Kubo) daemon.
+# Tracking them separately lets us compare the two and tell disk-bound from
+# network-bound regressions. Mean = duration_ms_sum / (total - failed) per type.
+STORE_FETCH_IPFS_TOTAL_KEY = "pyaleph_store_fetch_ipfs_total"
+STORE_FETCH_IPFS_FAILED_KEY = "pyaleph_store_fetch_ipfs_failed_total"
+STORE_FETCH_IPFS_DURATION_MS_SUM_KEY = "pyaleph_store_fetch_ipfs_duration_ms_sum"
+STORE_FETCH_STORAGE_TOTAL_KEY = "pyaleph_store_fetch_storage_total"
+STORE_FETCH_STORAGE_FAILED_KEY = "pyaleph_store_fetch_storage_failed_total"
+STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY = "pyaleph_store_fetch_storage_duration_ms_sum"
+
+
+def _store_fetch_keys(item_type: ItemType) -> tuple[str, str, str]:
+    """Return the (total, failed, duration_ms_sum) Redis keys for an item type."""
+    if item_type == ItemType.ipfs:
+        return (
+            STORE_FETCH_IPFS_TOTAL_KEY,
+            STORE_FETCH_IPFS_FAILED_KEY,
+            STORE_FETCH_IPFS_DURATION_MS_SUM_KEY,
+        )
+    return (
+        STORE_FETCH_STORAGE_TOTAL_KEY,
+        STORE_FETCH_STORAGE_FAILED_KEY,
+        STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY,
+    )
 
 
 def _get_store_content(message: MessageDb) -> StoreContent:
@@ -189,6 +207,8 @@ class StoreMessageHandler(ContentHandler):
                 f"Item hash '{file_hash}' is not of the expected type ('{item_type}')"
             )
 
+        total_key, failed_key, duration_key = _store_fetch_keys(item_type)
+
         # For CIDs, pin directories and files > 1MiB
         if item_type == ItemType.ipfs:
             ipfs_service = self.storage_service.ipfs_service
@@ -205,12 +225,12 @@ class StoreMessageHandler(ContentHandler):
                 # between here and the success/failure path leaves the total without a
                 # matching duration or failure entry, marginally skewing the mean — an
                 # acceptable tradeoff for approximate monitoring counters.
-                await self.storage_service.node_cache.incr(STORE_FETCH_TOTAL_KEY)
+                await self.storage_service.node_cache.incr(total_key)
                 try:
                     with Timer() as timer:
                         await ipfs_service.pin_add(cid=file_hash)
                 except Exception:
-                    await self.storage_service.node_cache.incr(STORE_FETCH_FAILED_KEY)
+                    await self.storage_service.node_cache.incr(failed_key)
                     LOGGER.warning(
                         "ipfs_fetch hash=%s type=ipfs path=pin size=%s duration=%.2f outcome=fail",
                         file_hash,
@@ -219,7 +239,7 @@ class StoreMessageHandler(ContentHandler):
                     )
                     raise
                 await self.storage_service.node_cache.incrby(
-                    STORE_FETCH_DURATION_MS_SUM_KEY, round(timer.elapsed() * 1000)
+                    duration_key, round(timer.elapsed() * 1000)
                 )
                 LOGGER.info(
                     "ipfs_fetch hash=%s type=ipfs path=pin size=%s duration=%.2f outcome=ok",
@@ -236,7 +256,7 @@ class StoreMessageHandler(ContentHandler):
                 return
 
         # Otherwise, fetch content directly from the Aleph network storage API
-        await self.storage_service.node_cache.incr(STORE_FETCH_TOTAL_KEY)
+        await self.storage_service.node_cache.incr(total_key)
         try:
             with Timer() as timer:
                 file_content = await self.storage_service.get_hash_content(
@@ -249,7 +269,7 @@ class StoreMessageHandler(ContentHandler):
                     store_value=config.storage.store_files.value,
                 )
         except AlephStorageException:
-            await self.storage_service.node_cache.incr(STORE_FETCH_FAILED_KEY)
+            await self.storage_service.node_cache.incr(failed_key)
             LOGGER.warning(
                 "ipfs_fetch hash=%s type=%s path=http duration=%.2f outcome=unavailable",
                 file_hash,
@@ -259,7 +279,7 @@ class StoreMessageHandler(ContentHandler):
             raise FileUnavailable("Could not retrieve file from storage at this time")
 
         await self.storage_service.node_cache.incrby(
-            STORE_FETCH_DURATION_MS_SUM_KEY, round(timer.elapsed() * 1000)
+            duration_key, round(timer.elapsed() * 1000)
         )
         LOGGER.info(
             "ipfs_fetch hash=%s type=%s path=http size=%s duration=%.2f outcome=ok",

--- a/src/aleph/services/cache/node_cache.py
+++ b/src/aleph/services/cache/node_cache.py
@@ -68,6 +68,9 @@ class NodeCache:
     async def incr(self, key: CacheKey):
         await self.redis_client.incr(key)
 
+    async def incrby(self, key: CacheKey, amount: int):
+        await self.redis_client.incrby(key, amount)
+
     async def decr(self, key: CacheKey):
         await self.redis_client.decr(key)
 

--- a/src/aleph/toolkit/metrics_keys.py
+++ b/src/aleph/toolkit/metrics_keys.py
@@ -1,0 +1,35 @@
+"""Shared Redis key constants for node metrics.
+
+Kept in toolkit (a leaf module that imports nothing from the web or handler
+layers) so both the writer (``handlers/content/store.py``) and the reader
+(``web/controllers/metrics.py``) use the same strings without a circular import.
+"""
+
+from aleph_message.models import ItemType
+
+# STORE file-fetch metrics, split by item type because the fetch source differs:
+# `storage` files are pulled from CCN HTTP APIs, `ipfs` files come through the
+# IPFS (Kubo) daemon. Tracking them separately tells a disk-bound regression
+# (both slow) from a network/bitswap one (only ipfs slow). The mean fetch time
+# is duration_ms_sum / (total - failed) per type.
+STORE_FETCH_IPFS_TOTAL_KEY = "pyaleph_store_fetch_ipfs_total"
+STORE_FETCH_IPFS_FAILED_KEY = "pyaleph_store_fetch_ipfs_failed_total"
+STORE_FETCH_IPFS_DURATION_MS_SUM_KEY = "pyaleph_store_fetch_ipfs_duration_ms_sum"
+STORE_FETCH_STORAGE_TOTAL_KEY = "pyaleph_store_fetch_storage_total"
+STORE_FETCH_STORAGE_FAILED_KEY = "pyaleph_store_fetch_storage_failed_total"
+STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY = "pyaleph_store_fetch_storage_duration_ms_sum"
+
+
+def store_fetch_keys(item_type: ItemType) -> tuple[str, str, str]:
+    """Return the (total, failed, duration_ms_sum) Redis keys for an item type."""
+    if item_type == ItemType.ipfs:
+        return (
+            STORE_FETCH_IPFS_TOTAL_KEY,
+            STORE_FETCH_IPFS_FAILED_KEY,
+            STORE_FETCH_IPFS_DURATION_MS_SUM_KEY,
+        )
+    return (
+        STORE_FETCH_STORAGE_TOTAL_KEY,
+        STORE_FETCH_STORAGE_FAILED_KEY,
+        STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY,
+    )

--- a/src/aleph/web/controllers/metrics.py
+++ b/src/aleph/web/controllers/metrics.py
@@ -16,6 +16,14 @@ from aleph.db.accessors.chains import get_last_height
 from aleph.db.accessors.messages import count_matching_messages_fast
 from aleph.db.models import FilePinDb, PeerDb, PendingMessageDb, PendingTxDb
 from aleph.services.cache.node_cache import NodeCache
+from aleph.toolkit.metrics_keys import (
+    STORE_FETCH_IPFS_DURATION_MS_SUM_KEY,
+    STORE_FETCH_IPFS_FAILED_KEY,
+    STORE_FETCH_IPFS_TOTAL_KEY,
+    STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY,
+    STORE_FETCH_STORAGE_FAILED_KEY,
+    STORE_FETCH_STORAGE_TOTAL_KEY,
+)
 from aleph.types.chain_sync import ChainEventType
 from aleph.types.db_session import DbSessionFactory
 from aleph.version import __version__
@@ -37,15 +45,6 @@ _WS_MESSAGES_CONNECTIONS_REJECTED_KEY = "pyaleph_ws_messages_connections_rejecte
 _WS_BROADCASTER_CONSUMER_RESTARTS_KEY = "pyaleph_ws_broadcaster_consumer_restarts_total"
 _WS_STATUS_CONNECTIONS_ACTIVE_KEY = "pyaleph_ws_status_connections_active"
 _WS_STATUS_CONNECTIONS_REJECTED_KEY = "pyaleph_ws_status_connections_rejected_total"
-
-# STORE file-fetch counters. Mirrors the keys in handlers/content/store.py —
-# duplicated here to avoid a circular import. Names match the metric fields.
-_STORE_FETCH_IPFS_TOTAL_KEY = "pyaleph_store_fetch_ipfs_total"
-_STORE_FETCH_IPFS_FAILED_KEY = "pyaleph_store_fetch_ipfs_failed_total"
-_STORE_FETCH_IPFS_DURATION_MS_SUM_KEY = "pyaleph_store_fetch_ipfs_duration_ms_sum"
-_STORE_FETCH_STORAGE_TOTAL_KEY = "pyaleph_store_fetch_storage_total"
-_STORE_FETCH_STORAGE_FAILED_KEY = "pyaleph_store_fetch_storage_failed_total"
-_STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY = "pyaleph_store_fetch_storage_duration_ms_sum"
 
 
 def format_dict_for_prometheus(values: Dict) -> str:
@@ -279,22 +278,22 @@ async def get_metrics_with_ws(
         node_cache, _WS_STATUS_CONNECTIONS_REJECTED_KEY
     )
     metrics.pyaleph_store_fetch_ipfs_total = await _read_int_key(
-        node_cache, _STORE_FETCH_IPFS_TOTAL_KEY
+        node_cache, STORE_FETCH_IPFS_TOTAL_KEY
     )
     metrics.pyaleph_store_fetch_ipfs_failed_total = await _read_int_key(
-        node_cache, _STORE_FETCH_IPFS_FAILED_KEY
+        node_cache, STORE_FETCH_IPFS_FAILED_KEY
     )
     metrics.pyaleph_store_fetch_ipfs_duration_ms_sum = await _read_int_key(
-        node_cache, _STORE_FETCH_IPFS_DURATION_MS_SUM_KEY
+        node_cache, STORE_FETCH_IPFS_DURATION_MS_SUM_KEY
     )
     metrics.pyaleph_store_fetch_storage_total = await _read_int_key(
-        node_cache, _STORE_FETCH_STORAGE_TOTAL_KEY
+        node_cache, STORE_FETCH_STORAGE_TOTAL_KEY
     )
     metrics.pyaleph_store_fetch_storage_failed_total = await _read_int_key(
-        node_cache, _STORE_FETCH_STORAGE_FAILED_KEY
+        node_cache, STORE_FETCH_STORAGE_FAILED_KEY
     )
     metrics.pyaleph_store_fetch_storage_duration_ms_sum = await _read_int_key(
-        node_cache, _STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY
+        node_cache, STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY
     )
 
     # Config-value gauges: same on every worker, read from the local instance.

--- a/src/aleph/web/controllers/metrics.py
+++ b/src/aleph/web/controllers/metrics.py
@@ -40,9 +40,12 @@ _WS_STATUS_CONNECTIONS_REJECTED_KEY = "pyaleph_ws_status_connections_rejected_to
 
 # STORE file-fetch counters. Mirrors the keys in handlers/content/store.py —
 # duplicated here to avoid a circular import. Names match the metric fields.
-_STORE_FETCH_TOTAL_KEY = "pyaleph_store_fetch_total"
-_STORE_FETCH_FAILED_KEY = "pyaleph_store_fetch_failed_total"
-_STORE_FETCH_DURATION_MS_SUM_KEY = "pyaleph_store_fetch_duration_ms_sum"
+_STORE_FETCH_IPFS_TOTAL_KEY = "pyaleph_store_fetch_ipfs_total"
+_STORE_FETCH_IPFS_FAILED_KEY = "pyaleph_store_fetch_ipfs_failed_total"
+_STORE_FETCH_IPFS_DURATION_MS_SUM_KEY = "pyaleph_store_fetch_ipfs_duration_ms_sum"
+_STORE_FETCH_STORAGE_TOTAL_KEY = "pyaleph_store_fetch_storage_total"
+_STORE_FETCH_STORAGE_FAILED_KEY = "pyaleph_store_fetch_storage_failed_total"
+_STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY = "pyaleph_store_fetch_storage_duration_ms_sum"
 
 
 def format_dict_for_prometheus(values: Dict) -> str:
@@ -123,9 +126,12 @@ class Metrics(DataClassJsonMixin):
     pyaleph_ws_messages_connections_rejected_total: int = 0
     pyaleph_ws_status_connections_rejected_total: int = 0
     pyaleph_ws_broadcaster_consumer_restarts_total: int = 0
-    pyaleph_store_fetch_total: int = 0
-    pyaleph_store_fetch_failed_total: int = 0
-    pyaleph_store_fetch_duration_ms_sum: int = 0
+    pyaleph_store_fetch_ipfs_total: int = 0
+    pyaleph_store_fetch_ipfs_failed_total: int = 0
+    pyaleph_store_fetch_ipfs_duration_ms_sum: int = 0
+    pyaleph_store_fetch_storage_total: int = 0
+    pyaleph_store_fetch_storage_failed_total: int = 0
+    pyaleph_store_fetch_storage_duration_ms_sum: int = 0
 
 
 pyaleph_build_info = BuildInfo(
@@ -272,14 +278,23 @@ async def get_metrics_with_ws(
     metrics.pyaleph_ws_status_connections_rejected_total = await _read_int_key(
         node_cache, _WS_STATUS_CONNECTIONS_REJECTED_KEY
     )
-    metrics.pyaleph_store_fetch_total = await _read_int_key(
-        node_cache, _STORE_FETCH_TOTAL_KEY
+    metrics.pyaleph_store_fetch_ipfs_total = await _read_int_key(
+        node_cache, _STORE_FETCH_IPFS_TOTAL_KEY
     )
-    metrics.pyaleph_store_fetch_failed_total = await _read_int_key(
-        node_cache, _STORE_FETCH_FAILED_KEY
+    metrics.pyaleph_store_fetch_ipfs_failed_total = await _read_int_key(
+        node_cache, _STORE_FETCH_IPFS_FAILED_KEY
     )
-    metrics.pyaleph_store_fetch_duration_ms_sum = await _read_int_key(
-        node_cache, _STORE_FETCH_DURATION_MS_SUM_KEY
+    metrics.pyaleph_store_fetch_ipfs_duration_ms_sum = await _read_int_key(
+        node_cache, _STORE_FETCH_IPFS_DURATION_MS_SUM_KEY
+    )
+    metrics.pyaleph_store_fetch_storage_total = await _read_int_key(
+        node_cache, _STORE_FETCH_STORAGE_TOTAL_KEY
+    )
+    metrics.pyaleph_store_fetch_storage_failed_total = await _read_int_key(
+        node_cache, _STORE_FETCH_STORAGE_FAILED_KEY
+    )
+    metrics.pyaleph_store_fetch_storage_duration_ms_sum = await _read_int_key(
+        node_cache, _STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY
     )
 
     # Config-value gauges: same on every worker, read from the local instance.

--- a/src/aleph/web/controllers/metrics.py
+++ b/src/aleph/web/controllers/metrics.py
@@ -38,6 +38,12 @@ _WS_BROADCASTER_CONSUMER_RESTARTS_KEY = "pyaleph_ws_broadcaster_consumer_restart
 _WS_STATUS_CONNECTIONS_ACTIVE_KEY = "pyaleph_ws_status_connections_active"
 _WS_STATUS_CONNECTIONS_REJECTED_KEY = "pyaleph_ws_status_connections_rejected_total"
 
+# STORE file-fetch counters. Mirrors the keys in handlers/content/store.py —
+# duplicated here to avoid a circular import. Names match the metric fields.
+_STORE_FETCH_TOTAL_KEY = "pyaleph_store_fetch_total"
+_STORE_FETCH_FAILED_KEY = "pyaleph_store_fetch_failed_total"
+_STORE_FETCH_DURATION_MS_SUM_KEY = "pyaleph_store_fetch_duration_ms_sum"
+
 
 def format_dict_for_prometheus(values: Dict) -> str:
     """Format a dict to a Prometheus tags string"""
@@ -117,6 +123,9 @@ class Metrics(DataClassJsonMixin):
     pyaleph_ws_messages_connections_rejected_total: int = 0
     pyaleph_ws_status_connections_rejected_total: int = 0
     pyaleph_ws_broadcaster_consumer_restarts_total: int = 0
+    pyaleph_store_fetch_total: int = 0
+    pyaleph_store_fetch_failed_total: int = 0
+    pyaleph_store_fetch_duration_ms_sum: int = 0
 
 
 pyaleph_build_info = BuildInfo(
@@ -262,6 +271,15 @@ async def get_metrics_with_ws(
     )
     metrics.pyaleph_ws_status_connections_rejected_total = await _read_int_key(
         node_cache, _WS_STATUS_CONNECTIONS_REJECTED_KEY
+    )
+    metrics.pyaleph_store_fetch_total = await _read_int_key(
+        node_cache, _STORE_FETCH_TOTAL_KEY
+    )
+    metrics.pyaleph_store_fetch_failed_total = await _read_int_key(
+        node_cache, _STORE_FETCH_FAILED_KEY
+    )
+    metrics.pyaleph_store_fetch_duration_ms_sum = await _read_int_key(
+        node_cache, _STORE_FETCH_DURATION_MS_SUM_KEY
     )
 
     # Config-value gauges: same on every worker, read from the local instance.

--- a/tests/storage/test_store_message.py
+++ b/tests/storage/test_store_message.py
@@ -9,20 +9,20 @@ from message_test_helpers import make_validated_message_from_dict
 from sqlalchemy import select
 
 from aleph.db.models import MessageDb, StoredFileDb
-from aleph.handlers.content.store import (
+from aleph.handlers.content.store import StoreMessageHandler
+from aleph.schemas.message_content import ContentSource, RawContent
+from aleph.services.ipfs import IpfsService
+from aleph.storage import StorageService
+from aleph.toolkit.constants import DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE
+from aleph.toolkit.metrics_keys import (
     STORE_FETCH_IPFS_DURATION_MS_SUM_KEY,
     STORE_FETCH_IPFS_FAILED_KEY,
     STORE_FETCH_IPFS_TOTAL_KEY,
     STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY,
     STORE_FETCH_STORAGE_FAILED_KEY,
     STORE_FETCH_STORAGE_TOTAL_KEY,
-    StoreMessageHandler,
-    _store_fetch_keys,
+    store_fetch_keys,
 )
-from aleph.schemas.message_content import ContentSource, RawContent
-from aleph.services.ipfs import IpfsService
-from aleph.storage import StorageService
-from aleph.toolkit.constants import DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE
 from aleph.types.db_session import DbSessionFactory
 from aleph.types.files import FileType
 
@@ -30,8 +30,8 @@ from aleph.types.files import FileType
 def test_store_fetch_keys_differentiate_by_type():
     """Metric keys are split by item type so ipfs and storage fetches never
     share a counter."""
-    ipfs_keys = _store_fetch_keys(ItemType.ipfs)
-    storage_keys = _store_fetch_keys(ItemType.storage)
+    ipfs_keys = store_fetch_keys(ItemType.ipfs)
+    storage_keys = store_fetch_keys(ItemType.storage)
 
     assert ipfs_keys == (
         STORE_FETCH_IPFS_TOTAL_KEY,
@@ -255,6 +255,66 @@ async def test_handle_storage_fetch_failure_metrics(
     node_cache.incr.assert_any_call(STORE_FETCH_IPFS_TOTAL_KEY)
     node_cache.incr.assert_any_call(STORE_FETCH_IPFS_FAILED_KEY)
     node_cache.incrby.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_new_storage_type_file_uses_storage_counters(
+    mocker,
+    session_factory: DbSessionFactory,
+    mock_config: Config,
+):
+    """A storage-type STORE file goes through the http path and increments the
+    storage counters, leaving the ipfs counters untouched."""
+    file_hash = "315f7313eb97d2c8299e3ee9c19d81f226c44ccf81c387c9fb25c54fced245f5"
+    message_dict: Mapping[str, Any] = {
+        "chain": "ETH",
+        "item_hash": "7e4f914865028356704919810073ec5690ecc4bb0ee3bd6bdb24829fd532398f",
+        "sender": "0xdeadbeef",
+        "type": "STORE",
+        "channel": "TEST",
+        "item_content": json.dumps(
+            {
+                "address": "0xdeadbeef",
+                "item_type": "storage",
+                "item_hash": file_hash,
+                "time": 1645807812.6829665,
+            }
+        ),
+        "item_type": "inline",
+        "signature": "0xfake",
+        "time": 1645807812.6829786,
+    }
+    message = make_validated_message_from_dict(
+        message_dict, raw_content=message_dict["item_content"]
+    )
+
+    raw_content = RawContent(
+        hash=file_hash, source=ContentSource.P2P, value=b"storage bytes"
+    )
+    node_cache = mocker.AsyncMock()
+    storage_service = StorageService(
+        storage_engine=mocker.AsyncMock(),
+        ipfs_service=mocker.AsyncMock(),
+        node_cache=node_cache,
+    )
+    get_hash_content_mock = mocker.AsyncMock(return_value=raw_content)
+    storage_service.get_hash_content = get_hash_content_mock  # type: ignore[method-assign]
+    store_message_handler = StoreMessageHandler(
+        storage_service=storage_service,
+        grace_period=24,
+        max_unauthenticated_upload_file_size=DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE,
+    )
+
+    with session_factory() as session:
+        await store_message_handler.fetch_related_content(
+            session=session, message=message
+        )
+        session.commit()
+
+    get_hash_content_mock.assert_called_once()
+    node_cache.incr.assert_any_call(STORE_FETCH_STORAGE_TOTAL_KEY)
+    node_cache.incrby.assert_any_call(STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY, ANY)
+    assert mocker.call(STORE_FETCH_IPFS_TOTAL_KEY) not in node_cache.incr.call_args_list
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_store_message.py
+++ b/tests/storage/test_store_message.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any, Mapping
+from unittest.mock import ANY
 
 import pytest
 from configmanager import Config
@@ -7,7 +8,12 @@ from message_test_helpers import make_validated_message_from_dict
 from sqlalchemy import select
 
 from aleph.db.models import MessageDb, StoredFileDb
-from aleph.handlers.content.store import StoreMessageHandler
+from aleph.handlers.content.store import (
+    STORE_FETCH_DURATION_MS_SUM_KEY,
+    STORE_FETCH_FAILED_KEY,
+    STORE_FETCH_TOTAL_KEY,
+    StoreMessageHandler,
+)
 from aleph.schemas.message_content import ContentSource, RawContent
 from aleph.services.ipfs import IpfsService
 from aleph.storage import StorageService
@@ -85,7 +91,9 @@ async def test_handle_new_storage_file(
         ipfs_service=IpfsService(ipfs_client=mock_ipfs_client),
         node_cache=mocker.AsyncMock(),
     )
-    storage_service.get_hash_content = get_hash_content_mock = mocker.AsyncMock(return_value=raw_content)  # type: ignore
+    storage_service.get_hash_content = get_hash_content_mock = mocker.AsyncMock(
+        return_value=raw_content
+    )  # type: ignore
     store_message_handler = StoreMessageHandler(
         storage_service=storage_service,
         grace_period=24,
@@ -108,6 +116,12 @@ async def test_handle_new_storage_file(
     assert stored_file.size == len(raw_content)
 
     get_hash_content_mock.assert_called_once()
+
+    # http fetch path: total counter incremented and duration recorded, no failure
+    node_cache = storage_service.node_cache
+    node_cache.incr.assert_any_call(STORE_FETCH_TOTAL_KEY)
+    node_cache.incrby.assert_any_call(STORE_FETCH_DURATION_MS_SUM_KEY, ANY)
+    assert mocker.call(STORE_FETCH_FAILED_KEY) not in node_cache.incr.call_args_list
 
 
 @pytest.mark.asyncio
@@ -159,6 +173,61 @@ async def test_handle_new_storage_directory(
     assert stored_file.type == FileType.DIRECTORY
 
     assert not storage_engine.called
+
+    # pin path: total counter incremented and duration recorded, no failure
+    node_cache = storage_service.node_cache
+    node_cache.incr.assert_any_call(STORE_FETCH_TOTAL_KEY)
+    node_cache.incrby.assert_any_call(STORE_FETCH_DURATION_MS_SUM_KEY, ANY)
+    assert mocker.call(STORE_FETCH_FAILED_KEY) not in node_cache.incr.call_args_list
+
+
+@pytest.mark.asyncio
+async def test_handle_storage_fetch_failure_metrics(
+    mocker,
+    session_factory: DbSessionFactory,
+    mock_config: Config,
+    fixture_message_directory: MessageDb,
+):
+    """A failed pin increments the failure counter, records no duration, and
+    re-raises so the message is retried."""
+    mock_ipfs_client = mocker.MagicMock()
+    mock_ipfs_client.files.stat = mocker.AsyncMock(
+        return_value={
+            "Hash": "QmPZrod87ceK4yVvXQzRexDcuDgmLxBiNJ1ajLjLoMx9sU",
+            "Size": 0,
+            "CumulativeSize": 4560,
+            "Blocks": 2,
+            "Type": "directory",
+        }
+    )
+
+    storage_service = StorageService(
+        storage_engine=mocker.AsyncMock(),
+        ipfs_service=IpfsService(ipfs_client=mock_ipfs_client),
+        node_cache=mocker.AsyncMock(),
+    )
+    # A non-APIError exception confirms the broad except counts every failure mode.
+    mocker.patch.object(
+        storage_service.ipfs_service,
+        "pin_add",
+        side_effect=RuntimeError("pin failed"),
+    )
+    store_message_handler = StoreMessageHandler(
+        storage_service=storage_service,
+        grace_period=24,
+        max_unauthenticated_upload_file_size=DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE,
+    )
+
+    with session_factory() as session:
+        with pytest.raises(RuntimeError, match="pin failed"):
+            await store_message_handler.fetch_related_content(
+                session=session, message=fixture_message_directory
+            )
+
+    node_cache = storage_service.node_cache
+    node_cache.incr.assert_any_call(STORE_FETCH_TOTAL_KEY)
+    node_cache.incr.assert_any_call(STORE_FETCH_FAILED_KEY)
+    node_cache.incrby.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_store_message.py
+++ b/tests/storage/test_store_message.py
@@ -110,14 +110,14 @@ async def test_handle_new_storage_file(
     mock_ipfs_client.files.stat = mocker.AsyncMock(return_value=ipfs_stats)
 
     message = fixture_message_file
+    node_cache = mocker.AsyncMock()
     storage_service = StorageService(
         storage_engine=mocker.AsyncMock(),
         ipfs_service=IpfsService(ipfs_client=mock_ipfs_client),
-        node_cache=mocker.AsyncMock(),
+        node_cache=node_cache,
     )
-    storage_service.get_hash_content = get_hash_content_mock = mocker.AsyncMock(
-        return_value=raw_content
-    )  # type: ignore
+    get_hash_content_mock = mocker.AsyncMock(return_value=raw_content)
+    storage_service.get_hash_content = get_hash_content_mock  # type: ignore[method-assign]
     store_message_handler = StoreMessageHandler(
         storage_service=storage_service,
         grace_period=24,
@@ -142,7 +142,6 @@ async def test_handle_new_storage_file(
     get_hash_content_mock.assert_called_once()
 
     # ipfs item via http path: ipfs counters incremented, duration recorded, no failure
-    node_cache = storage_service.node_cache
     node_cache.incr.assert_any_call(STORE_FETCH_IPFS_TOTAL_KEY)
     node_cache.incrby.assert_any_call(STORE_FETCH_IPFS_DURATION_MS_SUM_KEY, ANY)
     assert (
@@ -170,10 +169,11 @@ async def test_handle_new_storage_directory(
     message = fixture_message_directory
     storage_engine = mocker.AsyncMock()
 
+    node_cache = mocker.AsyncMock()
     storage_service = StorageService(
         storage_engine=storage_engine,
         ipfs_service=IpfsService(ipfs_client=mock_ipfs_client),
-        node_cache=mocker.AsyncMock(),
+        node_cache=node_cache,
     )
     store_message_handler = StoreMessageHandler(
         storage_service=storage_service,
@@ -201,7 +201,6 @@ async def test_handle_new_storage_directory(
     assert not storage_engine.called
 
     # pin path (ipfs): ipfs counters incremented, duration recorded, no failure
-    node_cache = storage_service.node_cache
     node_cache.incr.assert_any_call(STORE_FETCH_IPFS_TOTAL_KEY)
     node_cache.incrby.assert_any_call(STORE_FETCH_IPFS_DURATION_MS_SUM_KEY, ANY)
     assert (
@@ -229,10 +228,11 @@ async def test_handle_storage_fetch_failure_metrics(
         }
     )
 
+    node_cache = mocker.AsyncMock()
     storage_service = StorageService(
         storage_engine=mocker.AsyncMock(),
         ipfs_service=IpfsService(ipfs_client=mock_ipfs_client),
-        node_cache=mocker.AsyncMock(),
+        node_cache=node_cache,
     )
     # A non-APIError exception confirms the broad except counts every failure mode.
     mocker.patch.object(
@@ -252,7 +252,6 @@ async def test_handle_storage_fetch_failure_metrics(
                 session=session, message=fixture_message_directory
             )
 
-    node_cache = storage_service.node_cache
     node_cache.incr.assert_any_call(STORE_FETCH_IPFS_TOTAL_KEY)
     node_cache.incr.assert_any_call(STORE_FETCH_IPFS_FAILED_KEY)
     node_cache.incrby.assert_not_called()

--- a/tests/storage/test_store_message.py
+++ b/tests/storage/test_store_message.py
@@ -3,16 +3,21 @@ from typing import Any, Mapping
 from unittest.mock import ANY
 
 import pytest
+from aleph_message.models import ItemType
 from configmanager import Config
 from message_test_helpers import make_validated_message_from_dict
 from sqlalchemy import select
 
 from aleph.db.models import MessageDb, StoredFileDb
 from aleph.handlers.content.store import (
-    STORE_FETCH_DURATION_MS_SUM_KEY,
-    STORE_FETCH_FAILED_KEY,
-    STORE_FETCH_TOTAL_KEY,
+    STORE_FETCH_IPFS_DURATION_MS_SUM_KEY,
+    STORE_FETCH_IPFS_FAILED_KEY,
+    STORE_FETCH_IPFS_TOTAL_KEY,
+    STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY,
+    STORE_FETCH_STORAGE_FAILED_KEY,
+    STORE_FETCH_STORAGE_TOTAL_KEY,
     StoreMessageHandler,
+    _store_fetch_keys,
 )
 from aleph.schemas.message_content import ContentSource, RawContent
 from aleph.services.ipfs import IpfsService
@@ -20,6 +25,25 @@ from aleph.storage import StorageService
 from aleph.toolkit.constants import DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE
 from aleph.types.db_session import DbSessionFactory
 from aleph.types.files import FileType
+
+
+def test_store_fetch_keys_differentiate_by_type():
+    """Metric keys are split by item type so ipfs and storage fetches never
+    share a counter."""
+    ipfs_keys = _store_fetch_keys(ItemType.ipfs)
+    storage_keys = _store_fetch_keys(ItemType.storage)
+
+    assert ipfs_keys == (
+        STORE_FETCH_IPFS_TOTAL_KEY,
+        STORE_FETCH_IPFS_FAILED_KEY,
+        STORE_FETCH_IPFS_DURATION_MS_SUM_KEY,
+    )
+    assert storage_keys == (
+        STORE_FETCH_STORAGE_TOTAL_KEY,
+        STORE_FETCH_STORAGE_FAILED_KEY,
+        STORE_FETCH_STORAGE_DURATION_MS_SUM_KEY,
+    )
+    assert set(ipfs_keys).isdisjoint(storage_keys)
 
 
 @pytest.fixture
@@ -117,11 +141,13 @@ async def test_handle_new_storage_file(
 
     get_hash_content_mock.assert_called_once()
 
-    # http fetch path: total counter incremented and duration recorded, no failure
+    # ipfs item via http path: ipfs counters incremented, duration recorded, no failure
     node_cache = storage_service.node_cache
-    node_cache.incr.assert_any_call(STORE_FETCH_TOTAL_KEY)
-    node_cache.incrby.assert_any_call(STORE_FETCH_DURATION_MS_SUM_KEY, ANY)
-    assert mocker.call(STORE_FETCH_FAILED_KEY) not in node_cache.incr.call_args_list
+    node_cache.incr.assert_any_call(STORE_FETCH_IPFS_TOTAL_KEY)
+    node_cache.incrby.assert_any_call(STORE_FETCH_IPFS_DURATION_MS_SUM_KEY, ANY)
+    assert (
+        mocker.call(STORE_FETCH_IPFS_FAILED_KEY) not in node_cache.incr.call_args_list
+    )
 
 
 @pytest.mark.asyncio
@@ -174,11 +200,13 @@ async def test_handle_new_storage_directory(
 
     assert not storage_engine.called
 
-    # pin path: total counter incremented and duration recorded, no failure
+    # pin path (ipfs): ipfs counters incremented, duration recorded, no failure
     node_cache = storage_service.node_cache
-    node_cache.incr.assert_any_call(STORE_FETCH_TOTAL_KEY)
-    node_cache.incrby.assert_any_call(STORE_FETCH_DURATION_MS_SUM_KEY, ANY)
-    assert mocker.call(STORE_FETCH_FAILED_KEY) not in node_cache.incr.call_args_list
+    node_cache.incr.assert_any_call(STORE_FETCH_IPFS_TOTAL_KEY)
+    node_cache.incrby.assert_any_call(STORE_FETCH_IPFS_DURATION_MS_SUM_KEY, ANY)
+    assert (
+        mocker.call(STORE_FETCH_IPFS_FAILED_KEY) not in node_cache.incr.call_args_list
+    )
 
 
 @pytest.mark.asyncio
@@ -225,8 +253,8 @@ async def test_handle_storage_fetch_failure_metrics(
             )
 
     node_cache = storage_service.node_cache
-    node_cache.incr.assert_any_call(STORE_FETCH_TOTAL_KEY)
-    node_cache.incr.assert_any_call(STORE_FETCH_FAILED_KEY)
+    node_cache.incr.assert_any_call(STORE_FETCH_IPFS_TOTAL_KEY)
+    node_cache.incr.assert_any_call(STORE_FETCH_IPFS_FAILED_KEY)
     node_cache.incrby.assert_not_called()
 
 

--- a/tests/web/controllers/test_metrics.py
+++ b/tests/web/controllers/test_metrics.py
@@ -22,7 +22,6 @@ def test_format_dict_for_prometheus():
 
 
 def test_format_dataclass_for_prometheus() -> None:
-
     @dataclass
     class Simple:
         a: int
@@ -82,7 +81,10 @@ def test_metrics():
         "pyaleph_ws_messages_connections_rejected_total 0\n"
         "pyaleph_ws_status_connections_rejected_total 0\n"
         "pyaleph_ws_broadcaster_consumer_restarts_total 0\n"
-        "pyaleph_store_fetch_total 0\n"
-        "pyaleph_store_fetch_failed_total 0\n"
-        "pyaleph_store_fetch_duration_ms_sum 0"
+        "pyaleph_store_fetch_ipfs_total 0\n"
+        "pyaleph_store_fetch_ipfs_failed_total 0\n"
+        "pyaleph_store_fetch_ipfs_duration_ms_sum 0\n"
+        "pyaleph_store_fetch_storage_total 0\n"
+        "pyaleph_store_fetch_storage_failed_total 0\n"
+        "pyaleph_store_fetch_storage_duration_ms_sum 0"
     )

--- a/tests/web/controllers/test_metrics.py
+++ b/tests/web/controllers/test_metrics.py
@@ -81,5 +81,8 @@ def test_metrics():
         "pyaleph_ws_messages_broadcast_total 0\n"
         "pyaleph_ws_messages_connections_rejected_total 0\n"
         "pyaleph_ws_status_connections_rejected_total 0\n"
-        "pyaleph_ws_broadcaster_consumer_restarts_total 0"
+        "pyaleph_ws_broadcaster_consumer_restarts_total 0\n"
+        "pyaleph_store_fetch_total 0\n"
+        "pyaleph_store_fetch_failed_total 0\n"
+        "pyaleph_store_fetch_duration_ms_sum 0"
     )


### PR DESCRIPTION
  Instrument fetch_related_content to measure download time and failure
  rate during the IPFS thundering herd (90 CCNs pulling the same CID at
  once).

  - Log structured `ipfs_fetch` lines (hash, type, path, size, duration, outcome) on every pin/http fetch — source for p95/max via logs.
  - Add Redis counters surfaced at /metrics: pyaleph_store_fetch_total, pyaleph_store_fetch_failed_total, and pyaleph_store_fetch_duration_ms_sum (sum of successful durations; mean = sum / (total - failed)).
  - Add NodeCache.incrby for the duration sum.