### PR TITLE
fix(api): validate page path param in messages list endpoint

### DIFF
--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -58,6 +58,7 @@ from aleph.web.controllers.app_state_getters import (
 )
 from aleph.web.controllers.utils import (
     get_item_hash_from_request,
+    get_path_page,
     mq_make_aleph_message_topic_queue,
     validate_cursor_pagination,
 )
@@ -521,8 +522,8 @@ async def view_messages_list(request: web.Request) -> web.Response:
 
     # If called from the messages/page/{page}.json endpoint, override the page
     # parameters with the URL one
-    if url_page_param := request.match_info.get("page"):
-        query_params.page = int(url_page_param)
+    if (url_page := get_path_page(request)) is not None:
+        query_params.page = url_page
 
     find_filters = query_params.model_dump(exclude_none=True)
 

--- a/tests/api/test_list_messages.py
+++ b/tests/api/test_list_messages.py
@@ -575,6 +575,15 @@ async def test_pagination(fixture_messages, ccn_api_client):
     response = await fetch_messages_with_pagination(ccn_api_client, pagination=-10)
     assert response.status == 422
 
+    # Non-numeric page in the path
+    response = await ccn_api_client.get(MESSAGES_PAGE_URI.format(page="abc"))
+    assert response.status == 400
+
+    # Page < 1 in the path
+    for bad_page in (0, -3):
+        response = await ccn_api_client.get(MESSAGES_PAGE_URI.format(page=bad_page))
+        assert response.status == 422, await response.text()
+
 
 @pytest.mark.asyncio()
 @pytest.mark.parametrize("sort_order", [-1, 1])


### PR DESCRIPTION
## Summary

The `GET /api/v0/messages/page/{page}.json` endpoint cast the path parameter with a bare `int(url_page_param)`, **bypassing** the pydantic validation that the `?page=` query-param path goes through. Two attacker-reachable inputs both surfaced as **500s** (there is no error-handling middleware):

- **Non-numeric** (`/messages/page/abc.json`) → `int('abc')` raises `ValueError` → uncaught → 500.
- **Zero / negative** (`/messages/page/-5.json`) → parses fine, bypasses the `>= 1` floor → negative SQL `OFFSET` in the count query (`db/accessors/messages.py:414`) → 500.

Low severity (unauthenticated read endpoint, parameterized queries — no data leak or injection), but it returns server errors instead of client errors and adds log/Sentry noise.

## Fix

Reuse the existing `get_path_page()` helper (`web/controllers/utils.py`) — already used by the posts controllers — which raises `400` on non-numeric and `422` on `page < 1`.

## Tests

Added regression cases to `test_pagination` exercising the `/page/{page}.json` endpoint with `abc` (→400) and `0`/`-3` (→422). The existing `page=0/-3` cases only covered the query-param path, which was already validated.

## Verification

`ruff`, `black`, `isort`, and `py_compile` pass on the changed files. The full test suite requires the project's hatch + Postgres/redis/anvil test stack, which wasn't available in my environment — please confirm CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)