### PR TITLE
deps(ipfs): bump kubo to v0.41.0 and fix removed/no-op config

### DIFF
--- a/deployment/docker-build/dev/docker-compose.yml
+++ b/deployment/docker-build/dev/docker-compose.yml
@@ -115,7 +115,7 @@ services:
 
   ipfs:
     restart: always
-    image: ipfs/kubo:v0.37.0
+    image: ipfs/kubo:v0.41.0
     ports:
       - "4001:4001"
       - "4001:4001/udp"
@@ -128,7 +128,7 @@ services:
       - IPFS_TELEMETRY=off
     networks:
       - pyaleph
-    command: ["daemon", "--enable-pubsub-experiment", "--enable-gc", "--migrate"]
+    command: ["daemon", "--enable-gc", "--migrate"]
 
 
 networks:

--- a/deployment/docker-build/docker-compose.yml
+++ b/deployment/docker-build/docker-compose.yml
@@ -44,7 +44,7 @@ services:
 
   ipfs:
     restart: always
-    image: ipfs/kubo:v0.37.0
+    image: ipfs/kubo:v0.41.0
     ports:
       - "4001:4001"
       - "4001:4001/udp"
@@ -58,7 +58,7 @@ services:
       - IPFS_TELEMETRY=off
     networks:
       - pyaleph
-    command: ["daemon", "--enable-pubsub-experiment", "--enable-gc", "--migrate"]
+    command: ["daemon", "--enable-gc", "--migrate"]
 
   postgres:
     restart: always

--- a/deployment/samples/docker-compose/docker-compose.yml
+++ b/deployment/samples/docker-compose/docker-compose.yml
@@ -103,7 +103,7 @@ services:
 
   ipfs:
     restart: always
-    image: ipfs/kubo:v0.37.0
+    image: ipfs/kubo:v0.41.0
     ports:
       - "4001:4001"
       - "4001:4001/udp"
@@ -116,7 +116,7 @@ services:
       - IPFS_TELEMETRY=off
     networks:
       - pyaleph
-    command: ["daemon", "--enable-pubsub-experiment", "--enable-gc", "--migrate"]
+    command: ["daemon", "--enable-gc", "--migrate"]
 
 
 networks:

--- a/deployment/samples/docker-monitoring/docker-compose.yml
+++ b/deployment/samples/docker-monitoring/docker-compose.yml
@@ -105,7 +105,7 @@ services:
 
   ipfs:
     restart: always
-    image: ipfs/kubo:v0.37.0
+    image: ipfs/kubo:v0.41.0
     ports:
       - "4001:4001"
       - "4001:4001/udp"
@@ -118,7 +118,7 @@ services:
       - IPFS_TELEMETRY=off
     networks:
       - pyaleph
-    command: ["daemon", "--enable-pubsub-experiment", "--enable-gc", "--migrate"]
+    command: ["daemon", "--enable-gc", "--migrate"]
 
   prometheus:
     restart: always

--- a/deployment/scripts/001-update-ipfs-config.sh
+++ b/deployment/scripts/001-update-ipfs-config.sh
@@ -13,8 +13,12 @@ echo "Updating IPFS config file..."
 # Enable the V1+V2 service
 ipfs config AutoNAT.ServiceMode 'enabled'
 
-# Only announce recursively pinned CIDs
-ipfs config Reprovider.Strategy 'pinned'
+# Only announce recursively pinned CIDs (Reprovider.* keys were removed in kubo 0.38)
+ipfs config Provide.Strategy 'pinned'
+
+# Pubsub must be enabled via config in kubo 0.38+; the legacy --enable-pubsub-experiment
+# daemon flag is a no-op (logs a deprecation error without enabling pubsub).
+ipfs config Pubsub.Enabled --json 'true'
 
 # ONLY use the Amino DHT (no HTTP routers).
 ipfs config Routing.Type "dhtserver"


### PR DESCRIPTION
## Summary

Bumps the IPFS image from `kubo:v0.37.0` to `kubo:v0.41.0` across all
deployment compose files and fixes two configuration items that became
broken in the intervening releases.

### 1. `Reprovider.*` config keys REMOVED in 0.41

Kubo 0.38 merged the `Provider` and `Reprovider` sections into a single
`Provide` section. The v0.41 [`docs/config.md`](https://github.com/ipfs/kubo/blob/v0.41.0/docs/config.md#reproviderstrategy)
explicitly marks `Reprovider.Strategy` as **REMOVED** (and
`Reprovider.Interval` → use `Provide.DHT.Interval`).

Our init script set this value on every container start
(`ipfs config Reprovider.Strategy 'pinned'`), so `--migrate` does not
help: the line errors on each boot. Switched to `Provide.Strategy`.

### 2. `--enable-pubsub-experiment` is now a no-op (silent breakage)

Per v0.41 source
([`cmd/ipfs/kubo/daemon.go`](https://github.com/ipfs/kubo/blob/v0.41.0/cmd/ipfs/kubo/daemon.go)):

```
cmds.BoolOption(enablePubSubKwd, "DEPRECATED CLI flag. Use Pubsub.Enabled config instead.")
...
if psSet {
    log.Error("The --enable-pubsub-experiment flag is deprecated. Use Pubsub.Enabled config option instead.")
} else {
    pubsub = cfg.Pubsub.Enabled.WithDefault(false)
}
```

The flag value is no longer wired up, and `Pubsub.Enabled` defaults to
`false`. Since pyaleph relies on IPFS pubsub for peer liveness
(`src/aleph/services/ipfs/pubsub.py`, `services/peers/publish.py`,
`services/peers/monitor.py`), leaving this unchanged would silently
disable pubsub.

Fix: removed the dead flag from the daemon command and added
`ipfs config Pubsub.Enabled --json 'true'` to the init script.

### Preserved

- `--migrate` is kept so the on-disk repo migrates from v17 to v18 on
  first boot under 0.38+.

## Operator upgrade notes

- On nodes whose `/data/ipfs` volume was previously owned by `root`
  (e.g. an older deployment that ran the container as root), the new
  image runs as `ipfs` (UID 1000) and the entrypoint's auto-chown can
  be slow on large volumes. Operators may want to run a manual
  `chown -R 1000:100 /var/lib/docker/volumes/<...>/_data` ahead of the
  bump. This is unchanged behaviour vs. 0.37 (the kubo Dockerfile has
  set `ipfs:users` ownership for years); only volumes with mismatched
  history are affected.

## Test plan

- [ ] Deploy on a staging node previously running `kubo:v0.37.0`,
      confirm: daemon starts, `ipfs config Pubsub.Enabled` returns
      `true`, `ipfs config Provide.Strategy` returns `pinned`, no
      `Reprovider.Strategy` errors in `001-update-ipfs-config.sh` logs.
- [ ] Verify pyaleph peer liveness messages keep flowing on the IPFS
      pubsub topic after upgrade.
- [ ] Confirm repo migration v17 → v18 runs once on first boot.