### PR TITLE
feat(store): skip IPFS lookup in pre_check_balance when file is local

### DIFF
--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -18,6 +18,7 @@ from aleph_message.models import ItemHash, ItemType, PaymentType, StoreContent
 from aleph.config import get_config
 from aleph.db.accessors.files import (
     delete_file_pin,
+    get_file,
     get_file_tag,
     get_message_file_pin,
     insert_grace_period_file_pin,
@@ -243,9 +244,17 @@ class StoreMessageHandler(ContentHandler):
         engine = content.item_type
         # Initially only do that balance pre-check for ipfs files.
         if engine == ItemType.ipfs and ipfs_enabled:
-            ipfs_byte_size = await self.storage_service.ipfs_service.get_ipfs_size(
-                content.item_hash
-            )
+            # If we already have the file locally (e.g. from a prior add_file
+            # or add_car upload on this node), use the stored size instead of
+            # asking kubo. Avoids a redundant dag.get round-trip and the
+            # rejection risk when the daemon is busy right after upload.
+            stored_file = get_file(session, content.item_hash)
+            if stored_file is not None:
+                ipfs_byte_size: int | None = stored_file.size
+            else:
+                ipfs_byte_size = await self.storage_service.ipfs_service.get_ipfs_size(
+                    content.item_hash
+                )
             if ipfs_byte_size:
                 storage_mib = Decimal(ipfs_byte_size / MiB)
 


### PR DESCRIPTION
## Summary

- `pre_check_balance` calls `get_ipfs_size(item_hash)` to compute the storage cost, even for content this node just uploaded itself and already recorded in its own `files` table.
- That round-trip is what is rejecting freshly-uploaded CARs: under any kubo busyness the `dag.get` can fail and the message ends up rejected with `FILE_UNAVAILABLE` even though the file is fully pinned locally.
- Query `get_file(session, item_hash)` first. On hit, use `stored_file.size` and skip the IPFS call entirely. On miss, fall back to `get_ipfs_size` as before.

Covers both `add_car` directories and `add_file` singletons (both write to `files` before broadcasting the STORE), and also helps when a STORE arrives from the network for content the node happens to already host.

## Relationship to #1169

#1169 widens the `get_ipfs_size` deadline (the IPFS-call path). This PR removes the IPFS call entirely on the common hot path (locally-known content). They are independent fixes for the same production symptom. Either alone fixes the freshly-uploaded-CAR case; together they also harden the remote-content path.

## Test plan

- [x] `pytest tests/storage/test_store_message.py -v` (4 passed)
- [ ] On the affected node, deploy and re-upload the same CAR; confirm the STORE message reaches `processed` without any `dag.get` traffic in the kubo logs for that CID