### PR TITLE
ipfs: Route all IPFS storage operations through pinning_client

### DIFF
--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -80,7 +80,9 @@ class IpfsFileStats:
 async def _get_file_stats_from_ipfs(
     cid: ItemHash, ipfs_service: IpfsService, stat_timeout: int
 ) -> IpfsFileStats:
-    ipfs_client = ipfs_service.ipfs_client
+    # Stat is a storage operation: when a separate pinning service is
+    # configured, route it there. Falls back to the main daemon otherwise.
+    ipfs_client = ipfs_service.pinning_client
 
     try:
         try:

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -80,9 +80,10 @@ class IpfsFileStats:
 async def _get_file_stats_from_ipfs(
     cid: ItemHash, ipfs_service: IpfsService, stat_timeout: int
 ) -> IpfsFileStats:
-    # Stat is a storage operation: when a separate pinning service is
-    # configured, route it there. Falls back to the main daemon otherwise.
-    ipfs_client = ipfs_service.pinning_client
+    # Stat is a storage operation: route through the storage client (which
+    # the service maps to the pinning service when configured, otherwise the
+    # main daemon).
+    ipfs_client = ipfs_service.pinning_client()
 
     try:
         try:

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -83,19 +83,32 @@ class IpfsService:
     ):
         # P2P/network role only: swarm, identify, pubsub, peering.
         self.ipfs_client = ipfs_client
-        # Storage role: pinning, content reads, file stats. Falls back to the
-        # main daemon when no separate pinning service is configured, so
-        # single-daemon deployments behave the same as before.
-        self.pinning_client = pinning_client or ipfs_client
+        # Storage role: pinning, content reads, file stats. When the operator
+        # configures `ipfs.pinning.*` to a separate daemon, that daemon backs
+        # this client. Otherwise it falls back to the main daemon, so
+        # single-daemon deployments behave the same as before. Access via the
+        # ``pinning_client()`` method, not the attribute, so the routing
+        # decision lives in one place if it ever needs to grow.
+        self._pinning_client = pinning_client or ipfs_client
+
+    def pinning_client(self) -> aioipfs.AsyncIPFS:
+        """Return the aioipfs client that serves IPFS storage operations.
+
+        Centralizes the choice between the main daemon and the configured
+        pinning service so callers do not bind to the underlying attribute.
+        """
+        return self._pinning_client
 
     @classmethod
     def new(cls, config: Config) -> Self:
         # Create P2P client (for content retrieval, pubsub)
         p2p_client = make_ipfs_p2p_client(config)
 
-        # Create separate pinning client if configured differently
+        # Build a separate pinning client when an external pinning service is
+        # configured; otherwise reuse the P2P client so single-daemon
+        # deployments need no extra config.
         if _should_use_separate_pinning_client(config):
-            LOGGER.info("Using separate IPFS client for pinning operations")
+            LOGGER.info("Using separate IPFS client for storage operations")
             pinning_client = make_ipfs_pinning_client(config)
         else:
             pinning_client = p2p_client
@@ -107,9 +120,9 @@ class IpfsService:
 
     async def close(self):
         await self.ipfs_client.close()
-        # Only close pinning client if it's different from main client
-        if self.pinning_client != self.ipfs_client:
-            await self.pinning_client.close()
+        # Only close the pinning client if it is a separate daemon.
+        if self._pinning_client != self.ipfs_client:
+            await self._pinning_client.close()
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.close()
@@ -144,7 +157,7 @@ class IpfsService:
             try_count += 1
             try:
                 dag_node = await asyncio.wait_for(
-                    self.pinning_client.dag.get(hash), timeout=timeout
+                    self._pinning_client.dag.get(hash), timeout=timeout
                 )
                 result = 0
                 if isinstance(dag_node, str):
@@ -195,7 +208,7 @@ class IpfsService:
                         f"INFO: CID {hash} didn't return a Size field. Executing a block stat operation"
                     )
                     block_stat = await asyncio.wait_for(
-                        self.pinning_client.block.stat(hash), timeout=timeout
+                        self._pinning_client.block.stat(hash), timeout=timeout
                     )
                     result = block_stat["Size"]
             except aioipfs.APIError:
@@ -230,7 +243,7 @@ class IpfsService:
                 result = cast(
                     bytes,
                     await asyncio.wait_for(
-                        self.pinning_client.cat(hash, length=MAX_LEN), timeout=timeout
+                        self._pinning_client.cat(hash, length=MAX_LEN), timeout=timeout
                     ),
                 )
                 if len(result) == MAX_LEN:
@@ -258,7 +271,7 @@ class IpfsService:
     def get_ipfs_content_iterator(self, cid: str) -> AsyncIterable[bytes]:
         params = {aioipfs.helpers.ARG_PARAM: cid}
         return _fetch_ipfs_endpoint_streamed(
-            aioipfs_client=self.pinning_client, endpoint="cat", params=params
+            aioipfs_client=self._pinning_client, endpoint="cat", params=params
         )
 
     def get_ipfs_directory_iterator(self, cid: str) -> AsyncIterable[bytes]:
@@ -269,7 +282,7 @@ class IpfsService:
             "compress": "false",
         }
         return _fetch_ipfs_endpoint_streamed(
-            aioipfs_client=self.pinning_client, endpoint="get", params=params
+            aioipfs_client=self._pinning_client, endpoint="get", params=params
         )
 
     async def get_json(self, hash, timeout=1, tries=1):
@@ -287,11 +300,11 @@ class IpfsService:
         return result
 
     async def add_json(self, value: bytes) -> str:
-        result = await self.pinning_client.add_json(value)
+        result = await self._pinning_client.add_json(value)
         return result["Hash"]
 
     async def add_bytes(self, value: bytes, cid_version: int = 0) -> str:
-        result = await self.pinning_client.add_bytes(value, cid_version=cid_version)
+        result = await self._pinning_client.add_bytes(value, cid_version=cid_version)
         return result["Hash"]
 
     async def _pin_add(self, cid: str, timeout: int = 30):
@@ -306,7 +319,7 @@ class IpfsService:
         last_progress = None
 
         # Use pinning client instead of main client
-        async for status in self.pinning_client.pin.add(cid):
+        async for status in self._pinning_client.pin.add(cid):
             # If the Pins key appears, the file is pinned.
             if "Pins" in status:
                 break
