### PR TITLE
Apply full-jitter to message retry backoff

### DIFF
--- a/src/aleph/jobs/job_utils.py
+++ b/src/aleph/jobs/job_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime as dt
 import logging
+import random
 from typing import Dict, Optional, Union
 
 import aio_pika
@@ -85,15 +86,20 @@ def compute_next_retry_interval(attempts: int) -> dt.timedelta:
     """
     Computes the time interval for the next attempt/retry of a message.
 
-    The interval is computed as 2^attempts and is capped at 5 minutes.
-    The maximum amount of retries is controlled in the node configuration.
+    Uses exponential backoff with full jitter: the interval is drawn
+    uniformly from ``[0, min(2**attempts, MAX_RETRY_INTERVAL)]`` seconds.
+    The jitter decorrelates the next-attempt time across nodes that failed
+    the same attempt at roughly the same moment, so a retry storm does not
+    re-converge into the same instant. The maximum number of retries is
+    controlled in the node configuration.
 
     :param attempts: Current number of attempts.
     :return: The time interval between the previous processing attempt and the next one.
     """
 
-    seconds = 2**attempts
-    return dt.timedelta(seconds=min(seconds, MAX_RETRY_INTERVAL))
+    cap = min(2**attempts, MAX_RETRY_INTERVAL)
+    seconds = random.uniform(0, cap)
+    return dt.timedelta(seconds=seconds)
 
 
 def schedule_next_attempt(
@@ -221,7 +227,6 @@ class MessageJob(MqWatcher):
         pending_message: PendingMessageDb,
         exception: BaseException,
     ) -> Union[RejectedMessage, WillRetryMessage]:
-
         # Assume if the error_code attribute exists, get it, but if not assign to general Internal Error code.
         error_code = (
             exception.error_code

--- a/tests/jobs/test_retry_backoff.py
+++ b/tests/jobs/test_retry_backoff.py
@@ -1,0 +1,46 @@
+"""Tests for the retry-backoff jitter applied to pending-message scheduling."""
+
+import datetime as dt
+
+import pytest
+
+from aleph.jobs.job_utils import MAX_RETRY_INTERVAL, compute_next_retry_interval
+
+
+def test_compute_next_retry_interval_zero_attempts_bounded_by_one_second():
+    """First retry must fall within [0, 1] seconds (base = 2**0 = 1)."""
+    for _ in range(50):
+        delay = compute_next_retry_interval(0)
+        assert dt.timedelta(0) <= delay <= dt.timedelta(seconds=1)
+
+
+@pytest.mark.parametrize("attempts", [1, 2, 5, 8, 9])
+def test_compute_next_retry_interval_bounded_by_exponential_cap(attempts):
+    """Each draw stays within [0, min(2**attempts, MAX_RETRY_INTERVAL)] seconds.
+
+    attempts=9 is the first value where 2**attempts (512) exceeds the cap (300),
+    so it doubles as a boundary check that the clamp kicks in.
+    """
+    cap_seconds = min(2**attempts, MAX_RETRY_INTERVAL)
+    cap = dt.timedelta(seconds=cap_seconds)
+    for _ in range(50):
+        delay = compute_next_retry_interval(attempts)
+        assert dt.timedelta(0) <= delay <= cap
+
+
+def test_compute_next_retry_interval_capped_at_max():
+    """Large attempt counts cannot exceed MAX_RETRY_INTERVAL."""
+    cap = dt.timedelta(seconds=MAX_RETRY_INTERVAL)
+    for _ in range(50):
+        delay = compute_next_retry_interval(20)
+        assert delay <= cap
+
+
+def test_compute_next_retry_interval_is_jittered():
+    """Successive calls at the same attempt count produce distinct values
+    (the jitter actually decorrelates retries)."""
+    samples = {compute_next_retry_interval(5) for _ in range(50)}
+    # With a continuous uniform draw over a 32-second window, 50 samples
+    # should yield many distinct values; collapsing to <5 would be a sign
+    # the function reverted to a deterministic formula.
+    assert len(samples) >= 5


### PR DESCRIPTION
  compute_next_retry_interval now draws uniformly from
  [0, min(2**attempts, MAX_RETRY_INTERVAL)] seconds instead of returning
  the deterministic 2**attempts. Successive failed attempts on the same
  message no longer schedule retries to the same instant, so retries
  from multiple nodes do not re-converge into a single burst.

  - Tests cover the bounds at several attempt counts, the cap, and the no-determinism property.