### PR TITLE
refactor(ipfs): expose storage_client property instead of pinning_client() getter

### DIFF
--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -83,7 +83,7 @@ async def _get_file_stats_from_ipfs(
     # Stat is a storage operation: route through the storage client (which
     # the service maps to the pinning service when configured, otherwise the
     # main daemon).
-    ipfs_client = ipfs_service.pinning_client()
+    ipfs_client = ipfs_service.storage_client
 
     try:
         try:

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -83,35 +83,37 @@ class IpfsService:
     ):
         # P2P/network role only: swarm, identify, pubsub, peering.
         self.ipfs_client = ipfs_client
-        # Storage role: pinning, content reads, file stats. When the operator
-        # configures `ipfs.pinning.*` to a separate daemon, that daemon backs
-        # this client. Otherwise it falls back to the main daemon, so
-        # single-daemon deployments behave the same as before. Access via the
-        # ``pinning_client()`` method, not the attribute, so the routing
-        # decision lives in one place if it ever needs to grow.
-        self._pinning_client = pinning_client or ipfs_client
+        # The separate storage daemon configured via `ipfs.pinning.*`, or None
+        # when none is configured. Do NOT use this directly for storage
+        # operations: it is None in single-daemon deployments. Route every
+        # storage-role call through `storage_client` instead; this attribute
+        # only holds the raw config state and is closed in `close`.
+        self.pinning_client = pinning_client
 
-    def pinning_client(self) -> aioipfs.AsyncIPFS:
-        """Return the aioipfs client that serves IPFS storage operations.
+    @property
+    def storage_client(self) -> aioipfs.AsyncIPFS:
+        """Client for storage-role operations: pin/unpin, content reads, file
+        stats, dag/block ops.
 
-        Centralizes the choice between the main daemon and the configured
-        pinning service so callers do not bind to the underlying attribute.
+        Returns the separate pinning daemon when one is configured
+        (`ipfs.pinning.*`), otherwise falls back to the main daemon so
+        single-daemon deployments need no extra config.
         """
-        return self._pinning_client
+        return self.pinning_client or self.ipfs_client
 
     @classmethod
     def new(cls, config: Config) -> Self:
         # Create P2P client (for content retrieval, pubsub)
         p2p_client = make_ipfs_p2p_client(config)
 
-        # Build a separate pinning client when an external pinning service is
-        # configured; otherwise reuse the P2P client so single-daemon
-        # deployments need no extra config.
+        # Build a separate pinning client only when an external pinning service
+        # is configured; otherwise leave it None so `storage_client` falls back
+        # to the P2P client and single-daemon deployments need no extra config.
         if _should_use_separate_pinning_client(config):
             LOGGER.info("Using separate IPFS client for storage operations")
             pinning_client = make_ipfs_pinning_client(config)
         else:
-            pinning_client = p2p_client
+            pinning_client = None
 
         return cls(ipfs_client=p2p_client, pinning_client=pinning_client)
 
@@ -120,9 +122,9 @@ class IpfsService:
 
     async def close(self):
         await self.ipfs_client.close()
-        # Only close the pinning client if it is a separate daemon.
-        if self._pinning_client != self.ipfs_client:
-            await self._pinning_client.close()
+        # Only close the pinning client if a separate daemon was configured.
+        if self.pinning_client is not None:
+            await self.pinning_client.close()
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.close()
@@ -157,7 +159,7 @@ class IpfsService:
             try_count += 1
             try:
                 dag_node = await asyncio.wait_for(
-                    self._pinning_client.dag.get(hash), timeout=timeout
+                    self.storage_client.dag.get(hash), timeout=timeout
                 )
                 result = 0
                 if isinstance(dag_node, str):
@@ -208,7 +210,7 @@ class IpfsService:
                         f"INFO: CID {hash} didn't return a Size field. Executing a block stat operation"
                     )
                     block_stat = await asyncio.wait_for(
-                        self._pinning_client.block.stat(hash), timeout=timeout
+                        self.storage_client.block.stat(hash), timeout=timeout
                     )
                     result = block_stat["Size"]
             except aioipfs.APIError:
@@ -243,7 +245,7 @@ class IpfsService:
                 result = cast(
                     bytes,
                     await asyncio.wait_for(
-                        self._pinning_client.cat(hash, length=MAX_LEN), timeout=timeout
+                        self.storage_client.cat(hash, length=MAX_LEN), timeout=timeout
                     ),
                 )
                 if len(result) == MAX_LEN:
@@ -271,7 +273,7 @@ class IpfsService:
     def get_ipfs_content_iterator(self, cid: str) -> AsyncIterable[bytes]:
         params = {aioipfs.helpers.ARG_PARAM: cid}
         return _fetch_ipfs_endpoint_streamed(
-            aioipfs_client=self._pinning_client, endpoint="cat", params=params
+            aioipfs_client=self.storage_client, endpoint="cat", params=params
         )
 
     def get_ipfs_directory_iterator(self, cid: str) -> AsyncIterable[bytes]:
@@ -282,7 +284,7 @@ class IpfsService:
             "compress": "false",
         }
         return _fetch_ipfs_endpoint_streamed(
-            aioipfs_client=self._pinning_client, endpoint="get", params=params
+            aioipfs_client=self.storage_client, endpoint="get", params=params
         )
 
     async def get_json(self, hash, timeout=1, tries=1):
@@ -300,11 +302,11 @@ class IpfsService:
         return result
 
     async def add_json(self, value: bytes) -> str:
-        result = await self._pinning_client.add_json(value)
+        result = await self.storage_client.add_json(value)
         return result["Hash"]
 
     async def add_bytes(self, value: bytes, cid_version: int = 0) -> str:
-        result = await self._pinning_client.add_bytes(value, cid_version=cid_version)
+        result = await self.storage_client.add_bytes(value, cid_version=cid_version)
         return result["Hash"]
 
     async def _pin_add(self, cid: str, timeout: int = 30):
@@ -318,8 +320,8 @@ class IpfsService:
         tick_timeout = timeout * 2
         last_progress = None
 
-        # Use pinning client instead of main client
-        async for status in self._pinning_client.pin.add(cid):
+        # Pinning is a storage operation: route through the storage client.
+        async for status in self.storage_client.pin.add(cid):
             # If the Pins key appears, the file is pinned.
             if "Pins" in status:
                 break
@@ -364,8 +366,8 @@ class IpfsService:
                 error.
             aioipfs.APIError: on a non-2xx response from kubo.
         """