@@ -351,8 +364,8 @@ class IpfsService:
                 error.
             aioipfs.APIError: on a non-2xx response from kubo.
         """
-        driver = self.pinning_client.core.driver
-        url = self.pinning_client.core.url("dag/import")
+        driver = self._pinning_client.core.driver
+        url = self._pinning_client.core.url("dag/import")
         params = {
             "pin-roots": "true" if pin_roots else "false",
             "silent": "false",
@@ -381,7 +394,7 @@ class IpfsService:
             ) as response:
                 body = await response.read()
                 if response.status in aioipfs.apis.HTTP_ERROR_CODES:
-                    self.pinning_client.core.handle_error(response, body)
+                    self._pinning_client.core.handle_error(response, body)
 
         return parse_dag_import_response(body)
 

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -81,8 +81,12 @@ class IpfsService:
         ipfs_client: aioipfs.AsyncIPFS,
         pinning_client: Optional[aioipfs.AsyncIPFS] = None,
     ):
-        self.ipfs_client = ipfs_client  # For P2P operations
-        self.pinning_client = pinning_client or ipfs_client  # For pinning operations
+        # P2P/network role only: swarm, identify, pubsub, peering.
+        self.ipfs_client = ipfs_client
+        # Storage role: pinning, content reads, file stats. Falls back to the
+        # main daemon when no separate pinning service is configured, so
+        # single-daemon deployments behave the same as before.
+        self.pinning_client = pinning_client or ipfs_client
 
     @classmethod
     def new(cls, config: Config) -> Self:
@@ -140,7 +144,7 @@ class IpfsService:
             try_count += 1
             try:
                 dag_node = await asyncio.wait_for(
-                    self.ipfs_client.dag.get(hash), timeout=timeout
+                    self.pinning_client.dag.get(hash), timeout=timeout
                 )
                 result = 0
                 if isinstance(dag_node, str):
@@ -191,7 +195,7 @@ class IpfsService:
                         f"INFO: CID {hash} didn't return a Size field. Executing a block stat operation"
                     )
                     block_stat = await asyncio.wait_for(
-                        self.ipfs_client.block.stat(hash), timeout=timeout
+                        self.pinning_client.block.stat(hash), timeout=timeout
                     )
                     result = block_stat["Size"]
             except aioipfs.APIError:
@@ -226,7 +230,7 @@ class IpfsService:
                 result = cast(
                     bytes,
                     await asyncio.wait_for(
-                        self.ipfs_client.cat(hash, length=MAX_LEN), timeout=timeout
+                        self.pinning_client.cat(hash, length=MAX_LEN), timeout=timeout
                     ),
                 )
                 if len(result) == MAX_LEN:
@@ -254,7 +258,7 @@ class IpfsService:
     def get_ipfs_content_iterator(self, cid: str) -> AsyncIterable[bytes]:
         params = {aioipfs.helpers.ARG_PARAM: cid}
         return _fetch_ipfs_endpoint_streamed(
-            aioipfs_client=self.ipfs_client, endpoint="cat", params=params
+            aioipfs_client=self.pinning_client, endpoint="cat", params=params
         )
 
     def get_ipfs_directory_iterator(self, cid: str) -> AsyncIterable[bytes]:
@@ -265,7 +269,7 @@ class IpfsService:
             "compress": "false",
         }
         return _fetch_ipfs_endpoint_streamed(
-            aioipfs_client=self.ipfs_client, endpoint="get", params=params
+            aioipfs_client=self.pinning_client, endpoint="get", params=params
         )
 
     async def get_json(self, hash, timeout=1, tries=1):

--- a/src/aleph/services/storage/garbage_collector.py
+++ b/src/aleph/services/storage/garbage_collector.py
@@ -36,9 +36,8 @@ class GarbageCollector:
         self.storage_service = storage_service
 
     async def _delete_from_ipfs(self, file_hash: ItemHash):
-        # Unpin is a storage operation: route through the pinning service when
-        # configured (falls back to the main daemon otherwise).
-        ipfs_client = self.storage_service.ipfs_service.pinning_client
+        # Unpin is a storage operation: ask the service for the right client.
+        ipfs_client = self.storage_service.ipfs_service.pinning_client()
         try:
             await ipfs_client.pin.rm(file_hash)
         except NotPinnedError:

--- a/src/aleph/services/storage/garbage_collector.py
+++ b/src/aleph/services/storage/garbage_collector.py
@@ -36,7 +36,9 @@ class GarbageCollector:
         self.storage_service = storage_service
 
     async def _delete_from_ipfs(self, file_hash: ItemHash):
-        ipfs_client = self.storage_service.ipfs_service.ipfs_client
+        # Unpin is a storage operation: route through the pinning service when
+        # configured (falls back to the main daemon otherwise).
+        ipfs_client = self.storage_service.ipfs_service.pinning_client
         try:
             await ipfs_client.pin.rm(file_hash)
         except NotPinnedError:

--- a/src/aleph/web/controllers/ipfs.py
+++ b/src/aleph/web/controllers/ipfs.py
@@ -193,7 +193,7 @@ async def ipfs_add_file(request: web.Request):
         try:
             try:
                 stats = await asyncio.wait_for(
-                    ipfs_service.pinning_client.files.stat(f"/ipfs/{cid}"),
+                    ipfs_service.pinning_client().files.stat(f"/ipfs/{cid}"),
                     config.ipfs.stat_timeout.value,
                 )
             except TimeoutError:
@@ -448,7 +448,7 @@ async def ipfs_add_car(request: web.Request):
         try:
             try:
                 stats = await asyncio.wait_for(
-                    ipfs_service.pinning_client.files.stat(f"/ipfs/{cid}"),
+                    ipfs_service.pinning_client().files.stat(f"/ipfs/{cid}"),
                     config.ipfs.stat_timeout.value,
                 )
             except TimeoutError:

--- a/tests/api/test_ipfs.py
+++ b/tests/api/test_ipfs.py
@@ -80,7 +80,7 @@ IPFS_MESSAGE_DICT_CREDIT: dict[str, Any] = {
 async def api_client(ccn_test_aiohttp_app, mocker, aiohttp_client):
     ipfs_service = mocker.AsyncMock()
     ipfs_service.add_bytes = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
-    ipfs_service.pinning_client.files.stat = mocker.AsyncMock(
+    ipfs_service.pinning_client.return_value.files.stat = mocker.AsyncMock(
         return_value={
             "Hash": EXPECTED_FILE_CID,
             "Size": MOCK_FILE_SIZE,
@@ -446,7 +446,7 @@ async def test_auth_upload_stat_timeout_applies_grace(
     )
     ipfs_service = _get_ipfs_service_mock(api_client)
     # Make stat raise TimeoutError as if asyncio.wait_for timed out.
-    ipfs_service.pinning_client.files.stat = mocker.AsyncMock(
+    ipfs_service.pinning_client.return_value.files.stat = mocker.AsyncMock(
         side_effect=TimeoutError()
     )
 
@@ -630,7 +630,7 @@ async def api_client_with_dag_import(api_client):
     update files.stat to return directory-shaped stats."""
     ipfs_service = _get_ipfs_service_mock(api_client)
     ipfs_service.dag_import = MockAsyncMock(return_value=[DIR_ROOT_CID])
