### PR TITLE
fix(aggregates): write cache entries to the per-owner namespace

### DIFF
--- a/src/aleph/db/accessors/aggregates.py
+++ b/src/aleph/db/accessors/aggregates.py
@@ -101,7 +101,7 @@ def get_aggregates_by_owner(session, owner, with_info, keys=None):
             .order_by(AggregateDb.key)
         )
     result = query.all()
-    cache.set(cache_key, result, namespace="aggregates_by_owner:{owner}")
+    cache.set(cache_key, result, namespace=f"aggregates_by_owner:{owner}")
     return result
 
 


### PR DESCRIPTION
## Problem

In `get_aggregates_by_owner` (`src/aleph/db/accessors/aggregates.py`), the cache **write** used a plain string literal as the namespace:

```python
cache.set(cache_key, result, namespace="aggregates_by_owner:{owner}")
```

while the cache **read** (and invalidation in `refresh_aggregate`) use the interpolated f-string namespace `f"aggregates_by_owner:{owner}"`.

Reads and writes therefore never matched: every call was a cache miss that ran the full DB query, and entries accumulated in an orphan literal namespace that nothing reads or invalidates. The aggregates-by-owner cache was effectively dead.

Since reads always missed, there was no stale-data risk — this is purely a performance fix.

## Fix

Add the missing `f` prefix so writes land in the same per-owner namespace as reads and invalidation.

## Tests

`hatch run linting:all` passes; `tests/api/test_aggregates.py` and `tests/db/test_aggregates.py` pass locally (18 passed, 1 skipped).