-        driver = self._pinning_client.core.driver
-        url = self._pinning_client.core.url("dag/import")
+        driver = self.storage_client.core.driver
+        url = self.storage_client.core.url("dag/import")
         params = {
             "pin-roots": "true" if pin_roots else "false",
             "silent": "false",
@@ -394,7 +396,7 @@ class IpfsService:
             ) as response:
                 body = await response.read()
                 if response.status in aioipfs.apis.HTTP_ERROR_CODES:
-                    self._pinning_client.core.handle_error(response, body)
+                    self.storage_client.core.handle_error(response, body)
 
         return parse_dag_import_response(body)
 

--- a/src/aleph/services/storage/garbage_collector.py
+++ b/src/aleph/services/storage/garbage_collector.py
@@ -37,7 +37,7 @@ class GarbageCollector:
 
     async def _delete_from_ipfs(self, file_hash: ItemHash):
         # Unpin is a storage operation: ask the service for the right client.
-        ipfs_client = self.storage_service.ipfs_service.pinning_client()
+        ipfs_client = self.storage_service.ipfs_service.storage_client
         try:
             await ipfs_client.pin.rm(file_hash)
         except NotPinnedError:

--- a/src/aleph/web/controllers/ipfs.py
+++ b/src/aleph/web/controllers/ipfs.py
@@ -193,7 +193,7 @@ async def ipfs_add_file(request: web.Request):
         try:
             try:
                 stats = await asyncio.wait_for(
-                    ipfs_service.pinning_client().files.stat(f"/ipfs/{cid}"),
+                    ipfs_service.storage_client.files.stat(f"/ipfs/{cid}"),
                     config.ipfs.stat_timeout.value,
                 )
             except TimeoutError:
@@ -448,7 +448,7 @@ async def ipfs_add_car(request: web.Request):
         try:
             try:
                 stats = await asyncio.wait_for(
-                    ipfs_service.pinning_client().files.stat(f"/ipfs/{cid}"),
+                    ipfs_service.storage_client.files.stat(f"/ipfs/{cid}"),
                     config.ipfs.stat_timeout.value,
                 )
             except TimeoutError:

--- a/tests/api/test_ipfs.py
+++ b/tests/api/test_ipfs.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from io import BytesIO
 from typing import Any
 from unittest.mock import AsyncMock as MockAsyncMock
-from unittest.mock import Mock
 
 import aiohttp
 import pytest
