### PR TITLE
fix(ws): serialize MQ consumer start to stop duplicate message fanout

### DIFF
--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -107,6 +107,11 @@ class MessageBroadcaster:
         self._queue: Optional[aio_pika.abc.AbstractQueue] = None
         self._consumer_tag: Optional[aio_pika.abc.ConsumerTag] = None
         self._health_task: Optional[asyncio.Task] = None
+        # Serializes the consumer lifecycle (start/stop/restart). Without it,
+        # two clients connecting concurrently could both observe
+        # _consumer_tag is None and each start a consumer, binding a second
+        # queue to processed.* so every message gets fanned out more than once.
+        self._consumer_lock = asyncio.Lock()
 
         # Connection limit (same on every worker — from config).
         self.max_connections: int = config.websocket.max_message_connections.value
@@ -166,11 +171,12 @@ class MessageBroadcaster:
         """Restart the consumer after a channel failure."""
         await self._node_cache.incr(WS_BROADCASTER_CONSUMER_RESTARTS_KEY)
         LOGGER.warning("MessageBroadcaster: restarting consumer")
-        await self._stop_consumer()
-        try:
-            await self._start_consumer()
-        except Exception:
-            LOGGER.exception("MessageBroadcaster: failed to restart consumer")
+        async with self._consumer_lock:
+            await self._stop_consumer()
+            try:
+                await self._start_consumer()
+            except Exception:
+                LOGGER.exception("MessageBroadcaster: failed to restart consumer")
 
     async def _health_check_loop(self):
         """Periodic health check that restarts the consumer if the channel dies."""
@@ -189,10 +195,14 @@ class MessageBroadcaster:
             return
         self._clients.add(client)
         await self._node_cache.incr(WS_MESSAGES_CONNECTIONS_ACTIVE_KEY)
-        if self._consumer_tag is None:
-            await self._start_consumer()
-        if self._health_task is None or self._health_task.done():
-            self._health_task = asyncio.create_task(self._health_check_loop())
+        # Start the shared consumer and health task exactly once, even when
+        # many clients connect concurrently. The lock makes the
+        # check-and-start atomic so a second queue is never bound.
+        async with self._consumer_lock:
+            if self._consumer_tag is None:
+                await self._start_consumer()
+            if self._health_task is None or self._health_task.done():
+                self._health_task = asyncio.create_task(self._health_check_loop())
 
     async def remove(self, client: _WsClient):
         # Guard against double-remove: Redis DECR must be idempotent-safe.
@@ -204,14 +214,16 @@ class MessageBroadcaster:
             if self._health_task and not self._health_task.done():
                 self._health_task.cancel()
                 self._health_task = None
-            await self._stop_consumer()
+            async with self._consumer_lock:
+                await self._stop_consumer()
 
     async def shutdown(self):
         """Graceful shutdown — called from aiohttp on_cleanup."""
         if self._health_task and not self._health_task.done():
             self._health_task.cancel()
             self._health_task = None
-        await self._stop_consumer()
+        async with self._consumer_lock:
+            await self._stop_consumer()
         # Decrement the shared active counter once per client this worker
         # owned, so the Redis value reflects only clients still connected
         # through other workers.

