### PR TITLE
Add randomized delay before IPFS fetch

### DIFF
--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -268,6 +268,15 @@ def get_defaults():
             },
             # Timeout for file stat requests (seconds)
             "stat_timeout": 30,
+            # Randomized delay (in seconds, drawn uniformly from [0, value]) before
+            # an IPFS file fetch starts, to spread the thundering herd of CCNs
+            # pulling a newly-announced CID from the origin. A small non-zero
+            # default flattens the burst across the ~90-node fleet without
+            # materially delaying message processing — 5s gives ~18 starts/sec
+            # spread instead of all-at-once, and is negligible against typical
+            # multi-second pin durations. Set to 0 to disable; raise to 30-60
+            # for very large fleets or aggressively bursty workloads.
+            "fetch_jitter_seconds": 5,
         },
         "rabbitmq": {
             # Hostname of the RabbitMQ service.

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -8,6 +8,7 @@ TODO:
 import asyncio
 import datetime as dt
 import logging
+import random
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import List, Set
@@ -124,6 +125,21 @@ async def _get_file_stats_from_ipfs(
         raise
 
 
+async def _apply_fetch_jitter(window_seconds: float, file_hash: str) -> None:
+    """Wait a randomized delay before starting an IPFS fetch.
+
+    Spreads the simultaneous fetch attempts from many CCNs receiving the same
+    STORE message into a rolling wave so early fetchers can become reseeders for
+    later ones before the origin's uplink is saturated. A no-op when the window
+    is zero, so the behaviour is opt-in via ``ipfs.fetch_jitter_seconds``.
+    """
+    if window_seconds <= 0:
+        return
+    delay = random.uniform(0, window_seconds)
+    LOGGER.info("ipfs_fetch_jitter hash=%s delay=%.2f", file_hash, delay)
+    await asyncio.sleep(delay)
+
+
 def _should_pin_on_ipfs(
     file_stats: IpfsFileStats,
     min_file_size_for_pinning: int,
@@ -185,6 +201,7 @@ class StoreMessageHandler(ContentHandler):
 
         # For CIDs, pin directories and files > 1MiB
         if item_type == ItemType.ipfs:
+            await _apply_fetch_jitter(config.ipfs.fetch_jitter_seconds.value, file_hash)
             ipfs_service = self.storage_service.ipfs_service
 
             file_stats = await _get_file_stats_from_ipfs(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,6 +127,9 @@ def _create_test_config() -> Config:
     # To test handle_new_storage
     config.storage.store_files.value = True
 
+    # Disable IPFS fetch jitter in tests so fetch_related_content does not sleep.
+    config.ipfs.fetch_jitter_seconds.value = 0
+
     return config
 
 

--- a/tests/storage/test_store_message.py
+++ b/tests/storage/test_store_message.py
@@ -9,7 +9,7 @@ from message_test_helpers import make_validated_message_from_dict
 from sqlalchemy import select
 
 from aleph.db.models import MessageDb, StoredFileDb
-from aleph.handlers.content.store import StoreMessageHandler
+from aleph.handlers.content.store import StoreMessageHandler, _apply_fetch_jitter
 from aleph.schemas.message_content import ContentSource, RawContent
 from aleph.services.ipfs import IpfsService
 from aleph.storage import StorageService
@@ -25,6 +25,24 @@ from aleph.toolkit.metrics_keys import (
 )
 from aleph.types.db_session import DbSessionFactory
 from aleph.types.files import FileType
+
+
+@pytest.mark.asyncio
+async def test_apply_fetch_jitter_skipped_when_zero(mocker):
+    """fetch_jitter_seconds=0 disables jitter and does not sleep."""
+    sleep_mock = mocker.patch("asyncio.sleep", new_callable=mocker.AsyncMock)
+    await _apply_fetch_jitter(0, "abc")
+    sleep_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_fetch_jitter_sleeps_within_window(mocker):
+    """fetch_jitter_seconds>0 sleeps for a delay drawn from [0, window]."""
+    sleep_mock = mocker.patch("asyncio.sleep", new_callable=mocker.AsyncMock)
+    await _apply_fetch_jitter(30.0, "abc")
+    sleep_mock.assert_called_once()
+    delay = sleep_mock.call_args.args[0]
+    assert 0.0 <= delay <= 30.0
 
 
 def test_store_fetch_keys_differentiate_by_type():


### PR DESCRIPTION
  Sleep a random duration drawn uniformly from
  [0, ipfs.fetch_jitter_seconds] at the start of fetch_related_content
  when item_type is ipfs, spreading concurrent fetches over a window.

  - Add aleph.ipfs.fetch_jitter_seconds config field, default 5s.
  - New _apply_fetch_jitter helper; emits an ipfs_fetch_jitter log line with hash and delay. Storage-type fetches are unaffected.
  - Pin fetch_jitter_seconds to 0 in the test config so existing tests do not sleep.
  - Unit tests for the zero-window skip and within-window draw.