-    ipfs_service.pinning_client.files.stat = MockAsyncMock(
+    ipfs_service.pinning_client.return_value.files.stat = MockAsyncMock(
         return_value={
             "Hash": DIR_ROOT_CID,
             "Size": 0,
@@ -1074,7 +1074,7 @@ async def test_add_car_stat_timeout(
         session.commit()
 
     ipfs_service = _get_ipfs_service_mock(api_client_with_dag_import)
-    ipfs_service.pinning_client.files.stat = MockAsyncMock(
+    ipfs_service.pinning_client.return_value.files.stat = MockAsyncMock(
         side_effect=TimeoutError(),
     )
 

--- a/tests/api/test_ipfs.py
+++ b/tests/api/test_ipfs.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from io import BytesIO
 from typing import Any
 from unittest.mock import AsyncMock as MockAsyncMock
+from unittest.mock import Mock
 
 import aiohttp
 import pytest
@@ -80,6 +81,7 @@ IPFS_MESSAGE_DICT_CREDIT: dict[str, Any] = {
 async def api_client(ccn_test_aiohttp_app, mocker, aiohttp_client):
     ipfs_service = mocker.AsyncMock()
     ipfs_service.add_bytes = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
+    ipfs_service.pinning_client = mocker.Mock()
     ipfs_service.pinning_client.return_value.files.stat = mocker.AsyncMock(
         return_value={
             "Hash": EXPECTED_FILE_CID,
@@ -446,6 +448,7 @@ async def test_auth_upload_stat_timeout_applies_grace(
     )
     ipfs_service = _get_ipfs_service_mock(api_client)
     # Make stat raise TimeoutError as if asyncio.wait_for timed out.
+    ipfs_service.pinning_client = mocker.Mock()
     ipfs_service.pinning_client.return_value.files.stat = mocker.AsyncMock(
         side_effect=TimeoutError()
     )
@@ -630,6 +633,7 @@ async def api_client_with_dag_import(api_client):
     update files.stat to return directory-shaped stats."""
     ipfs_service = _get_ipfs_service_mock(api_client)
     ipfs_service.dag_import = MockAsyncMock(return_value=[DIR_ROOT_CID])
+    ipfs_service.pinning_client = Mock()
     ipfs_service.pinning_client.return_value.files.stat = MockAsyncMock(
         return_value={
             "Hash": DIR_ROOT_CID,
@@ -1074,6 +1078,7 @@ async def test_add_car_stat_timeout(
         session.commit()
 
     ipfs_service = _get_ipfs_service_mock(api_client_with_dag_import)
+    ipfs_service.pinning_client = Mock()
     ipfs_service.pinning_client.return_value.files.stat = MockAsyncMock(
         side_effect=TimeoutError(),
     )

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -84,6 +84,7 @@ async def api_client(ccn_test_aiohttp_app, mocker, aiohttp_client):
     ipfs_service.get_ipfs_content_iterator = mocker.Mock(
         return_value=_mock_ipfs_content_iterator()
     )
+    ipfs_service.pinning_client = mocker.Mock()
     ipfs_service.pinning_client.return_value.files.stat = mocker.AsyncMock(
         return_value={
             "Hash": EXPECTED_FILE_CID,

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -84,16 +84,7 @@ async def api_client(ccn_test_aiohttp_app, mocker, aiohttp_client):
     ipfs_service.get_ipfs_content_iterator = mocker.Mock(
         return_value=_mock_ipfs_content_iterator()
     )
-    ipfs_service.ipfs_client.files.stat = mocker.AsyncMock(
-        return_value={
-            "Hash": EXPECTED_FILE_CID,
-            "Size": 34,
-            "CumulativeSize": 42,
-            "Blocks": 0,
-            "Type": "file",
-        }
-    )
-    ipfs_service.pinning_client.files.stat = mocker.AsyncMock(
+    ipfs_service.pinning_client.return_value.files.stat = mocker.AsyncMock(
         return_value={
             "Hash": EXPECTED_FILE_CID,
             "Size": 34,

--- a/tests/message_processing/test_process_stores.py
+++ b/tests/message_processing/test_process_stores.py
@@ -730,7 +730,7 @@ async def test_pre_check_balance_with_existing_costs(
     ipfs_service = mocker.AsyncMock()
     ipfs_service.get_ipfs_size = AsyncMock(return_value=small_file_size)
     # _get_file_stats_from_ipfs routes through pinning_client now.
-    ipfs_service.pinning_client.files.stat = AsyncMock(
+    ipfs_service.pinning_client.return_value.files.stat = AsyncMock(
         return_value={"Type": "file", "Size": len(small_file_content)}
     )
 

--- a/tests/message_processing/test_process_stores.py
+++ b/tests/message_processing/test_process_stores.py
@@ -729,7 +729,8 @@ async def test_pre_check_balance_with_existing_costs(
 
     ipfs_service = mocker.AsyncMock()
     ipfs_service.get_ipfs_size = AsyncMock(return_value=small_file_size)
-    ipfs_service.ipfs_client.files.stat = AsyncMock(
+    # _get_file_stats_from_ipfs routes through pinning_client now.
+    ipfs_service.pinning_client.files.stat = AsyncMock(
         return_value={"Type": "file", "Size": len(small_file_content)}
     )
 

--- a/tests/message_processing/test_process_stores.py
+++ b/tests/message_processing/test_process_stores.py
@@ -730,6 +730,7 @@ async def test_pre_check_balance_with_existing_costs(
     ipfs_service = mocker.AsyncMock()
     ipfs_service.get_ipfs_size = AsyncMock(return_value=small_file_size)
     # _get_file_stats_from_ipfs routes through pinning_client now.
+    ipfs_service.pinning_client = mocker.Mock()
     ipfs_service.pinning_client.return_value.files.stat = AsyncMock(
         return_value={"Type": "file", "Size": len(small_file_content)}
     )


### PR DESCRIPTION
  When config.ipfs.pinning.* is configured, the separate pinning service
  now serves every storage-role call: pin/unpin, add_bytes/add_json,
  cat, dag.get, block.stat, files.stat, and the streamed cat/get
  iterators. The main daemon (ipfs_client) is kept for P2P operations
  only: swarm.connect, id, pubsub sub/pub.

  Single-daemon deployments are unaffected — when no separate pinning
  service is configured, IpfsService constructor falls back to
  pinning_client = ipfs_client, so storage calls land on the same client
  as before.

  - service.py: get_ipfs_size, get_ipfs_content, get_ipfs_content_iterator, get_ipfs_directory_iterator now use pinning_client.
  - garbage_collector.py: pin.rm uses pinning_client.
  - store.py: _get_file_stats_from_ipfs uses pinning_client.
  - test_process_stores.py: stat mock updated to pinning_client.files.stat (test_storage.py already mocked both clients).