### PR TITLE
build: exclude .worktrees/ from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,6 +61,9 @@ MANIFEST
 .venv*/
 venv*/
 
+# Git worktrees
+.worktrees/
+
 # User configuration with secrets
 /config.yml
 node-secret.key


### PR DESCRIPTION
## Summary
- Add `.worktrees/` to `.dockerignore` so local git worktrees are not sent to the Docker daemon as part of the build context.

## Why
Working on multiple branches via `git worktree add .worktrees/<branch>` (or via tooling that does the same) drops a full checkout per branch under `.worktrees/`. On this repo it currently sits at ~681 MB across 18 entries, which is uploaded to the daemon on every build and inflates image build times for no benefit. The new entry follows the existing pattern for dev-local paths (`venv*/`, `.idea`, `.claude/`).

## Test plan
- [ ] `docker build .` finishes with a noticeably smaller "Sending build context to Docker daemon" step on machines that have populated `.worktrees/`.
- [ ] No production paths under `.worktrees/` are referenced by the Dockerfile (verified: build context only pulls from `src/`, `deployment/`, top-level config).