### PR TITLE
fix(tests): stop credit-balance time-bomb test failures breaking CI

### DIFF
--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -1678,7 +1678,7 @@ def test_credit_balance_details_mixed_expiration(session_factory: DbSessionFacto
         session.commit()
 
         total, details = get_credit_balance_with_details(
-            session=session, address="0xdetails2"
+            session=session, address="0xdetails2", now=ts
         )
         assert total == 1800
         # Non-expiring first, then by expiration_date ascending
@@ -1735,7 +1735,7 @@ def test_credit_balance_details_partial_consumption(session_factory: DbSessionFa
         session.commit()
 
         total, details = get_credit_balance_with_details(
-            session=session, address="0xdetails3"
+            session=session, address="0xdetails3", now=ts
         )
         # 1000 - 700 = 300 non-expiring remaining, 500 expiring remaining
         assert total == 800
@@ -1901,7 +1901,7 @@ def test_credit_balance_details_matches_total(session_factory: DbSessionFactory)
         session.commit()
 
         total, details = get_credit_balance_with_details(
-            session=session, address="0xdetails6"
+            session=session, address="0xdetails6", now=ts
         )
         # 1000 - 1000 = 0 non-expiring, 800 - 200 = 600 exp1, 600 exp2
         assert total == 1200


### PR DESCRIPTION
## Problem

CI on `main` started failing on fresh runs (2026-06-01). The pytest job fails on:

```
tests/db/test_credit_balances.py::test_credit_balance_details_mixed_expiration
  assert 1300 == 1800
```

No code change caused it. `get_credit_balance_with_details` excludes lots where
`expiration_date <= now`, with `now` defaulting to the DB `func.now()`. The test
granted a 500-credit lot expiring `2026-06-01` and left `now` unset, so once the
wall clock reached that date the lot was treated as expired and dropped from the
total.

## Fix

Pin `now` to each test's own `ts` reference (a fixed past date) so the
assertions no longer depend on the wall clock. Two sibling tests had the same
latent defect and were set to break on `2026-09-01`; fixed in the same pass:

- `test_credit_balance_details_mixed_expiration` (failing now)
- `test_credit_balance_details_partial_consumption` (would break 2026-09-01)
- `test_credit_balance_details_matches_total` (would break 2026-09-01)

## Verification

`tests/db/test_credit_balances.py` — 46 passed locally against postgres 15.1.
black / isort / ruff clean.