### PR TITLE
fix(store): widen IPFS size lookup timeout in pre_check_balance

### DIFF
--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -92,7 +92,9 @@ async def _get_file_stats_from_ipfs(
         except aioipfs.InvalidCIDError as e:
             raise UnknownHashError(f"Invalid IPFS hash from API: '{cid}'") from e
         if stats is None:
-            raise FileUnavailable("Could not retrieve IPFS file stats at this time")
+            raise FileUnavailable(
+                str(cid), "could not retrieve IPFS file stats at this time"
+            )
 
         if stats["Type"] == "file":
             is_folder = False
@@ -114,7 +116,8 @@ async def _get_file_stats_from_ipfs(
             getattr(error, "message", None),
         )
         raise FileUnavailable(
-            f"Timeout ({stat_timeout}s) while retrieving stats of hash {cid}: {getattr(error, 'message', None)}"
+            str(cid),
+            f"timeout {stat_timeout}s retrieving IPFS file stats: {getattr(error, 'message', None)}",
         )
 
     except aioipfs.APIError as error:
@@ -268,7 +271,9 @@ class StoreMessageHandler(ContentHandler):
                 item_type,
                 timer.elapsed(),
             )
-            raise FileUnavailable("Could not retrieve file from storage at this time")
+            raise FileUnavailable(
+                file_hash, "could not retrieve file from storage at this time"
+            )
 
         await self.storage_service.node_cache.incrby(
             duration_key, round(timer.elapsed() * 1000)
@@ -318,7 +323,9 @@ class StoreMessageHandler(ContentHandler):
                 ipfs_byte_size: int | None = stored_file.size
             else:
                 ipfs_byte_size = await self.storage_service.ipfs_service.get_ipfs_size(
-                    content.item_hash
+                    content.item_hash,
+                    timeout=config.ipfs.stat_timeout.value,
+                    tries=3,
                 )
             if ipfs_byte_size:
                 storage_mib = Decimal(ipfs_byte_size / MiB)

--- a/src/aleph/handlers/message_handler.py
+++ b/src/aleph/handlers/message_handler.py
@@ -108,7 +108,9 @@ class BaseMessageHandler:
         except (ContentCurrentlyUnavailable, Exception) as e:
             if not isinstance(e, ContentCurrentlyUnavailable):
                 LOGGER.exception("Can't get content of object %s" % item_hash)
-            raise MessageContentUnavailable(f"Could not fetch content for {item_hash}")
+            raise MessageContentUnavailable(
+                item_hash, "could not fetch message content"
+            )
 
         try:
             validated_message = MessageDb.from_pending_message(

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -205,6 +205,7 @@ class IpfsService:
                     raise FileUnavailable(
                         hash, "could not retrieve IPFS content at this time"
                     )
+                continue
             except (
                 concurrent.futures.CancelledError,
                 aiohttp.client_exceptions.ClientConnectorError,

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -199,9 +199,11 @@ class IpfsService:
                 await asyncio.sleep(0.5)
                 continue
             except asyncio.TimeoutError:
-                raise FileUnavailable(
-                    hash, "could not retrieve IPFS content at this time"
-                )
+                if try_count >= tries:
+                    raise FileUnavailable(
+                        hash, "could not retrieve IPFS content at this time"
+                    )
+                await asyncio.sleep(0.5)
             except (
                 concurrent.futures.CancelledError,
                 aiohttp.client_exceptions.ClientConnectorError,

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -199,11 +199,12 @@ class IpfsService:
                 await asyncio.sleep(0.5)
                 continue
             except asyncio.TimeoutError:
+                # A timeout already consumed the full `timeout` budget, so it is
+                # its own backoff: retry immediately, or give up once exhausted.
                 if try_count >= tries:
                     raise FileUnavailable(
                         hash, "could not retrieve IPFS content at this time"
                     )
-                await asyncio.sleep(0.5)
             except (
                 concurrent.futures.CancelledError,
                 aiohttp.client_exceptions.ClientConnectorError,

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -199,7 +199,9 @@ class IpfsService:
                 await asyncio.sleep(0.5)
                 continue
             except asyncio.TimeoutError:
-                raise FileUnavailable("Could not retrieve IPFS content at this time")
+                raise FileUnavailable(
+                    hash, "could not retrieve IPFS content at this time"
+                )
             except (
                 concurrent.futures.CancelledError,
                 aiohttp.client_exceptions.ClientConnectorError,
@@ -306,12 +308,10 @@ class IpfsService:
                 tick_timeout -= 1
                 if tick_timeout == 0:
                     if progress is None:
-                        details = "file not found"
+                        reason = "file not found"
                     else:
-                        details = "could not fetch some blocks"
-                    raise FileUnavailable(
-                        f"Could not pin IPFS content at this time ({details})"
-                    )
+                        reason = "could not fetch some blocks"
+                    raise FileUnavailable(cid, f"could not pin IPFS content: {reason}")
             else:
                 # Reset the timeout counter if there is some measure of progress
                 tick_timeout = timeout * 2

--- a/src/aleph/types/message_status.py
+++ b/src/aleph/types/message_status.py
@@ -174,7 +174,6 @@ class FileNotFoundException(RetryMessageException):
             message = f"{message} ({details})"
         super().__init__(message)
         self.file_hash = file_hash
-        self.details = details
 
 
 class MessageContentUnavailable(FileNotFoundException):

--- a/src/aleph/types/message_status.py
+++ b/src/aleph/types/message_status.py
@@ -168,8 +168,13 @@ class FileNotFoundException(RetryMessageException):
     on the network.
     """
 
-    def __init__(self, file_hash: str):
-        super().__init__(f"File not found: {file_hash}")
+    def __init__(self, file_hash: str, details: Optional[str] = None):
+        message = f"File not found: {file_hash}"
+        if details:
+            message = f"{message} ({details})"
+        super().__init__(message)
+        self.file_hash = file_hash
+        self.details = details
 
 
 class MessageContentUnavailable(FileNotFoundException):

--- a/tests/message_processing/test_process_stores.py
+++ b/tests/message_processing/test_process_stores.py
@@ -460,7 +460,7 @@ async def test_pre_check_balance_small_ipfs_file(mocker, session_factory, mock_c
 
         # Verify that get_ipfs_size was called with correct hash
         ipfs_service.get_ipfs_size.assert_called_once_with(
-            "QmWVxvresoeadRbCeG4BmvsoSsqHV7VwUNuGK6nUCKKFGQ"
+            "QmWVxvresoeadRbCeG4BmvsoSsqHV7VwUNuGK6nUCKKFGQ", timeout=30, tries=3
         )
 
 
@@ -515,7 +515,7 @@ async def test_pre_check_balance_large_ipfs_file_insufficient_balance(
 
         # Verify that get_ipfs_size was called with correct hash
         ipfs_service.get_ipfs_size.assert_called_once_with(
-            "QmWVxvresoeadRbCeG4BmvsoSsqHV7VwUNuGK6nUCKKFGQ"
+            "QmWVxvresoeadRbCeG4BmvsoSsqHV7VwUNuGK6nUCKKFGQ", timeout=30, tries=3
         )
 
 
@@ -579,7 +579,7 @@ async def test_pre_check_balance_large_ipfs_file_sufficient_balance(
 
         # Verify that get_ipfs_size was called with correct hash
         ipfs_service.get_ipfs_size.assert_called_once_with(
-            "QmWVxvresoeadRbCeG4BmvsoSsqHV7VwUNuGK6nUCKKFGQ"
+            "QmWVxvresoeadRbCeG4BmvsoSsqHV7VwUNuGK6nUCKKFGQ", timeout=30, tries=3
         )
 
 
@@ -707,7 +707,7 @@ async def test_pre_check_balance_ipfs_size_none(mocker, session_factory, mock_co
 
         # Verify that get_ipfs_size was called with correct hash
         ipfs_service.get_ipfs_size.assert_called_once_with(
-            "QmWVxvresoeadRbCeG4BmvsoSsqHV7VwUNuGK6nUCKKFGQ"
+            "QmWVxvresoeadRbCeG4BmvsoSsqHV7VwUNuGK6nUCKKFGQ", timeout=30, tries=3
         )
 
 
@@ -805,7 +805,7 @@ async def test_pre_check_balance_with_existing_costs(
 
             # Verify that get_ipfs_size was called with correct hash
             ipfs_service.get_ipfs_size.assert_called_once_with(
-                "QmacDVDroxPVY1enhckVco1rTBziwC8hjf731apEKr3QoG"
+                "QmacDVDroxPVY1enhckVco1rTBziwC8hjf731apEKr3QoG", timeout=30, tries=3
             )
 
 

--- a/tests/services/test_ipfs_service.py
+++ b/tests/services/test_ipfs_service.py
@@ -205,15 +205,11 @@ async def test_get_ipfs_size_timeout_error():
 
     service = IpfsService(ipfs_client=ipfs_client)
 
+    # A single try should raise FileUnavailable immediately on timeout.
     with pytest.raises(FileUnavailable):
-        # Mock asyncio.sleep to not actually sleep during test
-        with patch("asyncio.sleep", new_callable=AsyncMock):
-            # Execute
-            result = await service.get_ipfs_size("test_hash")
+        await service.get_ipfs_size("test_hash")
 
-        # Assert
-        assert result is None
-        ipfs_client.dag.get.assert_called_once_with("test_hash")
+    ipfs_client.dag.get.assert_called_once_with("test_hash")
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_ipfs_service.py
+++ b/tests/services/test_ipfs_service.py
@@ -217,6 +217,22 @@ async def test_get_ipfs_size_timeout_error():
 
 
 @pytest.mark.asyncio
+async def test_get_ipfs_size_timeout_error_multiple_tries():
+    """Timeouts should retry up to `tries` times before raising FileUnavailable."""
+    ipfs_client = AsyncMock()
+    ipfs_client.dag.get = AsyncMock(side_effect=asyncio.TimeoutError())
+
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        with pytest.raises(FileUnavailable):
+            await service.get_ipfs_size("test_hash", tries=3)
+
+    # Should have attempted exactly `tries` times before giving up
+    assert ipfs_client.dag.get.call_count == 3
+
+
+@pytest.mark.asyncio
 async def test_get_ipfs_size_cancelled_error():
     """Test handling of CancelledError"""
     # Setup


### PR DESCRIPTION
## Summary

- `pre_check_balance` called `get_ipfs_size(item_hash)` with the helper's default `timeout=1, tries=1`. On any busy local kubo (which is the normal state right after a CAR upload), the single `dag.get` round-trip can blow past 1s, raising `FileUnavailable`. Pending-message retries each get the same 1s budget, so they keep failing and the message is rejected with error code 4 (`FILE_UNAVAILABLE`) even when the content is fully pinned locally.
- Pass `config.ipfs.stat_timeout` and `tries=3` from the call site so this deadline matches the rest of the IPFS read path.
- Reshape `FileNotFoundException.__init__` to take `(file_hash, details)`. All six raise sites in `store`, `service/ipfs/service`, and `message_handler` were stuffing prose into the `file_hash` slot, so rejection records and logs looked like `File not found: Could not retrieve IPFS content at this time` with no actual CID. They now carry the CID and the diagnostic separately.

## Concrete symptom this fixes

A user uploads a website CAR via `/api/v0/ipfs/add_car`. The endpoint succeeds (CAR imported, root recursively pinned, all blocks present on the local daemon, `files.stat` returns valid `CumulativeSize`). The accompanying STORE message is later rejected with `error_code=4`, `details="File not found: Could not retrieve IPFS content at this time"`. The rejection comes from `pre_check_balance`'s 1-second `dag.get` budget, not from anything actually being unavailable.

## Test plan

- [x] `pytest tests/services/test_ipfs_service.py tests/storage/test_store_message.py -v` (17 passed)
- [ ] On the affected node, deploy and re-upload the same CAR; confirm the STORE message reaches `processed`
- [ ] Tail rejection records and confirm `details` now carries the CID instead of prose