--- a/tests/web/controllers/test_message_broadcaster.py
+++ b/tests/web/controllers/test_message_broadcaster.py
@@ -1,0 +1,111 @@
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from aleph.web.controllers.messages import MessageBroadcaster, _WsClient
+
+
+def _make_broadcaster() -> MessageBroadcaster:
+    """Build a MessageBroadcaster with all external deps mocked."""
+    config = MagicMock()
+    config.websocket.max_message_connections.value = 100
+
+    node_cache = MagicMock()
+
+    async def _noop(*args, **kwargs):
+        # Yield control so concurrent add() calls interleave deterministically.
+        await asyncio.sleep(0)
+
+    node_cache.incr = _noop
+    node_cache.decr = _noop
+    node_cache.decrby = _noop
+
+    mq_conn = MagicMock()
+    return MessageBroadcaster(mq_conn=mq_conn, config=config, node_cache=node_cache)
+
+
+def _make_client() -> _WsClient:
+    ws = MagicMock()
+    ws.closed = False
+    return _WsClient(ws, MagicMock(), exclude_content=False)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_add_starts_single_consumer():
+    """Two clients connecting concurrently must not each spawn an MQ consumer.
+
+    Each extra consumer binds another queue to ``processed.*``, so every
+    processed message would be delivered (and fanned out) once per consumer,
+    making messages appear multiple times to every client.
+    """
+    broadcaster = _make_broadcaster()
+
+    start_calls = 0
+    release = asyncio.Event()
+
+    async def fake_start_consumer():
+        nonlocal start_calls
+        start_calls += 1
+        # Hold inside the consumer-start critical section, simulating the real
+        # awaits (channel(), declare_queue(), consume()) that run before
+        # _consumer_tag is assigned.
+        await release.wait()
+        broadcaster._consumer_tag = "tag"
+        broadcaster._queue = MagicMock()
+
+    async def fake_health_loop():
+        return
+
+    broadcaster._start_consumer = fake_start_consumer  # type: ignore[method-assign]
+    broadcaster._health_check_loop = fake_health_loop  # type: ignore[method-assign]
+
+    add_task = asyncio.gather(
+        broadcaster.add(_make_client()),
+        broadcaster.add(_make_client()),
+    )
+    # Let both add() coroutines reach the consumer-start decision point.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    release.set()
+    await add_task
+
+    assert start_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_add_then_remove_starts_and_stops_consumer_once():
+    """A normal connect/disconnect cycle starts and stops the consumer once,
+    and the consumer lock does not deadlock the lifecycle."""
+    broadcaster = _make_broadcaster()
+
+    start_calls = 0
+    stop_calls = 0
+
+    async def fake_start_consumer():
+        nonlocal start_calls
+        start_calls += 1
+        broadcaster._consumer_tag = "tag"
+        broadcaster._queue = MagicMock()
+
+    async def fake_stop_consumer():
+        nonlocal stop_calls
+        stop_calls += 1
+        broadcaster._consumer_tag = None
+        broadcaster._queue = None
+
+    async def fake_health_loop():
+        return
+
+    broadcaster._start_consumer = fake_start_consumer  # type: ignore[method-assign]
+    broadcaster._stop_consumer = fake_stop_consumer  # type: ignore[method-assign]
+    broadcaster._health_check_loop = fake_health_loop  # type: ignore[method-assign]
+
+    client = _make_client()
+    await asyncio.wait_for(broadcaster.add(client), timeout=1)
+    assert start_calls == 1
+    assert broadcaster._consumer_tag is not None
+
+    await asyncio.wait_for(broadcaster.remove(client), timeout=1)
+    assert stop_calls == 1
+    assert broadcaster._consumer_tag is None

--- a/tests/web/controllers/test_message_broadcaster.py
+++ b/tests/web/controllers/test_message_broadcaster.py
@@ -109,3 +109,55 @@ async def test_add_then_remove_starts_and_stops_consumer_once():
     await asyncio.wait_for(broadcaster.remove(client), timeout=1)
     assert stop_calls == 1
     assert broadcaster._consumer_tag is None
+
+
+@pytest.mark.asyncio
+async def test_restart_consumer_concurrent_with_add_does_not_deadlock():
+    """A channel-failure restart and a concurrent add() both take the consumer
+    lock; they must serialize without deadlocking and leave one live consumer.
+    """
+    broadcaster = _make_broadcaster()
+
+    start_calls = 0
+    stop_calls = 0
+    enter_start = asyncio.Event()
+    release_start = asyncio.Event()
+
+    async def fake_start_consumer():
+        nonlocal start_calls
+        start_calls += 1
+        # Hold the lock so the concurrent caller is forced to wait on it.
+        enter_start.set()
+        await release_start.wait()
+        broadcaster._consumer_tag = "tag"
+        broadcaster._queue = MagicMock()
+
+    async def fake_stop_consumer():
+        nonlocal stop_calls
+        stop_calls += 1
+        broadcaster._consumer_tag = None
+        broadcaster._queue = None
+
+    async def fake_health_loop():
+        return
+
+    broadcaster._start_consumer = fake_start_consumer
+    broadcaster._stop_consumer = fake_stop_consumer
+    broadcaster._health_check_loop = fake_health_loop
+
+    # Restart grabs the lock first and blocks inside _start_consumer.
+    restart_task = asyncio.create_task(broadcaster._restart_consumer())
+    await asyncio.wait_for(enter_start.wait(), timeout=1)
+
+    # add() must block on the lock rather than starting a second consumer.
+    add_task = asyncio.create_task(broadcaster.add(_make_client()))
+    await asyncio.sleep(0)
+
+    # Let the restart finish; add() then proceeds and sees the consumer is up.
+    release_start.set()
+    await asyncio.wait_for(asyncio.gather(restart_task, add_task), timeout=1)
+
+    # One restart-start; add() must not start a second consumer.
+    assert start_calls == 1
+    assert stop_calls == 1
+    assert broadcaster._consumer_tag is not None

