### PR TITLE
chore(deps): bump aleph-message to 1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "aiohttp-swagger3>=0.10.0",
   "aioipfs~=0.7.1",
   "alembic==1.18.4",
-  "aleph-message @ git+https://github.com/aleph-im/aleph-message@3c71a82ca41245091767eb06889c69753df3658a",
+  "aleph-message==1.2.0",
   "aleph-nuls2==0.1.1",
   "aleph-p2p-client @ git+https://github.com/aleph-im/p2p-service-client-python@1e992aaacdb0071a34ffb130cbbba9123509e08b",
   "asyncpg==0.31.0",


### PR DESCRIPTION
## Summary

Bumps `aleph-message` from the temporary git-commit pin (`3c71a82`) to the released **1.2.0**.

That commit pin was introduced in #1116 as a stopgap because the per-type tag validation it relied on was unreleased (it was the tip of aleph-message's `od/tags` branch). aleph-message 1.2.0 now ships that work as a tagged release, so this restores the normal PyPI version pin (matching the prior `aleph-message==1.1.1` style).

## What 1.2.0 contains

- **Per-type tag and metadata validation** (aleph-im/aleph-message#156) - exactly the `od/tags` snapshot #1116 was pinned to (`MAX_TAG_LENGTH`, `MAX_N_TAGS`, per-type `tags` rules, tightened executable `metadata`). No API change versus the pinned commit, so #1116's tag denormalization is unaffected.
- **Credit-payment `node_hash` relaxation** (aleph-im/aleph-message#157, released as 1.1.2): credit-based VMs (including GPU instances) no longer have to pin a specific compute node. Only PAYG still requires a `node_hash`.

## ⚠️ Depends on the PyPI publish

The aleph-message 1.2.0 PyPI publish is currently **pending approval** (the publish job is gated on the `pypi` deployment environment), so `pip`/CI will not resolve `aleph-message==1.2.0` until that publish is approved and completes. The 1.1.2 publish is in the same pending state. Once both are published, CI here should go green.