@@ -81,8 +80,7 @@ IPFS_MESSAGE_DICT_CREDIT: dict[str, Any] = {
 async def api_client(ccn_test_aiohttp_app, mocker, aiohttp_client):
     ipfs_service = mocker.AsyncMock()
     ipfs_service.add_bytes = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
-    ipfs_service.pinning_client = mocker.Mock()
-    ipfs_service.pinning_client.return_value.files.stat = mocker.AsyncMock(
+    ipfs_service.storage_client.files.stat = mocker.AsyncMock(
         return_value={
             "Hash": EXPECTED_FILE_CID,
             "Size": MOCK_FILE_SIZE,
@@ -448,8 +446,7 @@ async def test_auth_upload_stat_timeout_applies_grace(
     )
     ipfs_service = _get_ipfs_service_mock(api_client)
     # Make stat raise TimeoutError as if asyncio.wait_for timed out.
-    ipfs_service.pinning_client = mocker.Mock()
-    ipfs_service.pinning_client.return_value.files.stat = mocker.AsyncMock(
+    ipfs_service.storage_client.files.stat = mocker.AsyncMock(
         side_effect=TimeoutError()
     )
 
@@ -633,8 +630,7 @@ async def api_client_with_dag_import(api_client):
     update files.stat to return directory-shaped stats."""
     ipfs_service = _get_ipfs_service_mock(api_client)
     ipfs_service.dag_import = MockAsyncMock(return_value=[DIR_ROOT_CID])
-    ipfs_service.pinning_client = Mock()
-    ipfs_service.pinning_client.return_value.files.stat = MockAsyncMock(
+    ipfs_service.storage_client.files.stat = MockAsyncMock(
         return_value={
             "Hash": DIR_ROOT_CID,
             "Size": 0,
@@ -1078,8 +1074,7 @@ async def test_add_car_stat_timeout(
         session.commit()
 
     ipfs_service = _get_ipfs_service_mock(api_client_with_dag_import)
-    ipfs_service.pinning_client = Mock()
-    ipfs_service.pinning_client.return_value.files.stat = MockAsyncMock(
+    ipfs_service.storage_client.files.stat = MockAsyncMock(
         side_effect=TimeoutError(),
     )
 

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -84,8 +84,7 @@ async def api_client(ccn_test_aiohttp_app, mocker, aiohttp_client):
     ipfs_service.get_ipfs_content_iterator = mocker.Mock(
         return_value=_mock_ipfs_content_iterator()
     )
-    ipfs_service.pinning_client = mocker.Mock()
-    ipfs_service.pinning_client.return_value.files.stat = mocker.AsyncMock(
+    ipfs_service.storage_client.files.stat = mocker.AsyncMock(
         return_value={
             "Hash": EXPECTED_FILE_CID,
             "Size": 34,

--- a/tests/message_processing/test_process_stores.py
+++ b/tests/message_processing/test_process_stores.py
@@ -729,9 +729,8 @@ async def test_pre_check_balance_with_existing_costs(
 
     ipfs_service = mocker.AsyncMock()
     ipfs_service.get_ipfs_size = AsyncMock(return_value=small_file_size)
-    # _get_file_stats_from_ipfs routes through pinning_client now.
-    ipfs_service.pinning_client = mocker.Mock()
-    ipfs_service.pinning_client.return_value.files.stat = AsyncMock(
+    # _get_file_stats_from_ipfs routes through storage_client now.
+    ipfs_service.storage_client.files.stat = AsyncMock(
         return_value={"Type": "file", "Size": len(small_file_content)}
     )
 


### PR DESCRIPTION
Follow-up cleanup to #1179. The logic that PR shipped is correct (route storage-role IPFS ops to the configured pinning daemon, keep the main daemon for P2P), but the implementation was over-engineered:

- `pinning_client()` was a no-op getter (`return self._pinning_client`).
- Every in-class method bypassed it and used `self._pinning_client` directly, so the indirection it claimed to provide ("routing in one place") was never actually used.
- It turned a public attribute into a method, which broke the public surface for no gain: it forced edits in `web/controllers/ipfs.py` and made the test mocks uglier (`pinning_client.return_value.files.stat`).
- The fallback was decided in two places (`new()` and `__init__`), and `close()` used a `!=` equality check where an identity/None check was meant.

## This PR

Replace the getter with a real computed `@property`, and keep `pinning_client` as a plain attribute holding the raw config state (the separate daemon, or `None` when none is configured):

- **`storage_client` property** returns `pinning_client or ipfs_client`. The fallback lives in exactly one place, and every storage-role call (pin/unpin, `cat`, `dag.get`, `block.stat`, `files.stat`, `add_*`, the streamed iterators) goes through it, consistently, inside and outside the class.
- **`new()`** passes `None` in the single-daemon branch instead of duplicating the fallback to `p2p_client`.
- **`close()`** uses `if self.pinning_client is not None`, replacing the `!=`-identity check. `None` unambiguously means "no separate daemon, nothing extra to close".
- **Call sites** in `store.py`, `garbage_collector.py` and `web/controllers/ipfs.py` use `ipfs_service.storage_client` (attribute access, no call).
- **Tests** revert from `pinning_client.return_value.files.stat` back to plain `storage_client.files.stat`; the now-unused `Mock` import is dropped.

The `ipfs.pinning.*` config namespace is unchanged, so this is not an operator-facing change. `pinning_client` keeps that name to stay aligned with the config vocabulary; `storage_client` names the runtime role.

## Testing

- `black` / `isort` / `ruff`: clean.
- 116 tests pass across `test_ipfs_service`, `test_ipfs_dag_import`, `test_get_content`, `test_store_message`, `test_garbage_collector`, `api/test_ipfs`, `api/test_storage`, `message_processing/test_process_stores`.