--- a/tests/web/controllers/test_message_broadcaster.py
+++ b/tests/web/controllers/test_message_broadcaster.py
@@ -57,8 +57,8 @@ async def test_concurrent_add_starts_single_consumer():
     async def fake_health_loop():
         return
 
-    broadcaster._start_consumer = fake_start_consumer  # type: ignore[method-assign]
-    broadcaster._health_check_loop = fake_health_loop  # type: ignore[method-assign]
+    broadcaster._start_consumer = fake_start_consumer
+    broadcaster._health_check_loop = fake_health_loop
 
     add_task = asyncio.gather(
         broadcaster.add(_make_client()),
@@ -97,9 +97,9 @@ async def test_add_then_remove_starts_and_stops_consumer_once():
     async def fake_health_loop():
         return
 
-    broadcaster._start_consumer = fake_start_consumer  # type: ignore[method-assign]
-    broadcaster._stop_consumer = fake_stop_consumer  # type: ignore[method-assign]
-    broadcaster._health_check_loop = fake_health_loop  # type: ignore[method-assign]
+    broadcaster._start_consumer = fake_start_consumer
+    broadcaster._stop_consumer = fake_stop_consumer
+    broadcaster._health_check_loop = fake_health_loop
 
     client = _make_client()
     await asyncio.wait_for(broadcaster.add(client), timeout=1)


### PR DESCRIPTION
## Problem

The explorer frontend reports that processed messages appear **multiple times** over the WebSocket stream.

`MessageBroadcaster` (introduced in #1062) runs a single shared RabbitMQ consumer per gunicorn worker that fans processed messages out to all connected clients. The consumer-start logic in `add()` is not concurrency-safe:

```python
self._clients.add(client)
await self._node_cache.incr(...)     # await -> yields the event loop
if self._consumer_tag is None:        # both racers still see None
    await self._start_consumer()      # both start a consumer
```

`_start_consumer()` only assigns `self._consumer_tag` on its **last line**, after `channel()`, `declare_queue()` and `consume()` all await. When two clients connect close together (routine when the explorer hits one worker), both pass the `is None` check and each create their own `exclusive` queue bound to `processed.*`. The topic exchange then delivers a copy of every message to **each** queue, so `_on_message` fires once per consumer and every client receives each message more than once.

It compounds: more concurrent first-connections means higher multiplicity, and the losing racer's `_channel`/`_queue`/`_consumer_tag` get overwritten so cleanup only tears down the last consumer. The orphaned channel keeps a live consumer (so `x-expires` never triggers) and keeps duplicating until its connection drops.

The publish side was ruled out: `processed.*` matches only `processed.<hash>` (new messages); confirmations publish as `confirmed.<hash>`, so each message is published to the WS exchange exactly once. The duplication is purely consumer-side.

## Fix

Guard the consumer lifecycle with an `asyncio.Lock` so the check-and-start in `add()`, the teardown in `remove()`/`shutdown()`, and `_restart_consumer()` cannot interleave. The shared consumer is now started exactly once regardless of how many clients connect concurrently.

## Tests

- `test_concurrent_add_starts_single_consumer` reproduces the race (fails before the fix with `2 == 1`) and passes after.
- `test_add_then_remove_starts_and_stops_consumer_once` guards the normal lifecycle against deadlock.

All 20 `tests/web/controllers/` tests pass; black/isort/ruff clean.