### PR TITLE
feature: IPNS support (registration, tracking, republishing, gateway)

### DIFF
--- a/deployment/migrations/versions/0060_c7d2e9f4a1b8_add_ipns_records.py
+++ b/deployment/migrations/versions/0060_c7d2e9f4a1b8_add_ipns_records.py
@@ -1,0 +1,41 @@
+"""add ipns_records
+
+Revision ID: c7d2e9f4a1b8
+Revises: b9c4f1e6a2d7
+Create Date: 2026-06-10
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c7d2e9f4a1b8"
+down_revision = "b9c4f1e6a2d7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ipns_records",
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("owner", sa.String(), nullable=False),
+        sa.Column("item_hash", sa.String(), nullable=False),
+        sa.Column("record", sa.LargeBinary(), nullable=True),
+        sa.Column("record_sequence", sa.BigInteger(), nullable=True),
+        sa.Column("record_validity", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("max_size_mib", sa.Integer(), nullable=False),
+        sa.Column("resolved_cid", sa.String(), nullable=True),
+        sa.Column("last_resolved", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("last_republished", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("created", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["resolved_cid"], ["files.hash"]),
+        sa.PrimaryKeyConstraint("name", "owner"),
+    )
+    op.create_index("ix_ipns_records_owner", "ipns_records", ["owner"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ipns_records_owner", table_name="ipns_records")
+    op.drop_table("ipns_records")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "aiohttp-swagger3>=0.10.0",
   "aioipfs~=0.7.1",
   "alembic==1.18.4",
-  "aleph-message==1.2.0",
+  "aleph-message @ git+https://github.com/aleph-im/aleph-message.git@ipns-support",
   "aleph-nuls2==0.1.1",
   "aleph-p2p-client @ git+https://github.com/aleph-im/p2p-service-client-python@1e992aaacdb0071a34ffb130cbbba9123509e08b",
   "asyncpg==0.31.0",

--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -39,6 +39,7 @@ from aleph.repair import repair_node
 from aleph.services import p2p
 from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
+from aleph.services.ipns.republisher import IpnsRepublisher, ipns_republisher_task
 from aleph.services.keys import generate_keypair, save_keys
 from aleph.services.p2p.http import close_sessions
 from aleph.services.storage.fileystem_engine import FileSystemStorageEngine
@@ -161,6 +162,14 @@ async def main(args: List[str]) -> None:
         garbage_collector = GarbageCollector(
             session_factory=session_factory, storage_service=storage_service
         )
+        if config.ipfs.enabled.value and config.ipfs.ipns.enabled.value:
+            ipns_republisher = IpnsRepublisher(
+                session_factory=session_factory,
+                ipfs_service=ipfs_service,
+                grace_period_hours=config.storage.grace_period.value,
+                stat_timeout=config.ipfs.stat_timeout.value,
+                resolve_timeout=config.ipfs.ipns.resolve_timeout.value,
+            )
         cron_job = CronJob(
             session_factory=session_factory,
             jobs={
@@ -241,6 +250,13 @@ async def main(args: List[str]) -> None:
             garbage_collector_task(config=config, garbage_collector=garbage_collector)
         )
         LOGGER.debug("Initialized garbage collector task")
+
+        if config.ipfs.enabled.value and config.ipfs.ipns.enabled.value:
+            LOGGER.debug("Initializing IPNS republisher task")
+            tasks.append(
+                ipns_republisher_task(config=config, republisher=ipns_republisher)
+            )
+            LOGGER.debug("Initialized IPNS republisher task")
 
         LOGGER.debug("Initializing cron job task")
         tasks.append(cron_job_task(config=config, cron_job=cron_job))

--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -266,6 +266,18 @@ def get_defaults():
                 # Timeout for pinning operations (seconds)
                 "timeout": 60,
             },
+            # IPNS support configuration
+            "ipns": {
+                # Whether to process IPNS store messages and run the
+                # republish/re-resolve task.
+                "enabled": True,
+                # Interval between republish/re-resolve cycles, in hours.
+                # Kubo IPNS records expire from the DHT within ~24-48h, so
+                # the period must stay well below that.
+                "republish_period_hours": 4,
+                # Timeout for resolving an IPNS record from the DHT (seconds).
+                "resolve_timeout": 60,
+            },
             # Timeout for file stat requests (seconds)
             "stat_timeout": 30,
             # Randomized delay (in seconds, drawn uniformly from [0, value]) before

--- a/src/aleph/db/accessors/files.py
+++ b/src/aleph/db/accessors/files.py
@@ -16,6 +16,7 @@ from ..models.files import (
     FilePinType,
     FileTagDb,
     GracePeriodFilePinDb,
+    IpnsFilePinDb,
     MessageFilePinDb,
     StoredFileDb,
     TxFilePinDb,
@@ -353,6 +354,45 @@ def upsert_file_tag(
         where=FileTagDb.last_updated < last_updated,
     )
     session.execute(upsert_stmt)
+
+
+def insert_ipns_file_pin(
+    session: DbSession,
+    file_hash: str,
+    owner: str,
+    item_hash: str,
+    name: str,
+    created: dt.datetime,
+) -> None:
+    insert_stmt = insert(FilePinDb).values(
+        file_hash=file_hash,
+        owner=owner,
+        item_hash=item_hash,
+        ref=name,
+        created=created,
+        type=FilePinType.IPNS.value,
+    )
+    session.execute(insert_stmt)
+
+
+def get_ipns_file_pin(
+    session: DbSession, name: str, owner: str
+) -> Optional[IpnsFilePinDb]:
+    select_stmt = select(IpnsFilePinDb).where(
+        (IpnsFilePinDb.ref == name)
+        & (IpnsFilePinDb.owner == owner)
+        & (IpnsFilePinDb.type == FilePinType.IPNS.value)
+    )
+    return session.execute(select_stmt).scalar_one_or_none()
+
+
+def update_ipns_file_pin(
+    session: DbSession, name: str, owner: str, file_hash: str, item_hash: str
+) -> None:
+    pin = get_ipns_file_pin(session=session, name=name, owner=owner)
+    if pin is not None:
+        pin.file_hash = file_hash
+        pin.item_hash = item_hash
 
 
 def refresh_file_tag(session: DbSession, tag: FileTag) -> None:

--- a/src/aleph/db/accessors/files.py
+++ b/src/aleph/db/accessors/files.py
@@ -364,13 +364,13 @@ def insert_ipns_file_pin(
     name: str,
     created: dt.datetime,
 ) -> None:
-    insert_stmt = insert(FilePinDb).values(
+    insert_stmt = insert(IpnsFilePinDb).values(
         file_hash=file_hash,
         owner=owner,
         item_hash=item_hash,
         ref=name,
         created=created,
-        type=FilePinType.IPNS.value,
+        type=FilePinType.IPNS,
     )
     session.execute(insert_stmt)
 
@@ -379,9 +379,7 @@ def get_ipns_file_pin(
     session: DbSession, name: str, owner: str
 ) -> Optional[IpnsFilePinDb]:
     select_stmt = select(IpnsFilePinDb).where(
-        (IpnsFilePinDb.ref == name)
-        & (IpnsFilePinDb.owner == owner)
-        & (IpnsFilePinDb.type == FilePinType.IPNS.value)
+        (IpnsFilePinDb.ref == name) & (IpnsFilePinDb.owner == owner)
     )
     return session.execute(select_stmt).scalar_one_or_none()
 

--- a/src/aleph/db/accessors/files.py
+++ b/src/aleph/db/accessors/files.py
@@ -393,6 +393,13 @@ def update_ipns_file_pin(
         pin.item_hash = item_hash
 
 
+def delete_ipns_file_pin(session: DbSession, name: str, owner: str) -> None:
+    delete_stmt = delete(IpnsFilePinDb).where(
+        (IpnsFilePinDb.ref == name) & (IpnsFilePinDb.owner == owner)
+    )
+    session.execute(delete_stmt)
+
+
 def refresh_file_tag(session: DbSession, tag: FileTag) -> None:
     coalesced_ref = func.coalesce(MessageFilePinDb.ref, MessageFilePinDb.item_hash)
     select_latest_file_pin_stmt = (

--- a/src/aleph/db/accessors/ipns.py
+++ b/src/aleph/db/accessors/ipns.py
@@ -1,0 +1,82 @@
+import datetime as dt
+from typing import Iterable, Optional
+
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert
+
+from aleph.db.models.ipns import IpnsRecordDb
+from aleph.types.db_session import DbSession
+from aleph.types.ipns import IpnsStatus
+
+
+def upsert_ipns_record(
+    session: DbSession,
+    name: str,
+    owner: str,
+    item_hash: str,
+    record: Optional[bytes],
+    record_sequence: Optional[int],
+    record_validity: Optional[dt.datetime],
+    max_size_mib: int,
+    resolved_cid: Optional[str],
+    last_resolved: Optional[dt.datetime],
+    status: IpnsStatus,
+    created: dt.datetime,
+) -> None:
+    insert_stmt = insert(IpnsRecordDb).values(
+        name=name,
+        owner=owner,
+        item_hash=item_hash,
+        record=record,
+        record_sequence=record_sequence,
+        record_validity=record_validity,
+        max_size_mib=max_size_mib,
+        resolved_cid=resolved_cid,
+        last_resolved=last_resolved,
+        status=status.value,
+        created=created,
+    )
+    upsert_stmt = insert_stmt.on_conflict_do_update(
+        index_elements=["name", "owner"],
+        set_={
+            "item_hash": item_hash,
+            "record": record,
+            "record_sequence": record_sequence,
+            "record_validity": record_validity,
+            "max_size_mib": max_size_mib,
+            "resolved_cid": resolved_cid,
+            "last_resolved": last_resolved,
+            "status": status.value,
+        },
+    )
+    session.execute(upsert_stmt)
+
+
+def get_ipns_record(
+    session: DbSession, name: str, owner: str
+) -> Optional[IpnsRecordDb]:
+    select_stmt = select(IpnsRecordDb).where(
+        (IpnsRecordDb.name == name) & (IpnsRecordDb.owner == owner)
+    )
+    return session.execute(select_stmt).scalar_one_or_none()
+
+
+def get_ipns_records_by_name(session: DbSession, name: str) -> Iterable[IpnsRecordDb]:
+    select_stmt = select(IpnsRecordDb).where(IpnsRecordDb.name == name)
+    return session.execute(select_stmt).scalars().all()
+
+
+def get_ipns_records_by_owner(session: DbSession, owner: str) -> Iterable[IpnsRecordDb]:
+    select_stmt = select(IpnsRecordDb).where(IpnsRecordDb.owner == owner)
+    return session.execute(select_stmt).scalars().all()
+
+
+def get_all_ipns_records(session: DbSession) -> Iterable[IpnsRecordDb]:
+    return session.execute(select(IpnsRecordDb)).scalars().all()
+
+
+def delete_ipns_record(session: DbSession, name: str, owner: str) -> None:
+    delete_stmt = delete(IpnsRecordDb).where(
+        (IpnsRecordDb.name == name) & (IpnsRecordDb.owner == owner)
+    )
+    session.execute(delete_stmt)

--- a/src/aleph/db/models/__init__.py
+++ b/src/aleph/db/models/__init__.py
@@ -3,6 +3,7 @@ from .balances import *  # noqa
 from .base import Base  # noqa
 from .chains import *  # noqa
 from .files import *  # noqa
+from .ipns import *  # noqa
 from .message_counts import *  # noqa
 from .messages import *  # noqa
 from .metrics import *  # noqa

--- a/src/aleph/db/models/files.py
+++ b/src/aleph/db/models/files.py
@@ -27,6 +27,8 @@ class FilePinType(str, Enum):
     TX = "tx"
     # A file with a grace period (=no one paying for the file, but we keep it around for a while).
     GRACE_PERIOD = "grace_period"
+    # A file pinned because an IPNS registration currently points at it.
+    IPNS = "ipns"
 
 
 class StoredFileDb(Base):
@@ -126,6 +128,15 @@ class GracePeriodFilePinDb(FilePinDb):
 
     __mapper_args__ = {
         "polymorphic_identity": FilePinType.GRACE_PERIOD.value,
+    }
+
+
+class IpnsFilePinDb(FilePinDb):
+    # `ref` stores the IPNS name so the single pin of a registration can be
+    # looked up and re-pointed when the name resolves to a new CID.
+
+    __mapper_args__ = {
+        "polymorphic_identity": FilePinType.IPNS.value,
     }
 
 

--- a/src/aleph/db/models/ipns.py
+++ b/src/aleph/db/models/ipns.py
@@ -1,0 +1,65 @@
+import datetime as dt
+from typing import Optional
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    ForeignKey,
+    Index,
+    Integer,
+    LargeBinary,
+    String,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy_utils import ChoiceType
+
+from aleph.types.ipns import IpnsStatus
+
+from .base import Base
+
+
+class IpnsRecordDb(Base):
+    """
+    Current state of an IPNS registration.
+
+    One row per (name, owner): the same name registered by two different
+    addresses results in two rows, each billed independently. Only the
+    holder of the Ed25519 key behind the name can produce records that
+    verify, so this cannot be abused beyond paying to track a name.
+    """
+
+    __tablename__ = "ipns_records"
+
+    # Canonical base36 IPNS name (k51..., 62 chars).
+    name: Mapped[str] = mapped_column(String, primary_key=True)
+    owner: Mapped[str] = mapped_column(String, primary_key=True)
+    # Latest STORE message that changed this registration.
+    item_hash: Mapped[str] = mapped_column(String, nullable=False)
+    # Latest verified signed IPNS record (raw protobuf bytes).
+    record: Mapped[Optional[bytes]] = mapped_column(LargeBinary, nullable=True)
+    record_sequence: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    # Record end-of-life: republishing stops past this point.
+    record_validity: Mapped[Optional[dt.datetime]] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    # Paid size quota in MiB.
+    max_size_mib: Mapped[int] = mapped_column(Integer, nullable=False)
+    # CID the name currently resolves to (pinned within quota).
+    resolved_cid: Mapped[Optional[str]] = mapped_column(
+        ForeignKey("files.hash"), nullable=True
+    )
+    last_resolved: Mapped[Optional[dt.datetime]] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    last_republished: Mapped[Optional[dt.datetime]] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    status: Mapped[IpnsStatus] = mapped_column(
+        ChoiceType(IpnsStatus), nullable=False, default=IpnsStatus.OK
+    )
+    created: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+
+
+Index("ix_ipns_records_owner", IpnsRecordDb.owner)

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -6,6 +6,7 @@ TODO:
 """
 
 import asyncio
+import base64
 import datetime as dt
 import logging
 import random
@@ -17,17 +18,27 @@ import aioipfs
 from aleph_message.models import ItemHash, ItemType, PaymentType, StoreContent
 
 from aleph.config import get_config
+from aleph.db.accessors.cost import delete_costs_for_message
 from aleph.db.accessors.files import (
     delete_file_pin,
+    delete_ipns_file_pin,
     get_file,
     get_file_tag,
+    get_ipns_file_pin,
     get_message_file_pin,
     insert_grace_period_file_pin,
+    insert_ipns_file_pin,
     insert_message_file_pin,
     is_pinned_file,
     refresh_file_tag,
+    update_ipns_file_pin,
     upsert_file,
     upsert_file_tag,
+)
+from aleph.db.accessors.ipns import (
+    delete_ipns_record,
+    get_ipns_record,
+    upsert_ipns_record,
 )
 from aleph.db.models import MessageDb
 from aleph.db.models.account_costs import AccountCostsDb
@@ -41,6 +52,7 @@ from aleph.services.cost import (
 )
 from aleph.services.cost_validation import validate_balance_for_payment
 from aleph.services.ipfs import IpfsService
+from aleph.services.ipfs.service import InvalidIpnsRecordError, IpnsResolutionError
 from aleph.storage import StorageService
 from aleph.toolkit.constants import MiB
 from aleph.toolkit.costs import are_store_and_program_free, is_credit_only_required
@@ -49,6 +61,7 @@ from aleph.toolkit.timer import Timer
 from aleph.toolkit.timestamp import timestamp_to_datetime, utc_now
 from aleph.types.db_session import DbSession
 from aleph.types.files import FileType
+from aleph.types.ipns import IpnsStatus
 from aleph.types.message_status import (
     FileUnavailable,
     InvalidMessageFormat,
@@ -176,6 +189,12 @@ class StoreMessageHandler(ContentHandler):
         content = message.parsed_content
         assert isinstance(content, StoreContent)
 
+        if content.item_type == ItemType.ipns:
+            record_db = get_ipns_record(
+                session, name=content.item_hash, owner=content.address
+            )
+            return record_db is not None and record_db.item_hash == message.item_hash
+
         file_hash = content.item_hash
         return await self.storage_service.storage_engine.exists(file_hash)
 
@@ -203,6 +222,10 @@ class StoreMessageHandler(ContentHandler):
             raise InvalidMessageFormat(
                 f"Item hash '{file_hash}' is not of the expected type ('{item_type}')"
             )
+
+        if item_type == ItemType.ipns:
+            await self._fetch_ipns(session=session, message=message, content=content)
+            return
 
         total_key, failed_key, duration_key = store_fetch_keys(item_type)
 
@@ -296,6 +319,102 @@ class StoreMessageHandler(ContentHandler):
             size=len(file_content),
         )
 
+    async def _fetch_ipns(
+        self, session: DbSession, message: MessageDb, content: StoreContent
+    ) -> None:
+        config = get_config()
+        if not (config.ipfs.enabled.value and config.ipfs.ipns.enabled.value):
+            raise FileUnavailable(
+                content.item_hash, "IPNS support is disabled on this node"
+            )
+
+        ipfs_service = self.storage_service.ipfs_service
+        name = content.item_hash
+        owner = content.address
+        if content.max_size_mib is None:
+            raise InvalidMessageFormat(
+                f"IPNS store message '{message.item_hash}' has no max_size_mib"
+            )
+
+        if content.ipns_record is not None:
+            record = base64.b64decode(content.ipns_record)
+        else:
+            # Track-only flow: fetch the current record from the DHT.
+            try:
+                record = await ipfs_service.resolve_ipns_record(
+                    name, timeout=config.ipfs.ipns.resolve_timeout.value
+                )
+            except IpnsResolutionError:
+                raise FileUnavailable(
+                    name, "could not resolve the IPNS record from the DHT at this time"
+                )
+
+        try:
+            record_info = await ipfs_service.verify_ipns_record(record, name)
+        except InvalidIpnsRecordError as e:
+            raise InvalidMessageFormat(f"Invalid IPNS record for '{name}': {e}")
+
+        if record_info.validity <= utc_now():
+            raise InvalidMessageFormat(
+                f"IPNS record for '{name}' is already past its end-of-life "
+                f"({record_info.validity.isoformat()})"
+            )
+
+        existing = get_ipns_record(session, name=name, owner=owner)
+        if (
+            existing is not None
+            and existing.record_sequence is not None
+            and record_info.sequence <= existing.record_sequence
+        ):
+            # Records self-order by sequence: a stale or duplicate update is
+            # an idempotent no-op, which also makes out-of-order message
+            # processing safe without any chain logic.
+            LOGGER.info(
+                "ipns_fetch name=%s sequence=%d outcome=stale_noop",
+                name,
+                record_info.sequence,
+            )
+            return
+
+        file_stats = await _get_file_stats_from_ipfs(
+            cid=ItemHash(record_info.value_cid),
+            ipfs_service=ipfs_service,
+            stat_timeout=config.ipfs.stat_timeout.value,
+        )
+        if file_stats.size > content.max_size_mib * MiB:
+            raise InvalidMessageFormat(
+                f"IPNS content for '{name}' exceeds the paid quota "
+                f"({file_stats.size} bytes > {content.max_size_mib} MiB)"
+            )
+
+        await ipfs_service.pin_add(cid=record_info.value_cid)
+        upsert_file(
+            session=session,
+            file_hash=record_info.value_cid,
+            file_type=file_stats.file_type,
+            size=file_stats.size,
+        )
+        upsert_ipns_record(
+            session=session,
+            name=name,
+            owner=owner,
+            item_hash=message.item_hash,
+            record=record,
+            record_sequence=record_info.sequence,
+            record_validity=record_info.validity,
+            max_size_mib=content.max_size_mib,
+            resolved_cid=record_info.value_cid,
+            last_resolved=utc_now(),
+            status=IpnsStatus.OK,
+            created=timestamp_to_datetime(content.time),
+        )
+        # Keep-alive: inject the record into the DHT. Best effort, the
+        # republish task retries every cycle.
+        try:
+            await ipfs_service.put_ipns_record(name, record)
+        except Exception:
+            LOGGER.warning("ipns_put name=%s outcome=fail (will retry in cycle)", name)
+
     async def pre_check_balance(self, session: DbSession, message: MessageDb):
         content = _get_store_content(message)
         assert isinstance(content, StoreContent)
@@ -315,6 +434,19 @@ class StoreMessageHandler(ContentHandler):
         ipfs_enabled = config.ipfs.enabled.value
 
         engine = content.item_type
+
+        if content.item_type == ItemType.ipns:
+            message_cost, _ = get_total_and_detailed_costs(
+                session, content, message.item_hash
+            )
+            validate_balance_for_payment(
+                session=session,
+                address=content.address,
+                message_cost=message_cost,
+                payment_type=payment_type,
+            )
+            return None
+
         # Initially only do that balance pre-check for ipfs files.
         if engine == ItemType.ipfs and ipfs_enabled:
             # If we already have the file locally (e.g. from a prior add_file
@@ -385,10 +517,13 @@ class StoreMessageHandler(ContentHandler):
         storage_size_mib = calculate_storage_size(session, content)
 
         # Allow users to pin small files (only for hold payment type, before cutoff)
+        # IPNS registrations never get the free-file exception as quota is
+        # explicitly paid via max_size_mib.
         if (
             payment_type == PaymentType.hold
             and storage_size_mib
             and storage_size_mib <= (self.max_unauthenticated_upload_file_size / MiB)
+            and content.item_type != ItemType.ipns
         ):
             return costs
 
@@ -478,7 +613,54 @@ class StoreMessageHandler(ContentHandler):
 
     async def process(self, session: DbSession, messages: List[MessageDb]) -> None:
         for message in messages:
-            await self._pin_and_tag_file(session=session, message=message)
+            content = _get_store_content(message)
+            if content.item_type == ItemType.ipns:
+                await self._process_ipns(session=session, message=message)
+            else:
+                await self._pin_and_tag_file(session=session, message=message)
+
+    async def _process_ipns(self, session: DbSession, message: MessageDb) -> None:
+        content = _get_store_content(message)
+        name = content.item_hash
+        owner = content.address
+
+        record_db = get_ipns_record(session, name=name, owner=owner)
+        if record_db is None or record_db.item_hash != message.item_hash:
+            # This message lost the sequence race (stale update): no pin change.
+            return
+        assert record_db.resolved_cid is not None
+
+        pin = get_ipns_file_pin(session, name=name, owner=owner)
+        if pin is None:
+            insert_ipns_file_pin(
+                session=session,
+                file_hash=record_db.resolved_cid,
+                owner=owner,
+                item_hash=message.item_hash,
+                name=name,
+                created=timestamp_to_datetime(content.time),
+            )
+            return
+
+        old_file_hash = pin.file_hash
+        old_item_hash = pin.item_hash
+        update_ipns_file_pin(
+            session=session,
+            name=name,
+            owner=owner,
+            file_hash=record_db.resolved_cid,
+            item_hash=message.item_hash,
+        )
+        if old_item_hash and old_item_hash != message.item_hash:
+            # One logical registration carries one cost line: the superseded
+            # message must stop billing once the update takes over.
+            delete_costs_for_message(session=session, item_hash=old_item_hash)
+        if old_file_hash != record_db.resolved_cid:
+            await self._check_remaining_pins(
+                session=session,
+                storage_hash=old_file_hash,
+                storage_type=item_type_from_hash(old_file_hash),
+            )
 
     async def _check_remaining_pins(
         self, session: DbSession, storage_hash: str, storage_type: ItemType
@@ -518,8 +700,33 @@ class StoreMessageHandler(ContentHandler):
             delete_by=delete_by,
         )
 
+    async def _forget_ipns(self, session: DbSession, message: MessageDb) -> None:
+        content = _get_store_content(message)
+        name = content.item_hash
+        owner = content.address
+
+        record_db = get_ipns_record(session, name=name, owner=owner)
+        if record_db is None or record_db.item_hash != message.item_hash:
+            # Superseded registration message: nothing to tear down.
+            return
+
+        pin = get_ipns_file_pin(session, name=name, owner=owner)
+        delete_ipns_record(session, name=name, owner=owner)
+        if pin is not None:
+            pinned_hash = pin.file_hash
+            delete_ipns_file_pin(session=session, name=name, owner=owner)
+            await self._check_remaining_pins(
+                session=session,
+                storage_hash=pinned_hash,
+                storage_type=item_type_from_hash(pinned_hash),
+            )
+
     async def forget_message(self, session: DbSession, message: MessageDb) -> Set[str]:
         content = _get_store_content(message)
+
+        if content.item_type == ItemType.ipns:
+            await self._forget_ipns(session=session, message=message)
+            return set()
 
         delete_file_pin(session=session, item_hash=message.item_hash)
         refresh_file_tag(

--- a/src/aleph/handlers/content/store.py
+++ b/src/aleph/handlers/content/store.py
@@ -7,6 +7,7 @@ TODO:
 
 import asyncio
 import base64
+import binascii
 import datetime as dt
 import logging
 import random
@@ -91,7 +92,7 @@ class IpfsFileStats:
 
 
 async def _get_file_stats_from_ipfs(
-    cid: ItemHash, ipfs_service: IpfsService, stat_timeout: int
+    cid: str, ipfs_service: IpfsService, stat_timeout: int
 ) -> IpfsFileStats:
     # Stat is a storage operation: route through the storage client (which
     # the service maps to the pinning service when configured, otherwise the
@@ -337,7 +338,12 @@ class StoreMessageHandler(ContentHandler):
             )
 
         if content.ipns_record is not None:
-            record = base64.b64decode(content.ipns_record)
+            try:
+                record = base64.b64decode(content.ipns_record, validate=True)
+            except binascii.Error as e:
+                raise InvalidMessageFormat(
+                    f"IPNS record for '{name}' is not valid base64: {e}"
+                )
         else:
             # Track-only flow: fetch the current record from the DHT.
             try:
@@ -377,7 +383,7 @@ class StoreMessageHandler(ContentHandler):
             return
 
         file_stats = await _get_file_stats_from_ipfs(
-            cid=ItemHash(record_info.value_cid),
+            cid=record_info.value_cid,
             ipfs_service=ipfs_service,
             stat_timeout=config.ipfs.stat_timeout.value,
         )
@@ -394,6 +400,10 @@ class StoreMessageHandler(ContentHandler):
             file_type=file_stats.file_type,
             size=file_stats.size,
         )
+        # Note: fetch and process commit separately. If the message is
+        # rejected at process time (e.g. balance dropped between stages),
+        # this row and the pin survive until the registration is updated
+        # or forgotten. Accepted as a narrow, self-healing window.
         upsert_ipns_record(
             session=session,
             name=name,
@@ -626,7 +636,10 @@ class StoreMessageHandler(ContentHandler):
 
         record_db = get_ipns_record(session, name=name, owner=owner)
         if record_db is None or record_db.item_hash != message.item_hash:
-            # This message lost the sequence race (stale update): no pin change.
+            # This message lost the sequence race (stale update): no pin
+            # change, and it must not bill either, so drop the cost rows
+            # inserted for it earlier in this transaction.
+            delete_costs_for_message(session=session, item_hash=message.item_hash)
             return
         assert record_db.resolved_cid is not None
 
@@ -659,7 +672,7 @@ class StoreMessageHandler(ContentHandler):
             await self._check_remaining_pins(
                 session=session,
                 storage_hash=old_file_hash,
-                storage_type=item_type_from_hash(old_file_hash),
+                storage_type=ItemType.ipfs,
             )
 
     async def _check_remaining_pins(
@@ -681,7 +694,13 @@ class StoreMessageHandler(ContentHandler):
             return
 
         # Unpin the file from IPFS or remove it from local storage
-        storage_detected: ItemType = item_type_from_hash(storage_hash)
+        try:
+            storage_detected: ItemType = item_type_from_hash(storage_hash)
+        except UnknownHashError:
+            # IPNS records may point at CID shapes the STORE shape matcher
+            # does not recognize (e.g. raw-codec bafk... CIDv1). The hash
+            # still designates IPFS content; skip the cross-check.
+            storage_detected = storage_type
 
         if storage_type != storage_detected:
             raise ValueError(
@@ -718,7 +737,7 @@ class StoreMessageHandler(ContentHandler):
             await self._check_remaining_pins(
                 session=session,
                 storage_hash=pinned_hash,
-                storage_type=item_type_from_hash(pinned_hash),
+                storage_type=ItemType.ipfs,
             )
 
     async def forget_message(self, session: DbSession, message: MessageDb) -> Set[str]:

--- a/src/aleph/services/cost.py
+++ b/src/aleph/services/cost.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Tuple, TypeAlias, Union
 
 from aleph_message.models import (
     InstanceContent,
+    ItemType,
     PaymentType,
     ProgramContent,
     StoreContent,
@@ -232,6 +233,8 @@ def _get_product_price_type(
     price_aggregate: Union[AggregateDb, dict],
 ) -> ProductPriceType:
     if isinstance(content, (StoreContent, CostEstimationStoreContent)):
+        if isinstance(content, StoreContent) and content.item_type == ItemType.ipns:
+            return ProductPriceType.IPNS
         return ProductPriceType.STORAGE
 
     if isinstance(content, (ProgramContent, CostEstimationProgramContent)):
@@ -807,6 +810,13 @@ def calculate_storage_size(
     content: CostEstimationStoreContent | StoreContent,
 ) -> Optional[Decimal]:
 
+    if (
+        isinstance(content, StoreContent)
+        and content.item_type == ItemType.ipns
+        and content.max_size_mib is not None
+    ):
+        return Decimal(content.max_size_mib)
+
     if isinstance(content, CostEstimationStoreContent) and content.estimated_size_mib:
         storage_mib = Decimal(content.estimated_size_mib)
     else:
@@ -816,6 +826,52 @@ def calculate_storage_size(
         storage_mib = Decimal(file.size / MiB)
 
     return storage_mib
+
+
+def _calculate_ipns_costs(
+    session: DbSession,
+    content: CostEstimationStoreContent | StoreContent,
+    pricing: ProductPricing,
+    item_hash: str,
+) -> List[AccountCostsDb]:
+    """
+    IPNS registrations are billed on the declared quota (max_size_mib), not
+    the resolved content size, plus a flat name fee covering the
+    republish/re-resolve work. Billing therefore never changes without a
+    new message.
+    """
+    payment_type = get_payment_type(content)
+
+    assert content.max_size_mib is not None  # enforced by StoreContent validator
+    quota_mib = Decimal(content.max_size_mib)
+
+    volume = SizedVolume(CostType.STORAGE, quota_mib, item_hash)
+    costs = _get_volumes_costs(
+        session,
+        [volume],
+        payment_type,
+        pricing.price.storage.holding,
+        pricing.price.storage.payg / HOUR,
+        content.address,
+        item_hash,
+        pricing.price.storage.credit / HOUR,
+    )
+
+    if pricing.price.fixed is not None:
+        costs.append(
+            AccountCostsDb(
+                owner=content.address,
+                item_hash=item_hash,
+                type=CostType.IPNS,
+                name=CostType.IPNS.value,
+                payment_type=payment_type,
+                cost_hold=format_cost(pricing.price.fixed.holding),
+                cost_stream=format_cost(pricing.price.fixed.payg / HOUR),
+                cost_credit=format_cost(pricing.price.fixed.credit / HOUR),
+            )
+        )
+
+    return costs
 
 
 def _get_size_from_file_ref(session: DbSession, file_hash: str) -> Optional[float]:
@@ -980,6 +1036,8 @@ def get_detailed_costs(
     pricing = pricing or _get_product_price(session, content, settings)
 
     if isinstance(content, (StoreContent, CostEstimationStoreContent)):
+        if isinstance(content, StoreContent) and content.item_type == ItemType.ipns:
+            return _calculate_ipns_costs(session, content, pricing, item_hash)
         return _calculate_storage_costs(session, content, pricing, item_hash)
     else:
         return _calculate_executable_costs(session, content, pricing, item_hash)

--- a/src/aleph/services/cost.py
+++ b/src/aleph/services/cost.py
@@ -842,7 +842,10 @@ def _calculate_ipns_costs(
     """
     payment_type = get_payment_type(content)
 
-    assert content.max_size_mib is not None  # enforced by StoreContent validator
+    if content.max_size_mib is None:
+        raise ValueError(
+            f"IPNS store content for message {item_hash} has no max_size_mib"
+        )
     quota_mib = Decimal(content.max_size_mib)
 
     volume = SizedVolume(CostType.STORAGE, quota_mib, item_hash)
@@ -857,6 +860,8 @@ def _calculate_ipns_costs(
         pricing.price.storage.credit / HOUR,
     )
 
+    # STORE messages only allow hold and credit payment types, so the payg
+    # (stream) component of the fee is effectively unused and defaults to 0.
     if pricing.price.fixed is not None:
         costs.append(
             AccountCostsDb(

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -492,7 +492,6 @@ class IpfsService:
                     params={"arg": f"/ipns/{name}"},
                     outformat="json",
                 )
-        return None
 
     async def sub(self, topic: str):
         ipfs_client = self.ipfs_client

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -1,8 +1,12 @@
 import asyncio
+import base64
 import concurrent
+import datetime as dt
 import json
 import logging
 import pathlib
+import tempfile
+from dataclasses import dataclass
 from typing import AsyncIterable, Dict, Optional, Self, Union, cast
 
 import aiofiles
@@ -18,6 +22,21 @@ from aleph.utils import run_in_executor
 LOGGER = logging.getLogger(__name__)
 
 MAX_LEN = 1024 * 1024 * 100
+
+
+class InvalidIpnsRecordError(Exception):
+    """The IPNS record failed verification against its name."""
+
+
+class IpnsResolutionError(Exception):
+    """The IPNS name could not be resolved from the DHT."""
+
+
+@dataclass(frozen=True)
+class IpnsRecordInfo:
+    value_cid: str
+    sequence: int
+    validity: dt.datetime
 
 
 class DagImportError(Exception):
@@ -399,6 +418,81 @@ class IpfsService:
                     self.storage_client.core.handle_error(response, body)
 
         return parse_dag_import_response(body)
+
+    async def verify_ipns_record(self, record: bytes, name: str) -> IpnsRecordInfo:
+        """
+        Verify a signed IPNS record against its name via kubo and extract
+        the value CID, sequence number and end-of-life.
+        """
+        client = self.storage_client
+        # kubo's name/inspect endpoint takes the record as a file upload;
+        # the aioipfs wrapper only accepts a file path.
+        with tempfile.NamedTemporaryFile() as record_file:
+            record_file.write(record)
+            record_file.flush()
+            response = await client.name.inspect(
+                record=record_file.name, verify=name, dump=False
+            )
+
+        validation = response.get("Validation") or {}
+        if not validation.get("Valid"):
+            raise InvalidIpnsRecordError(
+                validation.get("Reason") or "record failed validation"
+            )
+
+        entry = response["Entry"]
+        value = entry["Value"]
+        if not value.startswith("/ipfs/"):
+            raise InvalidIpnsRecordError(f"unsupported IPNS value: {value}")
+        cid = value.removeprefix("/ipfs/")
+        if "/" in cid:
+            raise InvalidIpnsRecordError(
+                f"IPNS records with sub-path values are not supported: {value}"
+            )
+
+        validity = dt.datetime.fromisoformat(entry["Validity"].replace("Z", "+00:00"))
+        return IpnsRecordInfo(
+            value_cid=cid, sequence=int(entry["Sequence"]), validity=validity
+        )
+
+    async def resolve_ipns_record(self, name: str, timeout: int) -> bytes:
+        """Fetch the current signed record for an IPNS name from the DHT."""
+        client = self.storage_client
+        try:
+            response = await asyncio.wait_for(
+                client.routing.get(f"/ipns/{name}"), timeout
+            )
+        except (asyncio.TimeoutError, aioipfs.APIError) as e:
+            raise IpnsResolutionError(name) from e
+
+        extra = (response or {}).get("Extra")
+        if not extra:
+            raise IpnsResolutionError(name)
+        return base64.b64decode(extra)
+
+    async def put_ipns_record(self, name: str, record: bytes) -> None:
+        """
+        Inject/republish a signed IPNS record into the DHT.
+
+        The aioipfs routing.put wrapper passes the value as a query
+        argument, which kubo rejects for binary records; post the record
+        as a multipart body the way name/inspect does.
+        """
+        from aioipfs import multi
+
+        client = self.storage_client
+        with tempfile.NamedTemporaryFile() as record_file:
+            record_file.write(record)
+            record_file.flush()
+            with multi.FormDataWriter() as mpwriter:
+                mpwriter.append_payload(multi.bytes_payload_from_file(record_file.name))
+                await client.routing.post(
+                    client.routing.url("routing/put"),
+                    mpwriter,
+                    params={"arg": f"/ipns/{name}"},
+                    outformat="json",
+                )
+        return None
 
     async def sub(self, topic: str):
         ipfs_client = self.ipfs_client

--- a/src/aleph/services/ipns/__init__.py
+++ b/src/aleph/services/ipns/__init__.py
@@ -1,0 +1,3 @@
+from aleph.services.ipns.republisher import IpnsRepublisher, ipns_republisher_task
+
+__all__ = ["IpnsRepublisher", "ipns_republisher_task"]

--- a/src/aleph/services/ipns/republisher.py
+++ b/src/aleph/services/ipns/republisher.py
@@ -1,0 +1,156 @@
+"""
+Periodic IPNS maintenance: republish stored records to the DHT (kubo
+records expire within ~24-48h) and re-resolve names to adopt newer
+records published out-of-band or by tracked third parties.
+"""
+
+import asyncio
+import datetime as dt
+import logging
+
+from configmanager import Config
+
+from aleph.db.accessors.files import (
+    get_ipns_file_pin,
+    insert_grace_period_file_pin,
+    is_pinned_file,
+    update_ipns_file_pin,
+    upsert_file,
+)
+from aleph.db.accessors.ipns import get_all_ipns_records
+from aleph.db.models.ipns import IpnsRecordDb
+from aleph.handlers.content.store import _get_file_stats_from_ipfs
+from aleph.services.ipfs import IpfsService
+from aleph.services.ipfs.service import InvalidIpnsRecordError, IpnsResolutionError
+from aleph.toolkit.constants import MiB
+from aleph.toolkit.timestamp import utc_now
+from aleph.types.db_session import DbSession, DbSessionFactory
+from aleph.types.ipns import IpnsStatus
+
+LOGGER = logging.getLogger(__name__)
+
+
+class IpnsRepublisher:
+    def __init__(
+        self,
+        session_factory: DbSessionFactory,
+        ipfs_service: IpfsService,
+        grace_period_hours: int,
+        stat_timeout: int,
+        resolve_timeout: int,
+    ):
+        self.session_factory = session_factory
+        self.ipfs_service = ipfs_service
+        self.grace_period_hours = grace_period_hours
+        self.stat_timeout = stat_timeout
+        self.resolve_timeout = resolve_timeout
+
+    async def _republish(self, record_db: IpnsRecordDb) -> None:
+        now = utc_now()
+        if record_db.record_validity is not None and record_db.record_validity <= now:
+            if record_db.status != IpnsStatus.EXPIRED:
+                LOGGER.info("ipns_republish name=%s outcome=expired", record_db.name)
+                record_db.status = IpnsStatus.EXPIRED
+            return
+        if record_db.record is None:
+            return
+        try:
+            await self.ipfs_service.put_ipns_record(record_db.name, record_db.record)
+            record_db.last_republished = now
+        except Exception:
+            LOGGER.warning(
+                "ipns_republish name=%s outcome=fail", record_db.name, exc_info=True
+            )
+
+    async def _re_resolve(self, session: DbSession, record_db: IpnsRecordDb) -> None:
+        try:
+            record = await self.ipfs_service.resolve_ipns_record(
+                record_db.name, timeout=self.resolve_timeout
+            )
+            record_info = await self.ipfs_service.verify_ipns_record(
+                record, record_db.name
+            )
+        except (IpnsResolutionError, InvalidIpnsRecordError):
+            return
+
+        if (
+            record_db.record_sequence is not None
+            and record_info.sequence <= record_db.record_sequence
+        ):
+            return
+
+        file_stats = await _get_file_stats_from_ipfs(
+            cid=record_info.value_cid,
+            ipfs_service=self.ipfs_service,
+            stat_timeout=self.stat_timeout,
+        )
+        if file_stats.size > record_db.max_size_mib * MiB:
+            # Keep serving the last good CID; store the newer record so the
+            # sequence guard and republishing stay current.
+            LOGGER.info(
+                "ipns_resolve name=%s sequence=%d outcome=over_quota",
+                record_db.name,
+                record_info.sequence,
+            )
+            record_db.record = record
+            record_db.record_sequence = record_info.sequence
+            record_db.record_validity = record_info.validity
+            record_db.status = IpnsStatus.OVER_QUOTA
+            return
+
+        await self.ipfs_service.pin_add(cid=record_info.value_cid)
+        upsert_file(
+            session=session,
+            file_hash=record_info.value_cid,
+            file_type=file_stats.file_type,
+            size=file_stats.size,
+        )
+
+        old_cid = record_db.resolved_cid
+        record_db.record = record
+        record_db.record_sequence = record_info.sequence
+        record_db.record_validity = record_info.validity
+        record_db.resolved_cid = record_info.value_cid
+        record_db.last_resolved = utc_now()
+        record_db.status = IpnsStatus.OK
+
+        pin = get_ipns_file_pin(session, name=record_db.name, owner=record_db.owner)
+        if pin is not None and pin.file_hash != record_info.value_cid:
+            update_ipns_file_pin(
+                session=session,
+                name=record_db.name,
+                owner=record_db.owner,
+                file_hash=record_info.value_cid,
+                item_hash=pin.item_hash,
+            )
+        if old_cid and old_cid != record_info.value_cid:
+            session.flush()
+            if not is_pinned_file(session=session, file_hash=old_cid):
+                delete_by = utc_now() + dt.timedelta(hours=self.grace_period_hours)
+                insert_grace_period_file_pin(
+                    session=session,
+                    file_hash=old_cid,
+                    created=utc_now(),
+                    delete_by=delete_by,
+                )
+
+    async def run_cycle(self) -> None:
+        with self.session_factory() as session:
+            records = list(get_all_ipns_records(session))
+            for record_db in records:
+                await self._republish(record_db)
+                await self._re_resolve(session, record_db)
+            session.commit()
+
+
+async def ipns_republisher_task(config: Config, republisher: IpnsRepublisher) -> None:
+    period = config.ipfs.ipns.republish_period_hours.value * 3600
+    while True:
+        try:
+            LOGGER.info("Next IPNS republish cycle in %.0f seconds.", period)
+            await asyncio.sleep(period)
+            LOGGER.info("Starting IPNS republish cycle...")
+            await republisher.run_cycle()
+            LOGGER.info("IPNS republish cycle completed.")
+        except Exception:
+            LOGGER.exception("Error in IPNS republish cycle")

--- a/src/aleph/services/ipns/republisher.py
+++ b/src/aleph/services/ipns/republisher.py
@@ -73,6 +73,9 @@ class IpnsRepublisher:
         except (IpnsResolutionError, InvalidIpnsRecordError):
             return
 
+        # A NULL stored sequence means we have no baseline (the handler
+        # always sets one, so this only happens via manual intervention):
+        # adopt whatever valid record the DHT returns.
         if (
             record_db.record_sequence is not None
             and record_info.sequence <= record_db.record_sequence
@@ -138,8 +141,15 @@ class IpnsRepublisher:
         with self.session_factory() as session:
             records = list(get_all_ipns_records(session))
             for record_db in records:
-                await self._republish(record_db)
-                await self._re_resolve(session, record_db)
+                try:
+                    await self._republish(record_db)
+                    await self._re_resolve(session, record_db)
+                except Exception:
+                    LOGGER.warning(
+                        "ipns_cycle name=%s outcome=error",
+                        record_db.name,
+                        exc_info=True,
+                    )
             session.commit()
 
 

--- a/src/aleph/toolkit/constants.py
+++ b/src/aleph/toolkit/constants.py
@@ -19,6 +19,7 @@ class ProductPriceType(str, Enum):
     INSTANCE_GPU_PREMIUM = "instance_gpu_premium"
     INSTANCE_CONFIDENTIAL = "instance_confidential"
     INSTANCE_GPU_STANDARD = "instance_gpu_standard"
+    IPNS = "ipns"
 
 
 PRICE_AGGREGATE_OWNER = "0xFba561a84A537fCaa567bb7A2257e7142701ae2A"
@@ -51,6 +52,12 @@ DEFAULT_PRICE_AGGREGATE: Dict[Union[ProductPriceType, str], dict] = {
     ProductPriceType.STORAGE: {
         "price": {
             "storage": {"holding": "0.333333333", "credit": "0.17967489030626108"}
+        }
+    },
+    ProductPriceType.IPNS: {
+        "price": {
+            "storage": {"holding": "0.333333333", "credit": "0.17967489030626108"},
+            "fixed": {"holding": "1", "credit": "0.5"},
         }
     },
     ProductPriceType.INSTANCE: {

--- a/src/aleph/types/cost.py
+++ b/src/aleph/types/cost.py
@@ -36,14 +36,17 @@ class ProductComputeUnit:
 class ProductPrice:
     storage: ProductPriceOptions
     compute_unit: Optional[ProductPriceOptions]
+    fixed: Optional[ProductPriceOptions]
 
     def __init__(
         self,
         storage: ProductPriceOptions,
         compute_unit: Optional[ProductPriceOptions] = None,
+        fixed: Optional[ProductPriceOptions] = None,
     ):
         self.storage = storage
         self.compute_unit = compute_unit
+        self.fixed = fixed
 
 
 class ProductTier:
@@ -109,6 +112,8 @@ class ProductPricing:
                 for tier in tiers
             ]
 
+        fixed = price.get("fixed", None)
+
         pricing = ProductPricing(
             price_type=price_type,
             price=ProductPrice(
@@ -124,6 +129,15 @@ class ProductPricing:
                         price["compute_unit"].get("credit", None),
                     )
                     if compute_unit
+                    else None
+                ),
+                fixed=(
+                    ProductPriceOptions(
+                        fixed.get("holding", None),
+                        fixed.get("payg", None),
+                        fixed.get("credit", None),
+                    )
+                    if fixed and isinstance(fixed, dict)
                     else None
                 ),
             ),
@@ -152,6 +166,7 @@ class CostType(str, Enum):
     EXECUTION_PROGRAM_VOLUME_RUNTIME = "EXECUTION_PROGRAM_VOLUME_RUNTIME"
     EXECUTION_PROGRAM_VOLUME_DATA = "EXECUTION_PROGRAM_VOLUME_DATA"
     STORAGE = "STORAGE"
+    IPNS = "IPNS"
 
 
 class VolumeCost:

--- a/src/aleph/types/ipns.py
+++ b/src/aleph/types/ipns.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class IpnsStatus(str, Enum):
+    """Lifecycle status of an IPNS registration."""
+
+    # Record valid, content pinned within quota.
+    OK = "ok"
+    # The name resolved to content larger than the paid quota.
+    # The last good CID stays pinned and served.
+    OVER_QUOTA = "over_quota"
+    # The signed record passed its end-of-life and is no longer
+    # republished. The pin is kept; the user must renew the record.
+    EXPIRED = "expired"

--- a/src/aleph/utils.py
+++ b/src/aleph/utils.py
@@ -23,6 +23,12 @@ def item_type_from_hash(item_hash: str) -> ItemType:
         return ItemType.ipfs
     elif item_hash.startswith("bafy") and len(item_hash) == 59:  # CIDv1
         return ItemType.ipfs
+    elif (
+        item_hash.startswith("k51")
+        and len(item_hash) == 62
+        and set(item_hash[3:]) <= set("0123456789abcdefghijklmnopqrstuvwxyz")
+    ):  # CIDv1 libp2p-key, base36: Ed25519 IPNS name
+        return ItemType.ipns
     elif len(item_hash) == 64:
         return ItemType.storage
     else:

--- a/src/aleph/web/controllers/ipfs.py
+++ b/src/aleph/web/controllers/ipfs.py
@@ -50,6 +50,8 @@ async def _verify_ipns_record_and_get_cid(
             reason="IPNS store messages attached to uploads must include ipns_record"
         )
     ipfs_service = get_ipfs_service_from_request(request)
+    if ipfs_service is None:
+        raise web.HTTPForbidden(reason="IPFS is disabled on this node")
     record = base64.b64decode(message_content.ipns_record)
     try:
         record_info = await ipfs_service.verify_ipns_record(
@@ -101,7 +103,7 @@ async def ipfs_add_file(request: web.Request):
                 type: string
                 description: >
                   Optional JSON with a signed STORE message
-                  (item_type=ipfs). When present, the CID computed after
+                  (item_type=ipfs or ipns). When present, the CID computed after
                   pinning must match message.content.item_hash.
     responses:
       '200':
@@ -212,7 +214,7 @@ async def ipfs_add_file(request: web.Request):
             if message_content.item_type not in (ItemType.ipfs, ItemType.ipns):
                 raise web.HTTPUnprocessableEntity(
                     reason=(
-                        "Expected item_type=ipfs in STORE message, "
+                        "Expected item_type=ipfs or item_type=ipns in STORE message, "
                         f"got {message_content.item_type}"
                     )
                 )
@@ -345,7 +347,7 @@ async def ipfs_add_car(request: web.Request):
                 type: string
                 description: >
                   JSON {"message": <PendingInlineStoreMessage>, "sync": bool}.
-                  message.content.item_type must be "ipfs"; item_hash must
+                  message.content.item_type must be "ipfs" or "ipns"; item_hash must
                   equal the CAR's single root CID.
     responses:
       '200':
@@ -435,7 +437,7 @@ async def ipfs_add_car(request: web.Request):
         if message_content.item_type not in (ItemType.ipfs, ItemType.ipns):
             raise web.HTTPUnprocessableEntity(
                 reason=(
-                    "Expected item_type=ipfs in STORE message, "
+                    "Expected item_type=ipfs or item_type=ipns in STORE message, "
                     f"got {message_content.item_type}"
                 )
             )

--- a/src/aleph/web/controllers/ipfs.py
+++ b/src/aleph/web/controllers/ipfs.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import logging
 import math
 
@@ -9,6 +10,7 @@ from pydantic import ValidationError
 
 from aleph.db.accessors.files import upsert_file
 from aleph.schemas.cost_estimation_messages import CostEstimationStoreContent
+from aleph.services.ipfs.service import InvalidIpnsRecordError
 from aleph.toolkit.car import InvalidCarFile, read_carv1_root
 from aleph.toolkit.constants import MiB
 from aleph.types.files import FileType
@@ -32,6 +34,46 @@ from aleph.web.controllers.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+async def _verify_ipns_record_and_get_cid(
+    request: web.Request, message_content: CostEstimationStoreContent
+) -> str:
+    """Decode and verify the IPNS record embedded in *message_content*.
+
+    Returns the CID that the record points to (``value_cid``).  Raises
+    :class:`aiohttp.web.HTTPUnprocessableEntity` if the record is absent or
+    invalid.
+    """
+    if message_content.ipns_record is None:
+        raise web.HTTPUnprocessableEntity(
+            reason="IPNS store messages attached to uploads must include ipns_record"
+        )
+    ipfs_service = get_ipfs_service_from_request(request)
+    record = base64.b64decode(message_content.ipns_record)
+    try:
+        record_info = await ipfs_service.verify_ipns_record(
+            record, message_content.item_hash
+        )
+    except InvalidIpnsRecordError as e:
+        raise web.HTTPUnprocessableEntity(reason=f"Invalid IPNS record: {e}")
+    return record_info.value_cid
+
+
+async def _check_ipns_upload(
+    request: web.Request, message_content: CostEstimationStoreContent, cid: str
+) -> None:
+    """For IPNS STORE metadata the uploaded CID must match the value inside
+    the signed record, not the message item_hash (which is the IPNS name).
+    """
+    value_cid = await _verify_ipns_record_and_get_cid(request, message_content)
+    if value_cid != cid:
+        raise web.HTTPUnprocessableEntity(
+            reason=(
+                f"IPNS record value does not match the uploaded file "
+                f"({cid} != {value_cid})"
+            )
+        )
 
 
 async def ipfs_add_file(request: web.Request):
@@ -167,7 +209,7 @@ async def ipfs_add_file(request: web.Request):
                 raise web.HTTPUnprocessableEntity(
                     reason=f"Invalid store message content: {e.json()}"
                 )
-            if message_content.item_type != ItemType.ipfs:
+            if message_content.item_type not in (ItemType.ipfs, ItemType.ipns):
                 raise web.HTTPUnprocessableEntity(
                     reason=(
                         "Expected item_type=ipfs in STORE message, "
@@ -200,13 +242,16 @@ async def ipfs_add_file(request: web.Request):
                 raise web.HTTPGatewayTimeout(reason="Timed out waiting for IPFS stat")
             size = stats["Size"]
 
-            if message_content is not None and message_content.item_hash != cid:
-                raise web.HTTPUnprocessableEntity(
-                    reason=(
-                        f"File hash does not match "
-                        f"({cid} != {message_content.item_hash})"
+            if message_content is not None:
+                if message_content.item_type == ItemType.ipns:
+                    await _check_ipns_upload(request, message_content, cid)
+                elif message_content.item_hash != cid:
+                    raise web.HTTPUnprocessableEntity(
+                        reason=(
+                            f"File hash does not match "
+                            f"({cid} != {message_content.item_hash})"
+                        )
                     )
-                )
 
             with session_factory() as session:
                 upsert_file(
@@ -387,7 +432,7 @@ async def ipfs_add_car(request: web.Request):
             raise web.HTTPUnprocessableEntity(
                 reason=f"Invalid store message content: {e.json()}"
             )
-        if message_content.item_type != ItemType.ipfs:
+        if message_content.item_type not in (ItemType.ipfs, ItemType.ipns):
             raise web.HTTPUnprocessableEntity(
                 reason=(
                     "Expected item_type=ipfs in STORE message, "
@@ -403,11 +448,26 @@ async def ipfs_add_car(request: web.Request):
             car_root = read_carv1_root(car_path)
         except InvalidCarFile as e:
             raise web.HTTPUnprocessableEntity(reason=f"Invalid CAR file: {e}")
-        expected_root = message_content.item_hash
-        if car_root != expected_root:
-            raise web.HTTPUnprocessableEntity(
-                reason=(f"Root CID does not match " f"({car_root} != {expected_root})")
+        if message_content.item_type == ItemType.ipns:
+            # For IPNS, the expected root is the CID inside the signed record,
+            # not the item_hash (which is the IPNS name).
+            expected_root = await _verify_ipns_record_and_get_cid(
+                request, message_content
             )
+            if car_root != expected_root:
+                raise web.HTTPUnprocessableEntity(
+                    reason=(
+                        f"Root CID does not match " f"({car_root} != {expected_root})"
+                    )
+                )
+        else:
+            expected_root = message_content.item_hash
+            if car_root != expected_root:
+                raise web.HTTPUnprocessableEntity(
+                    reason=(
+                        f"Root CID does not match " f"({car_root} != {expected_root})"
+                    )
+                )
 
         # Balance check BEFORE dag_import so an underfunded request leaves no
         # pin on kubo. CAR file size is a conservative overestimate of the

--- a/src/aleph/web/controllers/ipns.py
+++ b/src/aleph/web/controllers/ipns.py
@@ -1,0 +1,104 @@
+"""
+API endpoints for IPNS registrations.
+
+Only names registered on Aleph (paid STORE messages with item_type=ipns)
+are served: CCNs are not open IPNS resolvers. Resolution is a DB lookup
+of the last good CID; content is served from already-pinned data through
+the existing storage endpoints.
+"""
+
+from aiohttp import web
+from aleph_message.models import ItemType
+
+from aleph.db.accessors.ipns import get_ipns_records_by_name, get_ipns_records_by_owner
+from aleph.exceptions import UnknownHashError
+from aleph.utils import item_type_from_hash
+from aleph.web.controllers.app_state_getters import get_session_factory_from_request
+
+
+def _validate_ipns_name(name: str) -> None:
+    try:
+        is_ipns = item_type_from_hash(name) == ItemType.ipns
+    except UnknownHashError:
+        is_ipns = False
+    if not is_ipns:
+        raise web.HTTPUnprocessableEntity(reason=f"Not an IPNS name: '{name}'")
+
+
+def _registration_to_dict(record_db) -> dict:
+    return {
+        "owner": record_db.owner,
+        "item_hash": record_db.item_hash,
+        "max_size_mib": record_db.max_size_mib,
+        "status": record_db.status.value,
+        "sequence": record_db.record_sequence,
+        "validity": (
+            record_db.record_validity.isoformat() if record_db.record_validity else None
+        ),
+        "resolved_cid": record_db.resolved_cid,
+        "last_resolved": (
+            record_db.last_resolved.isoformat() if record_db.last_resolved else None
+        ),
+    }
+
+
+def _best_registration(records):
+    # Among multiple owners of the same name, serve the registration with
+    # the highest record sequence (records all verify against the same key).
+    return max(records, key=lambda r: r.record_sequence or 0)
+
+
+async def get_ipns_name(request: web.Request) -> web.Response:
+    name = request.match_info["name"]
+    _validate_ipns_name(name)
+
+    session_factory = get_session_factory_from_request(request)
+    with session_factory() as session:
+        records = list(get_ipns_records_by_name(session, name=name))
+        if not records:
+            raise web.HTTPNotFound(reason=f"IPNS name not registered: '{name}'")
+        best = _best_registration(records)
+        return web.json_response(
+            {
+                "name": name,
+                "resolved_cid": best.resolved_cid,
+                "sequence": best.record_sequence,
+                "validity": (
+                    best.record_validity.isoformat() if best.record_validity else None
+                ),
+                "status": best.status.value,
+                "registrations": [_registration_to_dict(r) for r in records],
+            }
+        )
+
+
+async def get_ipns_raw(request: web.Request) -> web.Response:
+    name = request.match_info["name"]
+    _validate_ipns_name(name)
+
+    session_factory = get_session_factory_from_request(request)
+    with session_factory() as session:
+        records = list(get_ipns_records_by_name(session, name=name))
+        if not records:
+            raise web.HTTPNotFound(reason=f"IPNS name not registered: '{name}'")
+        best = _best_registration(records)
+        if best.resolved_cid is None:
+            raise web.HTTPNotFound(
+                reason=f"IPNS name has no resolved content yet: '{name}'"
+            )
+        raise web.HTTPFound(location=f"/api/v0/storage/raw/{best.resolved_cid}")
+
+
+async def list_ipns_by_address(request: web.Request) -> web.Response:
+    address = request.match_info["address"]
+    session_factory = get_session_factory_from_request(request)
+    with session_factory() as session:
+        records = list(get_ipns_records_by_owner(session, owner=address))
+        return web.json_response(
+            {
+                "address": address,
+                "registrations": [
+                    {**_registration_to_dict(r), "name": r.name} for r in records
+                ],
+            }
+        )

--- a/src/aleph/web/controllers/ipns.py
+++ b/src/aleph/web/controllers/ipns.py
@@ -11,6 +11,7 @@ from aiohttp import web
 from aleph_message.models import ItemType
 
 from aleph.db.accessors.ipns import get_ipns_records_by_name, get_ipns_records_by_owner
+from aleph.db.models.ipns import IpnsRecordDb
 from aleph.exceptions import UnknownHashError
 from aleph.utils import item_type_from_hash
 from aleph.web.controllers.app_state_getters import get_session_factory_from_request
@@ -25,7 +26,7 @@ def _validate_ipns_name(name: str) -> None:
         raise web.HTTPUnprocessableEntity(reason=f"Not an IPNS name: '{name}'")
 
 
-def _registration_to_dict(record_db) -> dict:
+def _registration_to_dict(record_db: IpnsRecordDb) -> dict:
     return {
         "owner": record_db.owner,
         "item_hash": record_db.item_hash,
@@ -44,8 +45,8 @@ def _registration_to_dict(record_db) -> dict:
 
 def _best_registration(records):
     # Among multiple owners of the same name, serve the registration with
-    # the highest record sequence (records all verify against the same key).
-    return max(records, key=lambda r: r.record_sequence or 0)
+    # the highest record sequence; tie-break by owner for determinism.
+    return max(records, key=lambda r: (r.record_sequence or 0, r.owner))
 
 
 async def get_ipns_name(request: web.Request) -> web.Response:

--- a/src/aleph/web/controllers/routes.py
+++ b/src/aleph/web/controllers/routes.py
@@ -11,6 +11,7 @@ from aleph.web.controllers import (
     channels,
     info,
     ipfs,
+    ipns,
     main,
     messages,
     p2p,
@@ -138,6 +139,12 @@ def register_routes(app: web.Application, swagger: Optional[SwaggerDocs]):
         web.post(
             "/api/v0/ipfs/add_json",
             storage.add_ipfs_json_controller,
+        ),
+        web.get("/api/v0/ipns/{name}", ipns.get_ipns_name),
+        web.get("/api/v0/ipns/{name}/raw", ipns.get_ipns_raw),
+        web.get(
+            "/api/v0/addresses/{address}/ipns",
+            ipns.list_ipns_by_address,
         ),
         web.post(
             "/api/v0/storage/add_file",

--- a/tests/api/test_ipfs.py
+++ b/tests/api/test_ipfs.py
@@ -1,3 +1,4 @@
+import base64
 import datetime as dt
 import hashlib
 import json
@@ -17,6 +18,7 @@ from in_memory_storage_engine import InMemoryStorageEngine
 from aleph.chains.signature_verifier import SignatureVerifier
 from aleph.db.accessors.files import get_file
 from aleph.db.models import AlephBalanceDb, AlephCreditBalanceDb, GracePeriodFilePinDb
+from aleph.services.ipfs.service import InvalidIpnsRecordError, IpnsRecordInfo
 from aleph.storage import StorageService
 from aleph.types.db_session import DbSessionFactory
 from aleph.types.files import FileType
@@ -1151,3 +1153,404 @@ async def test_add_car_dag_import_failure(
 
     with session_factory() as session:
         assert get_file(session=session, file_hash=DIR_ROOT_CID) is None
+
+
+# ---------------------------------------------------------------------------
+# IPNS upload tests (add_file and add_car with item_type=ipns)
+# ---------------------------------------------------------------------------
+
+# A real-looking IPNS name (k51 multibase-encoded Ed25519 public key).
+IPNS_NAME = "k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8"
+# Arbitrary bytes that stand in for the signed IPNS record wire format.
+# IpfsService.verify_ipns_record is mocked away so the exact content doesn't
+# matter.
+IPNS_RECORD_BYTES = b"\x0a\x10fake-ipns-record-bytes"
+IPNS_RECORD_B64 = base64.b64encode(IPNS_RECORD_BYTES).decode()
+
+
+def _build_ipns_store_message(ipns_name: str, ipns_record_b64: str) -> dict:
+    """Build a PendingInlineStoreMessage dict with item_type=ipns.
+
+    The outer message uses item_type=inline so that item_content is a JSON
+    string; the inner StoreContent has item_type=ipns.  The outer item_hash
+    must equal sha256(item_content) or pydantic rejects it.
+    """
+    item_content = json.dumps(
+        {
+            "address": "0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+            "time": 1692193373.714271,
+            "item_type": "ipns",
+            "item_hash": ipns_name,
+            "max_size_mib": 10,
+            "ipns_record": ipns_record_b64,
+        }
+    )
+    outer_hash = hashlib.sha256(item_content.encode("utf-8")).hexdigest()
+    return {
+        "chain": "ETH",
+        "sender": "0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+        "type": "STORE",
+        "channel": "null",
+        "signature": "0x" + "00" * 65,
+        "time": 1692193373.7144432,
+        "item_type": "inline",
+        "item_content": item_content,
+        "item_hash": outer_hash,
+    }
+
+
+def _build_ipns_store_message_no_record(ipns_name: str) -> dict:
+    """Build an IPNS STORE message without an embedded record (track-only)."""
+    item_content = json.dumps(
+        {
+            "address": "0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+            "time": 1692193373.714271,
+            "item_type": "ipns",
+            "item_hash": ipns_name,
+            "max_size_mib": 10,
+        }
+    )
+    outer_hash = hashlib.sha256(item_content.encode("utf-8")).hexdigest()
+    return {
+        "chain": "ETH",
+        "sender": "0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+        "type": "STORE",
+        "channel": "null",
+        "signature": "0x" + "00" * 65,
+        "time": 1692193373.7144432,
+        "item_type": "inline",
+        "item_content": item_content,
+        "item_hash": outer_hash,
+    }
+
+
+@pytest.mark.asyncio
+async def test_ipns_add_file_record_matches_upload(
+    api_client,
+    session_factory: DbSessionFactory,
+    mocker,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """IPNS STORE metadata accepted when record value_cid == uploaded CID."""
+    mocker.patch(
+        "aleph.web.controllers.ipfs._verify_message_signature",
+        new_callable=mocker.AsyncMock,
+    )
+    mocker.patch(
+        "aleph.web.controllers.ipfs.broadcast_and_process_message",
+        new_callable=mocker.AsyncMock,
+        return_value=BroadcastStatus(
+            publication_status=PublicationStatus.from_failures([]),
+            message_status=MessageStatus.PROCESSED,
+        ),
+    )
+
+    # Mock verify_ipns_record to return a record whose value_cid equals the
+    # CID the (mocked) IPFS daemon will produce for the uploaded file.
+    ipfs_service = _get_ipfs_service_mock(api_client)
+    ipfs_service.verify_ipns_record = MockAsyncMock(
+        return_value=IpnsRecordInfo(
+            value_cid=EXPECTED_FILE_CID,
+            sequence=1,
+            validity=dt.datetime(2030, 1, 1, tzinfo=dt.timezone.utc),
+        )
+    )
+
+    with session_factory() as session:
+        session.add(
+            AlephBalanceDb(
+                address="0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+                chain=Chain.ETH,
+                balance=Decimal(1000),
+                eth_height=0,
+            )
+        )
+        session.commit()
+
+    message = _build_ipns_store_message(IPNS_NAME, IPNS_RECORD_B64)
+    form_data = aiohttp.FormData()
+    form_data.add_field("file", BytesIO(FILE_CONTENT))
+    form_data.add_field(
+        "metadata",
+        json.dumps({"message": message, "sync": True}),
+        content_type="application/json",
+    )
+
+    response = await api_client.post(IPFS_ADD_FILE_URI, data=form_data)
+    body = await response.text()
+    assert response.status == 200, body
+    payload = await response.json()
+    assert payload["hash"] == EXPECTED_FILE_CID
+
+    ipfs_service.verify_ipns_record.assert_called_once_with(
+        IPNS_RECORD_BYTES, IPNS_NAME
+    )
+
+
+@pytest.mark.asyncio
+async def test_ipns_add_file_record_value_mismatch(
+    api_client,
+    session_factory: DbSessionFactory,
+    mocker,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """IPNS record that points to a different CID than the uploaded file: 422."""
+    mocker.patch(
+        "aleph.web.controllers.ipfs._verify_message_signature",
+        new_callable=mocker.AsyncMock,
+    )
+
+    other_cid = "QmY8HD3jCfJ5K6t4VYQvkFBni2LpasVusLGkCrtjkfntSA"
+    ipfs_service = _get_ipfs_service_mock(api_client)
+    ipfs_service.verify_ipns_record = MockAsyncMock(
+        return_value=IpnsRecordInfo(
+            value_cid=other_cid,  # different from EXPECTED_FILE_CID
+            sequence=1,
+            validity=dt.datetime(2030, 1, 1, tzinfo=dt.timezone.utc),
+        )
+    )
+
+    with session_factory() as session:
+        session.add(
+            AlephBalanceDb(
+                address="0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+                chain=Chain.ETH,
+                balance=Decimal(1000),
+                eth_height=0,
+            )
+        )
+        session.commit()
+
+    message = _build_ipns_store_message(IPNS_NAME, IPNS_RECORD_B64)
+    form_data = aiohttp.FormData()
+    form_data.add_field("file", BytesIO(FILE_CONTENT))
+    form_data.add_field(
+        "metadata",
+        json.dumps({"message": message, "sync": False}),
+        content_type="application/json",
+    )
+
+    response = await api_client.post(IPFS_ADD_FILE_URI, data=form_data)
+    body = await response.text()
+    assert response.status == 422, body
+    assert "IPNS record value does not match" in body
+
+
+@pytest.mark.asyncio
+async def test_ipns_add_file_no_record_rejected(
+    api_client,
+    session_factory: DbSessionFactory,
+    mocker,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """IPNS STORE metadata without an embedded record is rejected with 422."""
+    mocker.patch(
+        "aleph.web.controllers.ipfs._verify_message_signature",
+        new_callable=mocker.AsyncMock,
+    )
+
+    with session_factory() as session:
+        session.add(
+            AlephBalanceDb(
+                address="0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+                chain=Chain.ETH,
+                balance=Decimal(1000),
+                eth_height=0,
+            )
+        )
+        session.commit()
+
+    message = _build_ipns_store_message_no_record(IPNS_NAME)
+    form_data = aiohttp.FormData()
+    form_data.add_field("file", BytesIO(FILE_CONTENT))
+    form_data.add_field(
+        "metadata",
+        json.dumps({"message": message, "sync": False}),
+        content_type="application/json",
+    )
+
+    response = await api_client.post(IPFS_ADD_FILE_URI, data=form_data)
+    body = await response.text()
+    assert response.status == 422, body
+    assert "must include ipns_record" in body
+
+
+@pytest.mark.asyncio
+async def test_ipfs_add_file_cid_mismatch_preserved(
+    api_client,
+    session_factory: DbSessionFactory,
+    mocker,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """Non-IPNS upload with mismatched item_hash still returns 422 (regression)."""
+    mocker.patch(
+        "aleph.web.controllers.ipfs._verify_message_signature",
+        new_callable=mocker.AsyncMock,
+    )
+
+    with session_factory() as session:
+        session.add(
+            AlephBalanceDb(
+                address="0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+                chain=Chain.ETH,
+                balance=Decimal(1000),
+                eth_height=0,
+            )
+        )
+        session.commit()
+
+    mismatched_item_content = json.dumps(
+        {
+            "address": "0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+            "time": 1692193373.714271,
+            "item_type": "ipfs",
+            "item_hash": "QmY8HD3jCfJ5K6t4VYQvkFBni2LpasVusLGkCrtjkfntSA",
+            "mime_type": "application/octet-stream",
+        }
+    )
+    mismatched = {
+        **IPFS_MESSAGE_DICT,
+        "item_content": mismatched_item_content,
+        "item_hash": hashlib.sha256(
+            mismatched_item_content.encode("utf-8")
+        ).hexdigest(),
+    }
+
+    form_data = aiohttp.FormData()
+    form_data.add_field("file", BytesIO(FILE_CONTENT))
+    form_data.add_field(
+        "metadata",
+        json.dumps({"message": mismatched, "sync": False}),
+        content_type="application/json",
+    )
+
+    response = await api_client.post(IPFS_ADD_FILE_URI, data=form_data)
+    body = await response.text()
+    assert response.status == 422, body
+    assert "File hash does not match" in body
+
+
+# ---------------------------------------------------------------------------
+# CAR + IPNS upload tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ipns_add_car_record_matches_upload(
+    api_client_with_dag_import,
+    session_factory: DbSessionFactory,
+    mocker,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """IPNS STORE metadata on add_car: accepted when record value_cid == CAR root."""
+    mocker.patch(
+        "aleph.web.controllers.ipfs._verify_message_signature",
+        new_callable=mocker.AsyncMock,
+    )
+    mocker.patch(
+        "aleph.web.controllers.ipfs.broadcast_and_process_message",
+        new_callable=mocker.AsyncMock,
+        return_value=BroadcastStatus(
+            publication_status=PublicationStatus.from_failures([]),
+            message_status=MessageStatus.PROCESSED,
+        ),
+    )
+
+    ipfs_service = _get_ipfs_service_mock(api_client_with_dag_import)
+    # The record value_cid matches the CAR root CID.
+    ipfs_service.verify_ipns_record = MockAsyncMock(
+        return_value=IpnsRecordInfo(
+            value_cid=DIR_ROOT_CID,
+            sequence=1,
+            validity=dt.datetime(2030, 1, 1, tzinfo=dt.timezone.utc),
+        )
+    )
+    # dag_import returns the same root.
+    ipfs_service.dag_import = MockAsyncMock(return_value=[DIR_ROOT_CID])
+
+    with session_factory() as session:
+        session.add(
+            AlephBalanceDb(
+                address="0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+                chain=Chain.ETH,
+                balance=Decimal(1000),
+                eth_height=0,
+            )
+        )
+        session.commit()
+
+    car_bytes = build_carv1(DIR_ROOT_CID)
+    message = _build_ipns_store_message(IPNS_NAME, IPNS_RECORD_B64)
+
+    form_data = aiohttp.FormData()
+    form_data.add_field("file", BytesIO(car_bytes), filename="dir.car")
+    form_data.add_field(
+        "metadata",
+        json.dumps({"message": message, "sync": True}),
+        content_type="application/json",
+    )
+
+    response = await api_client_with_dag_import.post(IPFS_ADD_CAR_URI, data=form_data)
+    body = await response.text()
+    assert response.status == 200, body
+    payload = await response.json()
+    assert payload["hash"] == DIR_ROOT_CID
+
+
+@pytest.mark.asyncio
+async def test_ipns_add_car_record_value_mismatch(
+    api_client_with_dag_import,
+    session_factory: DbSessionFactory,
+    mocker,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """IPNS record value_cid differs from CAR root: 422, no dag_import call."""
+    mocker.patch(
+        "aleph.web.controllers.ipfs._verify_message_signature",
+        new_callable=mocker.AsyncMock,
+    )
+
+    other_cid = "bafybeicndzezzx7zyvuoukheebsegjnokf3vlwm4nlz77pnxllgr2jjelu"
+    ipfs_service = _get_ipfs_service_mock(api_client_with_dag_import)
+    ipfs_service.verify_ipns_record = MockAsyncMock(
+        return_value=IpnsRecordInfo(
+            value_cid=other_cid,  # different from DIR_ROOT_CID
+            sequence=1,
+            validity=dt.datetime(2030, 1, 1, tzinfo=dt.timezone.utc),
+        )
+    )
+
+    with session_factory() as session:
+        session.add(
+            AlephBalanceDb(
+                address="0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+                chain=Chain.ETH,
+                balance=Decimal(1000),
+                eth_height=0,
+            )
+        )
+        session.commit()
+
+    car_bytes = build_carv1(DIR_ROOT_CID)
+    message = _build_ipns_store_message(IPNS_NAME, IPNS_RECORD_B64)
+
+    form_data = aiohttp.FormData()
+    form_data.add_field("file", BytesIO(car_bytes), filename="dir.car")
+    form_data.add_field(
+        "metadata",
+        json.dumps({"message": message, "sync": False}),
+        content_type="application/json",
+    )
+
+    response = await api_client_with_dag_import.post(IPFS_ADD_CAR_URI, data=form_data)
+    body = await response.text()
+    assert response.status == 422, body
+    assert "Root CID does not match" in body
+
+    ipfs_service.dag_import.assert_not_called()

--- a/tests/api/test_ipfs.py
+++ b/tests/api/test_ipfs.py
@@ -1337,6 +1337,65 @@ async def test_ipns_add_file_record_value_mismatch(
     assert response.status == 422, body
     assert "IPNS record value does not match" in body
 
+    # Pin happened (record mismatch is a post-pin check), so the file is in DB
+    # with a grace period.
+    with session_factory() as session:
+        file = get_file(session=session, file_hash=EXPECTED_FILE_CID)
+        assert file is not None
+        assert _has_grace_period(session, EXPECTED_FILE_CID)
+
+
+@pytest.mark.asyncio
+async def test_ipns_add_file_invalid_record(
+    api_client,
+    session_factory: DbSessionFactory,
+    mocker,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """IPNS record with invalid signature: 422 and grace period applied."""
+    mocker.patch(
+        "aleph.web.controllers.ipfs._verify_message_signature",
+        new_callable=mocker.AsyncMock,
+    )
+
+    ipfs_service = _get_ipfs_service_mock(api_client)
+    ipfs_service.verify_ipns_record = MockAsyncMock(
+        side_effect=InvalidIpnsRecordError("bad signature")
+    )
+
+    with session_factory() as session:
+        session.add(
+            AlephBalanceDb(
+                address="0x6dA130FD646f826C1b8080C07448923DF9a79aaA",
+                chain=Chain.ETH,
+                balance=Decimal(1000),
+                eth_height=0,
+            )
+        )
+        session.commit()
+
+    message = _build_ipns_store_message(IPNS_NAME, IPNS_RECORD_B64)
+    form_data = aiohttp.FormData()
+    form_data.add_field("file", BytesIO(FILE_CONTENT))
+    form_data.add_field(
+        "metadata",
+        json.dumps({"message": message, "sync": False}),
+        content_type="application/json",
+    )
+
+    response = await api_client.post(IPFS_ADD_FILE_URI, data=form_data)
+    body = await response.text()
+    assert response.status == 422, body
+    assert "Invalid IPNS record" in body
+
+    # Pin happened (record validation is a post-pin check), so the file is in DB
+    # with a grace period.
+    with session_factory() as session:
+        file = get_file(session=session, file_hash=EXPECTED_FILE_CID)
+        assert file is not None
+        assert _has_grace_period(session, EXPECTED_FILE_CID)
+
 
 @pytest.mark.asyncio
 async def test_ipns_add_file_no_record_rejected(

--- a/tests/api/test_ipns_api.py
+++ b/tests/api/test_ipns_api.py
@@ -1,0 +1,120 @@
+import datetime as dt
+
+import pytest
+
+from aleph.db.accessors.files import upsert_file
+from aleph.db.accessors.ipns import upsert_ipns_record
+from aleph.types.db_session import DbSessionFactory
+from aleph.types.files import FileType
+from aleph.types.ipns import IpnsStatus
+
+# A valid IPNS name (62-char base36 k51... CIDv1 key)
+IPNS_NAME = "k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8"
+# Same length, last char changed -- still a syntactically valid-looking key but
+# not registered in the DB (used for the 404 test).
+UNREGISTERED_NAME = "k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v7"
+
+OWNER = "0xA07B1214bAe0D5ccAA25449C3149c0aC83658874"
+CID = "QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB"
+MSG_HASH = "7f2d09b2c4e1a8f3d6b5c2e9a1f4d7b8e3c6a9f2d5b8e1c4a7f0d3b6e9c2a5f8"
+NOW = dt.datetime(2026, 6, 10, tzinfo=dt.timezone.utc)
+
+
+@pytest.fixture
+def seeded_ipns(session_factory: DbSessionFactory):
+    with session_factory() as session:
+        upsert_file(session, file_hash=CID, size=1024, file_type=FileType.FILE)
+        upsert_ipns_record(
+            session=session,
+            name=IPNS_NAME,
+            owner=OWNER,
+            item_hash=MSG_HASH,
+            record=b"\x0a\x01raw",
+            record_sequence=42,
+            record_validity=NOW + dt.timedelta(days=365),
+            max_size_mib=100,
+            resolved_cid=CID,
+            last_resolved=NOW,
+            status=IpnsStatus.OK,
+            created=NOW,
+        )
+        session.commit()
+
+
+@pytest.mark.asyncio
+async def test_get_ipns_name_registered(
+    ccn_api_client,
+    session_factory: DbSessionFactory,
+    seeded_ipns,
+):
+    """GET /api/v0/ipns/{name} returns 200 with correct JSON for a registered name."""
+    response = await ccn_api_client.get(f"/api/v0/ipns/{IPNS_NAME}")
+    assert response.status == 200
+    data = await response.json()
+
+    assert data["name"] == IPNS_NAME
+    assert data["resolved_cid"] == CID
+    assert data["sequence"] == 42
+    assert data["validity"] is not None
+    assert data["status"] == IpnsStatus.OK.value
+
+    registrations = data["registrations"]
+    assert len(registrations) == 1
+    reg = registrations[0]
+    assert reg["owner"] == OWNER
+    assert reg["max_size_mib"] == 100
+    assert reg["status"] == IpnsStatus.OK.value
+
+
+@pytest.mark.asyncio
+async def test_get_ipns_name_not_registered(
+    ccn_api_client,
+    session_factory: DbSessionFactory,
+):
+    """GET /api/v0/ipns/{name} with a valid-but-unregistered name returns 404."""
+    response = await ccn_api_client.get(f"/api/v0/ipns/{UNREGISTERED_NAME}")
+    assert response.status == 404
+
+
+@pytest.mark.asyncio
+async def test_get_ipns_name_invalid(
+    ccn_api_client,
+):
+    """GET /api/v0/ipns/{name} with a non-IPNS name returns 422."""
+    response = await ccn_api_client.get("/api/v0/ipns/not-a-name")
+    assert response.status == 422
+
+
+@pytest.mark.asyncio
+async def test_get_ipns_raw_redirect(
+    ccn_api_client,
+    session_factory: DbSessionFactory,
+    seeded_ipns,
+):
+    """GET /api/v0/ipns/{name}/raw returns 302 to /api/v0/storage/raw/{cid}."""
+    response = await ccn_api_client.get(
+        f"/api/v0/ipns/{IPNS_NAME}/raw", allow_redirects=False
+    )
+    assert response.status == 302
+    assert response.headers["Location"] == f"/api/v0/storage/raw/{CID}"
+
+
+@pytest.mark.asyncio
+async def test_list_ipns_by_address(
+    ccn_api_client,
+    session_factory: DbSessionFactory,
+    seeded_ipns,
+):
+    """GET /api/v0/addresses/{address}/ipns lists seeded registrations for the owner."""
+    response = await ccn_api_client.get(f"/api/v0/addresses/{OWNER}/ipns")
+    assert response.status == 200
+    data = await response.json()
+
+    assert data["address"] == OWNER
+    registrations = data["registrations"]
+    assert len(registrations) == 1
+    reg = registrations[0]
+    assert reg["name"] == IPNS_NAME
+    assert reg["owner"] == OWNER
+    assert reg["max_size_mib"] == 100
+    assert reg["status"] == IpnsStatus.OK.value

--- a/tests/api/test_ipns_api.py
+++ b/tests/api/test_ipns_api.py
@@ -100,6 +100,33 @@ async def test_get_ipns_raw_redirect(
 
 
 @pytest.mark.asyncio
+async def test_get_ipns_raw_no_resolved_cid(
+    ccn_api_client,
+    session_factory: DbSessionFactory,
+):
+    """GET /api/v0/ipns/{name}/raw returns 404 when resolved_cid is None."""
+    with session_factory() as session:
+        upsert_ipns_record(
+            session=session,
+            name=IPNS_NAME,
+            owner=OWNER,
+            item_hash=MSG_HASH,
+            record=b"\x0a\x01raw",
+            record_sequence=42,
+            record_validity=NOW + dt.timedelta(days=365),
+            max_size_mib=100,
+            resolved_cid=None,
+            last_resolved=None,
+            status=IpnsStatus.OK,
+            created=NOW,
+        )
+        session.commit()
+
+    response = await ccn_api_client.get(f"/api/v0/ipns/{IPNS_NAME}/raw")
+    assert response.status == 404
+
+
+@pytest.mark.asyncio
 async def test_list_ipns_by_address(
     ccn_api_client,
     session_factory: DbSessionFactory,

--- a/tests/db/test_ipns_accessors.py
+++ b/tests/db/test_ipns_accessors.py
@@ -1,0 +1,115 @@
+import datetime as dt
+
+import pytest
+
+from aleph.db.accessors.files import (
+    get_ipns_file_pin,
+    insert_ipns_file_pin,
+    update_ipns_file_pin,
+    upsert_file,
+)
+from aleph.db.accessors.ipns import (
+    delete_ipns_record,
+    get_all_ipns_records,
+    get_ipns_record,
+    get_ipns_records_by_name,
+    get_ipns_records_by_owner,
+    upsert_ipns_record,
+)
+from aleph.types.db_session import DbSessionFactory
+from aleph.types.files import FileType
+from aleph.types.ipns import IpnsStatus
+
+IPNS_NAME = "k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8"
+OWNER = "0xA07B1214bAe0D5ccAA25449C3149c0aC83658874"
+CID = "QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB"
+MSG_HASH = "7f2d09b2c4e1a8f3d6b5c2e9a1f4d7b8e3c6a9f2d5b8e1c4a7f0d3b6e9c2a5f8"
+NOW = dt.datetime(2026, 6, 10, tzinfo=dt.timezone.utc)
+
+
+def _upsert(session, sequence=1, item_hash=MSG_HASH, resolved_cid=CID):
+    upsert_ipns_record(
+        session=session,
+        name=IPNS_NAME,
+        owner=OWNER,
+        item_hash=item_hash,
+        record=b"\x0a\x01raw",
+        record_sequence=sequence,
+        record_validity=NOW + dt.timedelta(days=365),
+        max_size_mib=100,
+        resolved_cid=resolved_cid,
+        last_resolved=NOW,
+        status=IpnsStatus.OK,
+        created=NOW,
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_get_ipns_record(session_factory: DbSessionFactory):
+    with session_factory() as session:
+        upsert_file(session, file_hash=CID, size=1024, file_type=FileType.FILE)
+        _upsert(session)
+        session.commit()
+
+    with session_factory() as session:
+        record = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        assert record is not None
+        assert record.record_sequence == 1
+        assert record.resolved_cid == CID
+
+    with session_factory() as session:
+        _upsert(session, sequence=2)
+        session.commit()
+
+    with session_factory() as session:
+        record = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        assert record.record_sequence == 2
+
+        assert len(list(get_ipns_records_by_name(session, name=IPNS_NAME))) == 1
+        assert len(list(get_ipns_records_by_owner(session, owner=OWNER))) == 1
+        assert len(list(get_all_ipns_records(session))) == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_ipns_record(session_factory: DbSessionFactory):
+    with session_factory() as session:
+        upsert_file(session, file_hash=CID, size=1024, file_type=FileType.FILE)
+        _upsert(session)
+        session.commit()
+        delete_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        session.commit()
+        assert get_ipns_record(session, name=IPNS_NAME, owner=OWNER) is None
+
+
+@pytest.mark.asyncio
+async def test_ipns_file_pin_lifecycle(session_factory: DbSessionFactory):
+    cid2 = "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG"
+    msg2 = "8a3e10c3d5f2b9a4e7c6d3f0b2a5e8c1d4b7f0a3e6c9d2b5a8f1e4c7d0b3a6f9"
+    with session_factory() as session:
+        upsert_file(session, file_hash=CID, size=1024, file_type=FileType.FILE)
+        upsert_file(session, file_hash=cid2, size=2048, file_type=FileType.FILE)
+        insert_ipns_file_pin(
+            session=session,
+            file_hash=CID,
+            owner=OWNER,
+            item_hash=MSG_HASH,
+            name=IPNS_NAME,
+            created=NOW,
+        )
+        session.commit()
+
+        pin = get_ipns_file_pin(session, name=IPNS_NAME, owner=OWNER)
+        assert pin is not None
+        assert pin.file_hash == CID
+
+        update_ipns_file_pin(
+            session=session,
+            name=IPNS_NAME,
+            owner=OWNER,
+            file_hash=cid2,
+            item_hash=msg2,
+        )
+        session.commit()
+        pin = get_ipns_file_pin(session, name=IPNS_NAME, owner=OWNER)
+        assert pin.file_hash == cid2
+        assert pin.item_hash == msg2

--- a/tests/db/test_ipns_accessors.py
+++ b/tests/db/test_ipns_accessors.py
@@ -27,11 +27,11 @@ MSG_HASH = "7f2d09b2c4e1a8f3d6b5c2e9a1f4d7b8e3c6a9f2d5b8e1c4a7f0d3b6e9c2a5f8"
 NOW = dt.datetime(2026, 6, 10, tzinfo=dt.timezone.utc)
 
 
-def _upsert(session, sequence=1, item_hash=MSG_HASH, resolved_cid=CID):
+def _upsert(session, sequence=1, item_hash=MSG_HASH, resolved_cid=CID, owner=OWNER):
     upsert_ipns_record(
         session=session,
         name=IPNS_NAME,
-        owner=OWNER,
+        owner=owner,
         item_hash=item_hash,
         record=b"\x0a\x01raw",
         record_sequence=sequence,
@@ -56,6 +56,7 @@ async def test_upsert_and_get_ipns_record(session_factory: DbSessionFactory):
         assert record is not None
         assert record.record_sequence == 1
         assert record.resolved_cid == CID
+        assert record.status == IpnsStatus.OK
 
     with session_factory() as session:
         _upsert(session, sequence=2)
@@ -113,3 +114,25 @@ async def test_ipns_file_pin_lifecycle(session_factory: DbSessionFactory):
         pin = get_ipns_file_pin(session, name=IPNS_NAME, owner=OWNER)
         assert pin.file_hash == cid2
         assert pin.item_hash == msg2
+
+
+@pytest.mark.asyncio
+async def test_multiple_owners_same_ipns_name(session_factory: DbSessionFactory):
+    owner2 = "0x000000000000000000000000000000000000dEaD"
+    with session_factory() as session:
+        upsert_file(session, file_hash=CID, size=1024, file_type=FileType.FILE)
+        _upsert(session, owner=OWNER)
+        _upsert(session, owner=owner2)
+        session.commit()
+
+    with session_factory() as session:
+        records = list(get_ipns_records_by_name(session, name=IPNS_NAME))
+        assert len(records) == 2
+
+        record1 = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        assert record1 is not None
+        assert record1.owner == OWNER
+
+        record2 = get_ipns_record(session, name=IPNS_NAME, owner=owner2)
+        assert record2 is not None
+        assert record2.owner == owner2

--- a/tests/db/test_ipns_models.py
+++ b/tests/db/test_ipns_models.py
@@ -1,0 +1,29 @@
+import datetime as dt
+
+from aleph.db.models.files import FilePinType, IpnsFilePinDb
+from aleph.db.models.ipns import IpnsRecordDb
+from aleph.types.ipns import IpnsStatus
+
+IPNS_NAME = "k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8"
+
+
+def test_ipns_pin_type_exists():
+    assert FilePinType.IPNS.value == "ipns"
+    assert IpnsFilePinDb.__mapper_args__["polymorphic_identity"] == "ipns"
+
+
+def test_ipns_record_model_columns():
+    record = IpnsRecordDb(
+        name=IPNS_NAME,
+        owner="0xA07B1214bAe0D5ccAA25449C3149c0aC83658874",
+        item_hash="7f2d09b2c4e1a8f3d6b5c2e9a1f4d7b8e3c6a9f2d5b8e1c4a7f0d3b6e9c2a5f8",
+        record=b"\x0a\x01raw",
+        record_sequence=1,
+        record_validity=dt.datetime(2028, 6, 9, tzinfo=dt.timezone.utc),
+        max_size_mib=100,
+        resolved_cid=None,
+        status=IpnsStatus.OK,
+        created=dt.datetime(2026, 6, 10, tzinfo=dt.timezone.utc),
+    )
+    assert record.status == IpnsStatus.OK
+    assert record.record_sequence == 1

--- a/tests/message_processing/test_process_ipns_stores.py
+++ b/tests/message_processing/test_process_ipns_stores.py
@@ -12,23 +12,13 @@ from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from aleph_message.models import (
-    Chain,
-    ItemHash,
-    ItemType,
-    MessageType,
-    StoreContent,
-)
+from aleph_message.models import Chain, ItemHash, ItemType, MessageType, StoreContent
 from configmanager import Config
 from sqlalchemy import select
 
 from aleph.db.accessors.files import get_ipns_file_pin
 from aleph.db.accessors.ipns import get_ipns_record, upsert_ipns_record
-from aleph.db.models import (
-    GracePeriodFilePinDb,
-    MessageDb,
-    StoredFileDb,
-)
+from aleph.db.models import GracePeriodFilePinDb, MessageDb, StoredFileDb
 from aleph.db.models.account_costs import AccountCostsDb
 from aleph.handlers.content.store import IpfsFileStats, StoreMessageHandler
 from aleph.services.ipfs.service import IpnsRecordInfo, IpnsResolutionError
@@ -729,3 +719,197 @@ async def test_ipns_cost_rows_migrate_on_update(
         record_db = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
         assert record_db is not None
         assert record_db.item_hash == MSG_HASH_2
+
+
+@pytest.mark.asyncio
+async def test_ipns_stale_update_cost_rows_deleted(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """
+    Stale update: message A (sequence 1) arrives after message B (sequence 2)
+    has already been processed and won the race.  _process_ipns must delete
+    A's cost rows so the owner is not double-billed.  B's registration, pin,
+    and cost rows must remain intact.
+    """
+    from aleph_message.models import PaymentType
+
+    handler, ipfs_service = _make_handler(mocker)
+    ipfs_service.pin_add = AsyncMock()
+
+    content_a = _make_ipns_content()
+    content_b = _make_ipns_content()
+
+    with session_factory() as session:
+        # Insert both message rows (needed for FK on AccountCostsDb).
+        _insert_message_row(session, item_hash=MSG_HASH_1, content=content_a)
+        _insert_message_row(session, item_hash=MSG_HASH_2, content=content_b)
+        session.flush()
+
+        # Seed registration already pointing at message B (sequence 2 won).
+        _seed_ipns_record(
+            session, item_hash=MSG_HASH_2, resolved_cid=CID_V2, sequence=2
+        )
+        session.flush()
+
+        # Seed cost row for message B (the winner).
+        session.add(
+            AccountCostsDb(
+                owner=OWNER,
+                item_hash=MSG_HASH_2,
+                type=CostType.STORAGE,
+                name="storage",
+                ref=None,
+                payment_type=PaymentType.hold,
+                cost_hold=Decimal("1.0"),
+                cost_stream=Decimal("0"),
+                cost_credit=Decimal("0"),
+            )
+        )
+        # Seed a cost row for message A (stale; the pipeline inserts these
+        # before calling process, so we simulate that here).
+        session.add(
+            AccountCostsDb(
+                owner=OWNER,
+                item_hash=MSG_HASH_1,
+                type=CostType.STORAGE,
+                name="storage",
+                ref=None,
+                payment_type=PaymentType.hold,
+                cost_hold=Decimal("1.0"),
+                cost_stream=Decimal("0"),
+                cost_credit=Decimal("0"),
+            )
+        )
+        session.commit()
+
+    # Process the stale message A (sequence 1, record_db will point at B).
+    message_a = _make_message_db(mocker, item_hash=MSG_HASH_1, content=content_a)
+
+    with session_factory() as session:
+        await handler.process(session=session, messages=[message_a])
+        session.commit()
+
+    with session_factory() as session:
+        # Message A's cost rows must be gone.
+        costs_a = (
+            session.execute(
+                select(AccountCostsDb).where(AccountCostsDb.item_hash == MSG_HASH_1)
+            )
+            .scalars()
+            .all()
+        )
+        assert len(costs_a) == 0
+
+        # Registration still points at B.
+        record_db = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        assert record_db is not None
+        assert record_db.item_hash == MSG_HASH_2
+
+        # B's cost rows untouched.
+        costs_b = (
+            session.execute(
+                select(AccountCostsDb).where(AccountCostsDb.item_hash == MSG_HASH_2)
+            )
+            .scalars()
+            .all()
+        )
+        assert len(costs_b) == 1
+
+
+# ---------------------------------------------------------------------------
+# bafk CID (raw-codec CIDv1) handling
+# ---------------------------------------------------------------------------
+
+# A syntactically valid raw-codec CIDv1 that item_type_from_hash and ItemHash
+# both reject with UnknownHashError / ValueError respectively.
+BAFK_CID = "bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy"
+
+
+@pytest.mark.asyncio
+async def test_ipns_bafk_cid_update_no_exception(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+):
+    """
+    An IPNS update where the OLD resolved CID is a raw-codec bafk... CIDv1
+    must not raise an exception when checking remaining pins.  The bafk CID
+    should receive a grace-period pin because it has no other active pins.
+    """
+    handler, ipfs_service = _make_handler(mocker)
+    ipfs_service.verify_ipns_record = AsyncMock(
+        return_value=_record_info(CID_V2, sequence=2)
+    )
+    ipfs_service.pin_add = AsyncMock()
+    ipfs_service.put_ipns_record = AsyncMock()
+
+    with session_factory() as session:
+        # Seed a stored file row for the bafk CID (simulates what fetch
+        # would have done when the name first resolved to this CID).
+        session.add(
+            StoredFileDb(hash=BAFK_CID, size=2 * 1024 * 1024, type=FileType.FILE)
+        )
+        session.flush()
+
+        # Seed registration at sequence 1 pointing at the bafk CID.
+        upsert_ipns_record(
+            session=session,
+            name=IPNS_NAME,
+            owner=OWNER,
+            item_hash=MSG_HASH_1,
+            record=FAKE_RECORD,
+            record_sequence=1,
+            record_validity=VALIDITY,
+            max_size_mib=100,
+            resolved_cid=BAFK_CID,
+            last_resolved=dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc),
+            status=IpnsStatus.OK,
+            created=timestamp_to_datetime(MSG_TIME),
+        )
+        # Seed the IPNS file pin pointing at the bafk CID.
+        from aleph.db.accessors.files import insert_ipns_file_pin
+
+        insert_ipns_file_pin(
+            session=session,
+            file_hash=BAFK_CID,
+            owner=OWNER,
+            item_hash=MSG_HASH_1,
+            name=IPNS_NAME,
+            created=timestamp_to_datetime(MSG_TIME),
+        )
+        # Seed the new target CID as a stored file.
+        session.add(StoredFileDb(hash=CID_V2, size=5 * 1024 * 1024, type=FileType.FILE))
+        session.commit()
+
+    content = _make_ipns_content(max_size_mib=100)
+    message2 = _make_message_db(mocker, item_hash=MSG_HASH_2, content=content)
+
+    with patch(
+        "aleph.handlers.content.store._get_file_stats_from_ipfs",
+        new=AsyncMock(
+            return_value=IpfsFileStats(size=5 * 1024 * 1024, file_type=FileType.FILE)
+        ),
+    ):
+        # Must not raise.
+        with session_factory() as session:
+            await handler.fetch_related_content(session=session, message=message2)
+            await handler.process(session=session, messages=[message2])
+            session.commit()
+
+    with session_factory() as session:
+        # Pin re-pointed to CID_V2.
+        pin = get_ipns_file_pin(session, name=IPNS_NAME, owner=OWNER)
+        assert pin is not None
+        assert pin.file_hash == CID_V2
+
+        # bafk CID has no remaining active pins -> grace-period pin inserted.
+        bafk_file = session.execute(
+            select(StoredFileDb).where(StoredFileDb.hash == BAFK_CID)
+        ).scalar_one_or_none()
+        assert bafk_file is not None
+        grace_pins = [p for p in bafk_file.pins if isinstance(p, GracePeriodFilePinDb)]
+        assert len(grace_pins) == 1

--- a/tests/message_processing/test_process_ipns_stores.py
+++ b/tests/message_processing/test_process_ipns_stores.py
@@ -1,0 +1,731 @@
+"""
+Tests for the IPNS branch of StoreMessageHandler.
+
+Drives StoreMessageHandler directly (with a mocked StorageService / IpfsService)
+to avoid the full message pipeline, following the same style as
+test_process_stores.py.
+"""
+
+import datetime as dt
+import json
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aleph_message.models import (
+    Chain,
+    ItemHash,
+    ItemType,
+    MessageType,
+    StoreContent,
+)
+from configmanager import Config
+from sqlalchemy import select
+
+from aleph.db.accessors.files import get_ipns_file_pin
+from aleph.db.accessors.ipns import get_ipns_record, upsert_ipns_record
+from aleph.db.models import (
+    GracePeriodFilePinDb,
+    MessageDb,
+    StoredFileDb,
+)
+from aleph.db.models.account_costs import AccountCostsDb
+from aleph.handlers.content.store import IpfsFileStats, StoreMessageHandler
+from aleph.services.ipfs.service import IpnsRecordInfo, IpnsResolutionError
+from aleph.toolkit.constants import (
+    DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE,
+    STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP,
+)
+from aleph.toolkit.timestamp import timestamp_to_datetime
+from aleph.types.channel import Channel
+from aleph.types.cost import CostType
+from aleph.types.db_session import DbSessionFactory
+from aleph.types.files import FileType
+from aleph.types.ipns import IpnsStatus
+from aleph.types.message_status import FileUnavailable, InvalidMessageFormat
+
+# ---------------------------------------------------------------------------
+# Test constants
+# ---------------------------------------------------------------------------
+
+IPNS_NAME = "k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8"
+OWNER = "0xA07B1214bAe0D5ccAA25449C3149c0aC83658874"
+CID_V1 = "QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB"
+CID_V2 = "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG"
+VALIDITY = dt.datetime(2028, 6, 9, tzinfo=dt.timezone.utc)
+
+# A timestamp that is after the cost cutoff so messages always require payment.
+MSG_TIME = STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1
+
+# Fake record bytes (content does not matter; we mock verify_ipns_record)
+FAKE_RECORD = b"\x00\x01\x02fake_record"
+FAKE_RECORD_B64 = __import__("base64").b64encode(FAKE_RECORD).decode()
+
+# Minimal valid-looking message hashes (64 hex chars = storage type according
+# to item_type_from_hash, but that function is not called on the *message*
+# item_hash — only on the *content* item_hash which is an IPNS name).
+MSG_HASH_1 = "a" * 64
+MSG_HASH_2 = "b" * 64
+MSG_HASH_3 = "c" * 64
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ipns_content(
+    *,
+    name: str = IPNS_NAME,
+    owner: str = OWNER,
+    max_size_mib: int = 100,
+    ipns_record: str | None = FAKE_RECORD_B64,
+    time: float = MSG_TIME,
+) -> StoreContent:
+    """Build a StoreContent with item_type=ipns."""
+    return StoreContent(
+        address=owner,
+        time=time,
+        item_type=ItemType.ipns,
+        item_hash=ItemHash(name),
+        max_size_mib=max_size_mib,
+        ipns_record=ipns_record,
+    )
+
+
+def _make_message_db(
+    mocker,
+    *,
+    item_hash: str = MSG_HASH_1,
+    content: StoreContent | None = None,
+) -> MagicMock:
+    """Return a minimal MessageDb-spec mock with parsed_content wired up."""
+    if content is None:
+        content = _make_ipns_content()
+    msg = mocker.MagicMock(spec=MessageDb)
+    msg.item_hash = item_hash
+    msg.type = MessageType.store
+    msg.chain = Chain.ETH
+    msg.sender = OWNER
+    msg.signature = None
+    msg.item_type = ItemType.inline
+    msg.item_content = json.dumps(content.model_dump())
+    msg.parsed_content = content
+    msg.time = timestamp_to_datetime(content.time)
+    msg.channel = Channel("TEST")
+    msg.confirmations = []
+    return msg
+
+
+def _make_handler(
+    mocker, *, ipfs_service=None
+) -> tuple[StoreMessageHandler, MagicMock]:
+    """Return (handler, ipfs_service_mock)."""
+    if ipfs_service is None:
+        ipfs_service = mocker.AsyncMock()
+    storage_service = mocker.MagicMock()
+    storage_service.ipfs_service = ipfs_service
+    handler = StoreMessageHandler(
+        storage_service=storage_service,
+        grace_period=24,
+        max_unauthenticated_upload_file_size=DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE,
+    )
+    return handler, ipfs_service
+
+
+def _setup_stats_mock(ipfs_service, *, size: int, file_type: FileType = FileType.FILE):
+    """Wire up _get_file_stats_from_ipfs to return a fixed IpfsFileStats."""
+    ipfs_service.storage_client.files.stat = AsyncMock(
+        return_value={
+            "Type": "file" if file_type == FileType.FILE else "dir",
+            "Size": size,
+            "CumulativeSize": size,
+        }
+    )
+
+
+def _record_info(
+    cid: str, sequence: int = 1, validity: dt.datetime = VALIDITY
+) -> IpnsRecordInfo:
+    return IpnsRecordInfo(value_cid=cid, sequence=sequence, validity=validity)
+
+
+def _seed_ipns_record(
+    session,
+    *,
+    name: str = IPNS_NAME,
+    owner: str = OWNER,
+    item_hash: str = MSG_HASH_1,
+    resolved_cid: str = CID_V1,
+    sequence: int = 1,
+) -> None:
+    """Insert an ipns_records row and the corresponding files row."""
+    session.add(
+        StoredFileDb(hash=resolved_cid, size=4 * 1024 * 1024, type=FileType.FILE)
+    )
+    session.flush()
+    upsert_ipns_record(
+        session=session,
+        name=name,
+        owner=owner,
+        item_hash=item_hash,
+        record=FAKE_RECORD,
+        record_sequence=sequence,
+        record_validity=VALIDITY,
+        max_size_mib=100,
+        resolved_cid=resolved_cid,
+        last_resolved=dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc),
+        status=IpnsStatus.OK,
+        created=timestamp_to_datetime(MSG_TIME),
+    )
+
+
+def _insert_message_row(session, item_hash: str, content: StoreContent) -> None:
+    """Insert a minimal MessageDb row so AccountCostsDb FK is satisfied."""
+    session.add(
+        MessageDb(
+            item_hash=item_hash,
+            type=MessageType.store,
+            chain=Chain.ETH,
+            sender=OWNER,
+            signature=None,
+            item_type=ItemType.inline,
+            item_content=json.dumps(content.model_dump()),
+            content=content.model_dump(),
+            time=timestamp_to_datetime(content.time),
+            channel=None,
+            size=len(json.dumps(content.model_dump())),
+            status_value="processed",
+            reception_time=timestamp_to_datetime(content.time),
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ipns_publish(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+):
+    """
+    Happy-path publish: message with ipns_record, verify OK, stats within quota.
+    After fetch+process: ipns_records row (resolved_cid=CID_V1, sequence=1, status=OK),
+    IpnsFilePinDb exists pointing at CID_V1.
+    """
+    handler, ipfs_service = _make_handler(mocker)
+    ipfs_service.verify_ipns_record = AsyncMock(
+        return_value=_record_info(CID_V1, sequence=1)
+    )
+    ipfs_service.pin_add = AsyncMock()
+    ipfs_service.put_ipns_record = AsyncMock()
+    _setup_stats_mock(ipfs_service, size=4 * 1024 * 1024)
+
+    content = _make_ipns_content()
+    message = _make_message_db(mocker, item_hash=MSG_HASH_1, content=content)
+
+    with patch(
+        "aleph.handlers.content.store._get_file_stats_from_ipfs",
+        new=AsyncMock(
+            return_value=IpfsFileStats(size=4 * 1024 * 1024, file_type=FileType.FILE)
+        ),
+    ):
+        with session_factory() as session:
+            await handler.fetch_related_content(session=session, message=message)
+            await handler.process(session=session, messages=[message])
+            session.commit()
+
+        with session_factory() as session:
+            record_db = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+            assert record_db is not None
+            assert record_db.resolved_cid == CID_V1
+            assert record_db.record_sequence == 1
+            assert record_db.status == IpnsStatus.OK
+            assert record_db.item_hash == MSG_HASH_1
+
+            pin = get_ipns_file_pin(session, name=IPNS_NAME, owner=OWNER)
+            assert pin is not None
+            assert pin.file_hash == CID_V1
+            assert pin.item_hash == MSG_HASH_1
+
+
+@pytest.mark.asyncio
+async def test_ipns_update_repoints_pin(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+):
+    """
+    Update: existing registration at seq=1/CID_V1. New message verifies to seq=2/CID_V2.
+    Pin re-points to CID_V2, old CID_V1 gets a grace-period pin.
+    """
+    handler, ipfs_service = _make_handler(mocker)
+    ipfs_service.verify_ipns_record = AsyncMock(
+        return_value=_record_info(CID_V2, sequence=2)
+    )
+    ipfs_service.pin_add = AsyncMock()
+    ipfs_service.put_ipns_record = AsyncMock()
+
+    with session_factory() as session:
+        # Seed registration at sequence=1 pointing at CID_V1.
+        _seed_ipns_record(
+            session, item_hash=MSG_HASH_1, resolved_cid=CID_V1, sequence=1
+        )
+        # Also seed a CID_V1 IPNS pin (as if the first message was already processed).
+        from aleph.db.accessors.files import insert_ipns_file_pin
+
+        insert_ipns_file_pin(
+            session=session,
+            file_hash=CID_V1,
+            owner=OWNER,
+            item_hash=MSG_HASH_1,
+            name=IPNS_NAME,
+            created=timestamp_to_datetime(MSG_TIME),
+        )
+        # Also seed CID_V2 as a stored file (to satisfy FK when upsert_file is called).
+        session.add(StoredFileDb(hash=CID_V2, size=5 * 1024 * 1024, type=FileType.FILE))
+        session.commit()
+
+    content = _make_ipns_content(max_size_mib=100)
+    message2 = _make_message_db(mocker, item_hash=MSG_HASH_2, content=content)
+
+    with patch(
+        "aleph.handlers.content.store._get_file_stats_from_ipfs",
+        new=AsyncMock(
+            return_value=IpfsFileStats(size=5 * 1024 * 1024, file_type=FileType.FILE)
+        ),
+    ):
+        with session_factory() as session:
+            await handler.fetch_related_content(session=session, message=message2)
+            await handler.process(session=session, messages=[message2])
+            session.commit()
+
+    with session_factory() as session:
+        # Pin must now point at CID_V2.
+        pin = get_ipns_file_pin(session, name=IPNS_NAME, owner=OWNER)
+        assert pin is not None
+        assert pin.file_hash == CID_V2
+        assert pin.item_hash == MSG_HASH_2
+
+        # CID_V1 has no more active pins, so it should have a grace-period pin.
+        cid_v1_file = session.execute(
+            select(StoredFileDb).where(StoredFileDb.hash == CID_V1)
+        ).scalar_one_or_none()
+        assert cid_v1_file is not None
+        grace_pins = [
+            p for p in cid_v1_file.pins if isinstance(p, GracePeriodFilePinDb)
+        ]
+        assert len(grace_pins) == 1
+
+
+@pytest.mark.asyncio
+async def test_ipns_stale_sequence_noop(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+):
+    """
+    Stale sequence: stored sequence=2, incoming verifies to sequence=1.
+    fetch_related_content returns without error; ipns_records unchanged.
+    """
+    handler, ipfs_service = _make_handler(mocker)
+    # Verify returns sequence=1 (stale vs stored sequence=2).
+    ipfs_service.verify_ipns_record = AsyncMock(
+        return_value=_record_info(CID_V1, sequence=1)
+    )
+    ipfs_service.pin_add = AsyncMock()
+    ipfs_service.put_ipns_record = AsyncMock()
+
+    with session_factory() as session:
+        _seed_ipns_record(
+            session, item_hash=MSG_HASH_1, resolved_cid=CID_V1, sequence=2
+        )
+        session.commit()
+
+    content = _make_ipns_content()
+    message = _make_message_db(mocker, item_hash=MSG_HASH_2, content=content)
+
+    with patch(
+        "aleph.handlers.content.store._get_file_stats_from_ipfs",
+        new=AsyncMock(
+            return_value=IpfsFileStats(size=4 * 1024 * 1024, file_type=FileType.FILE)
+        ),
+    ):
+        with session_factory() as session:
+            # Should not raise.
+            await handler.fetch_related_content(session=session, message=message)
+            session.commit()
+
+    with session_factory() as session:
+        # Record still points at original message.
+        record_db = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        assert record_db is not None
+        assert record_db.item_hash == MSG_HASH_1
+        assert record_db.record_sequence == 2
+
+    # pin_add must not have been called for the stale update.
+    ipfs_service.pin_add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ipns_track_only(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+):
+    """
+    Track-only flow: message has no ipns_record field.
+    resolve_ipns_record returns FAKE_RECORD; rest proceeds like publish.
+    """
+    handler, ipfs_service = _make_handler(mocker)
+    ipfs_service.resolve_ipns_record = AsyncMock(return_value=FAKE_RECORD)
+    ipfs_service.verify_ipns_record = AsyncMock(
+        return_value=_record_info(CID_V1, sequence=1)
+    )
+    ipfs_service.pin_add = AsyncMock()
+    ipfs_service.put_ipns_record = AsyncMock()
+
+    # No ipns_record field in the content.
+    content = _make_ipns_content(ipns_record=None)
+    message = _make_message_db(mocker, item_hash=MSG_HASH_1, content=content)
+
+    with patch(
+        "aleph.handlers.content.store._get_file_stats_from_ipfs",
+        new=AsyncMock(
+            return_value=IpfsFileStats(size=4 * 1024 * 1024, file_type=FileType.FILE)
+        ),
+    ):
+        with session_factory() as session:
+            await handler.fetch_related_content(session=session, message=message)
+            await handler.process(session=session, messages=[message])
+            session.commit()
+
+    # resolve_ipns_record should have been called with the name.
+    ipfs_service.resolve_ipns_record.assert_called_once_with(
+        IPNS_NAME, timeout=mock_config.ipfs.ipns.resolve_timeout.value
+    )
+
+    with session_factory() as session:
+        record_db = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        assert record_db is not None
+        assert record_db.resolved_cid == CID_V1
+
+
+@pytest.mark.asyncio
+async def test_ipns_track_only_dht_failure(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+):
+    """
+    Track-only: resolve_ipns_record raises IpnsResolutionError.
+    fetch_related_content must raise FileUnavailable.
+    """
+    handler, ipfs_service = _make_handler(mocker)
+    ipfs_service.resolve_ipns_record = AsyncMock(
+        side_effect=IpnsResolutionError("dht down")
+    )
+
+    content = _make_ipns_content(ipns_record=None)
+    message = _make_message_db(mocker, item_hash=MSG_HASH_1, content=content)
+
+    with session_factory() as session:
+        with pytest.raises(FileUnavailable):
+            await handler.fetch_related_content(session=session, message=message)
+
+
+@pytest.mark.asyncio
+async def test_ipns_invalid_record(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+):
+    """
+    verify_ipns_record raises InvalidIpnsRecordError.
+    fetch_related_content must raise InvalidMessageFormat.
+    """
+    from aleph.services.ipfs.service import InvalidIpnsRecordError
+
+    handler, ipfs_service = _make_handler(mocker)
+    ipfs_service.verify_ipns_record = AsyncMock(
+        side_effect=InvalidIpnsRecordError("bad sig")
+    )
+
+    content = _make_ipns_content()
+    message = _make_message_db(mocker, item_hash=MSG_HASH_1, content=content)
+
+    with session_factory() as session:
+        with pytest.raises(InvalidMessageFormat):
+            await handler.fetch_related_content(session=session, message=message)
+
+
+@pytest.mark.asyncio
+async def test_ipns_expired_record(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+):
+    """
+    verify_ipns_record returns a validity in the past.
+    fetch_related_content must raise InvalidMessageFormat.
+    """
+    past_validity = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+
+    handler, ipfs_service = _make_handler(mocker)
+    ipfs_service.verify_ipns_record = AsyncMock(
+        return_value=_record_info(CID_V1, sequence=1, validity=past_validity)
+    )
+
+    content = _make_ipns_content()
+    message = _make_message_db(mocker, item_hash=MSG_HASH_1, content=content)
+
+    with session_factory() as session:
+        with pytest.raises(InvalidMessageFormat):
+            await handler.fetch_related_content(session=session, message=message)
+
+
+@pytest.mark.asyncio
+async def test_ipns_over_quota(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+):
+    """
+    File stats size > max_size_mib * MiB.
+    fetch_related_content must raise InvalidMessageFormat.
+    """
+    handler, ipfs_service = _make_handler(mocker)
+    ipfs_service.verify_ipns_record = AsyncMock(
+        return_value=_record_info(CID_V1, sequence=1)
+    )
+    ipfs_service.pin_add = AsyncMock()
+
+    content = _make_ipns_content(max_size_mib=100)
+    message = _make_message_db(mocker, item_hash=MSG_HASH_1, content=content)
+
+    # 200 MiB file vs 100 MiB quota.
+    with patch(
+        "aleph.handlers.content.store._get_file_stats_from_ipfs",
+        new=AsyncMock(
+            return_value=IpfsFileStats(size=200 * 1024 * 1024, file_type=FileType.FILE)
+        ),
+    ):
+        with session_factory() as session:
+            with pytest.raises(InvalidMessageFormat):
+                await handler.fetch_related_content(session=session, message=message)
+
+
+@pytest.mark.asyncio
+async def test_ipns_forget_teardown(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+):
+    """
+    After a publish (test 1 flow), forget_message deletes ipns_records and pin;
+    CID_V1 gets a grace-period pin.
+    """
+    handler, ipfs_service = _make_handler(mocker)
+    ipfs_service.verify_ipns_record = AsyncMock(
+        return_value=_record_info(CID_V1, sequence=1)
+    )
+    ipfs_service.pin_add = AsyncMock()
+    ipfs_service.put_ipns_record = AsyncMock()
+
+    content = _make_ipns_content()
+    message = _make_message_db(mocker, item_hash=MSG_HASH_1, content=content)
+
+    with patch(
+        "aleph.handlers.content.store._get_file_stats_from_ipfs",
+        new=AsyncMock(
+            return_value=IpfsFileStats(size=4 * 1024 * 1024, file_type=FileType.FILE)
+        ),
+    ):
+        with session_factory() as session:
+            await handler.fetch_related_content(session=session, message=message)
+            await handler.process(session=session, messages=[message])
+            session.commit()
+
+        with session_factory() as session:
+            await handler.forget_message(session=session, message=message)
+            session.commit()
+
+    with session_factory() as session:
+        # ipns_records row deleted.
+        record_db = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        assert record_db is None
+
+        # IPNS pin deleted; CID_V1 should have a grace-period pin.
+        pin = get_ipns_file_pin(session, name=IPNS_NAME, owner=OWNER)
+        assert pin is None
+
+        cid_v1_file = session.execute(
+            select(StoredFileDb).where(StoredFileDb.hash == CID_V1)
+        ).scalar_one_or_none()
+        assert cid_v1_file is not None
+        grace_pins = [
+            p for p in cid_v1_file.pins if isinstance(p, GracePeriodFilePinDb)
+        ]
+        assert len(grace_pins) == 1
+
+
+@pytest.mark.asyncio
+async def test_ipns_forget_superseded_noop(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+):
+    """
+    After an update (test 2 scenario), forgetting the FIRST (superseded) message
+    leaves the registration and pin intact.
+    """
+    handler, ipfs_service = _make_handler(mocker)
+    ipfs_service.pin_add = AsyncMock()
+    ipfs_service.put_ipns_record = AsyncMock()
+
+    with session_factory() as session:
+        # State: registration now points at MSG_HASH_2 / CID_V2.
+        session.add(StoredFileDb(hash=CID_V2, size=5 * 1024 * 1024, type=FileType.FILE))
+        session.flush()
+        upsert_ipns_record(
+            session=session,
+            name=IPNS_NAME,
+            owner=OWNER,
+            item_hash=MSG_HASH_2,  # current winning message
+            record=FAKE_RECORD,
+            record_sequence=2,
+            record_validity=VALIDITY,
+            max_size_mib=100,
+            resolved_cid=CID_V2,
+            last_resolved=dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc),
+            status=IpnsStatus.OK,
+            created=timestamp_to_datetime(MSG_TIME),
+        )
+        from aleph.db.accessors.files import insert_ipns_file_pin
+
+        insert_ipns_file_pin(
+            session=session,
+            file_hash=CID_V2,
+            owner=OWNER,
+            item_hash=MSG_HASH_2,
+            name=IPNS_NAME,
+            created=timestamp_to_datetime(MSG_TIME),
+        )
+        session.commit()
+
+    # Forget the OLD (superseded) message 1.
+    content = _make_ipns_content()
+    old_message = _make_message_db(mocker, item_hash=MSG_HASH_1, content=content)
+
+    with session_factory() as session:
+        await handler.forget_message(session=session, message=old_message)
+        session.commit()
+
+    with session_factory() as session:
+        # Registration intact, pointing at MSG_HASH_2.
+        record_db = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        assert record_db is not None
+        assert record_db.item_hash == MSG_HASH_2
+
+        # Pin intact.
+        pin = get_ipns_file_pin(session, name=IPNS_NAME, owner=OWNER)
+        assert pin is not None
+        assert pin.file_hash == CID_V2
+
+
+@pytest.mark.asyncio
+async def test_ipns_cost_rows_migrate_on_update(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """
+    On update: AccountCostsDb rows for the superseded message are deleted;
+    the new registration remains intact.
+    """
+    from aleph_message.models import PaymentType
+
+    handler, ipfs_service = _make_handler(mocker)
+    ipfs_service.verify_ipns_record = AsyncMock(
+        return_value=_record_info(CID_V2, sequence=2)
+    )
+    ipfs_service.pin_add = AsyncMock()
+    ipfs_service.put_ipns_record = AsyncMock()
+
+    content1 = _make_ipns_content()
+    content2 = _make_ipns_content()
+
+    with session_factory() as session:
+        # Insert message 1 row (needed for FK on AccountCostsDb).
+        _insert_message_row(session, item_hash=MSG_HASH_1, content=content1)
+        session.flush()
+
+        # Seed registration pointing at message 1.
+        _seed_ipns_record(
+            session, item_hash=MSG_HASH_1, resolved_cid=CID_V1, sequence=1
+        )
+        session.flush()
+
+        # Seed a cost row for message 1.
+        session.add(
+            AccountCostsDb(
+                owner=OWNER,
+                item_hash=MSG_HASH_1,
+                type=CostType.STORAGE,
+                name="storage",
+                ref=None,
+                payment_type=PaymentType.hold,
+                cost_hold=Decimal("1.0"),
+                cost_stream=Decimal("0"),
+                cost_credit=Decimal("0"),
+            )
+        )
+        # Seed the IPNS file pin for message 1.
+        from aleph.db.accessors.files import insert_ipns_file_pin
+
+        insert_ipns_file_pin(
+            session=session,
+            file_hash=CID_V1,
+            owner=OWNER,
+            item_hash=MSG_HASH_1,
+            name=IPNS_NAME,
+            created=timestamp_to_datetime(MSG_TIME),
+        )
+        # Seed CID_V2 as a stored file.
+        session.add(StoredFileDb(hash=CID_V2, size=5 * 1024 * 1024, type=FileType.FILE))
+        session.commit()
+
+    message2 = _make_message_db(mocker, item_hash=MSG_HASH_2, content=content2)
+
+    with patch(
+        "aleph.handlers.content.store._get_file_stats_from_ipfs",
+        new=AsyncMock(
+            return_value=IpfsFileStats(size=5 * 1024 * 1024, file_type=FileType.FILE)
+        ),
+    ):
+        with session_factory() as session:
+            await handler.fetch_related_content(session=session, message=message2)
+            await handler.process(session=session, messages=[message2])
+            session.commit()
+
+    with session_factory() as session:
+        # Message 1 cost rows deleted.
+        costs_msg1 = (
+            session.execute(
+                select(AccountCostsDb).where(AccountCostsDb.item_hash == MSG_HASH_1)
+            )
+            .scalars()
+            .all()
+        )
+        assert len(costs_msg1) == 0
+
+        # Registration updated to message 2.
+        record_db = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        assert record_db is not None
+        assert record_db.item_hash == MSG_HASH_2

--- a/tests/services/test_cost_ipns.py
+++ b/tests/services/test_cost_ipns.py
@@ -1,0 +1,50 @@
+from decimal import Decimal
+
+import pytest
+from aleph_message.models import StoreContent
+
+from aleph.services.cost import get_total_and_detailed_costs
+from aleph.types.cost import CostType
+from aleph.types.db_session import DbSessionFactory
+
+IPNS_NAME = "k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8"
+MSG_HASH = "7f2d09b2c4e1a8f3d6b5c2e9a1f4d7b8e3c6a9f2d5b8e1c4a7f0d3b6e9c2a5f8"
+
+
+def _ipns_content(max_size_mib=100):
+    return StoreContent.model_validate(
+        {
+            "address": "0xA07B1214bAe0D5ccAA25449C3149c0aC83658874",
+            "time": 1780000000.0,
+            "item_type": "ipns",
+            "item_hash": IPNS_NAME,
+            "max_size_mib": max_size_mib,
+        }
+    )
+
+
+def test_ipns_costs_contain_quota_and_name_fee(session_factory: DbSessionFactory):
+    content = _ipns_content()
+    with session_factory() as session:
+        total, costs = get_total_and_detailed_costs(session, content, MSG_HASH)
+
+    cost_types = {cost.type for cost in costs}
+    assert CostType.STORAGE in cost_types
+    assert CostType.IPNS in cost_types
+    assert total > Decimal(0)
+
+    storage_cost = next(c for c in costs if c.type == CostType.STORAGE)
+    fee_cost = next(c for c in costs if c.type == CostType.IPNS)
+    assert storage_cost.cost_hold > Decimal(0)
+    assert fee_cost.cost_hold > Decimal(0)
+
+
+def test_ipns_costs_scale_with_quota(session_factory: DbSessionFactory):
+    with session_factory() as session:
+        total_small, _ = get_total_and_detailed_costs(
+            session, _ipns_content(max_size_mib=10), MSG_HASH
+        )
+        total_large, _ = get_total_and_detailed_costs(
+            session, _ipns_content(max_size_mib=1000), MSG_HASH
+        )
+    assert total_large > total_small

--- a/tests/services/test_cost_ipns.py
+++ b/tests/services/test_cost_ipns.py
@@ -48,3 +48,36 @@ def test_ipns_costs_scale_with_quota(session_factory: DbSessionFactory):
             session, _ipns_content(max_size_mib=1000), MSG_HASH
         )
     assert total_large > total_small
+
+
+def test_ipns_costs_credit_payment(session_factory):
+    content = StoreContent.model_validate(
+        {
+            "address": "0xA07B1214bAe0D5ccAA25449C3149c0aC83658874",
+            "time": 1780000000.0,
+            "item_type": "ipns",
+            "item_hash": IPNS_NAME,
+            "max_size_mib": 100,
+            "payment": {"chain": "ETH", "type": "credit"},
+        }
+    )
+    with session_factory() as session:
+        total, costs = get_total_and_detailed_costs(session, content, MSG_HASH)
+
+    fee_cost = next(c for c in costs if c.type == CostType.IPNS)
+    storage_cost = next(c for c in costs if c.type == CostType.STORAGE)
+    assert fee_cost.cost_credit > Decimal(0)
+    assert storage_cost.cost_credit > Decimal(0)
+    assert total > Decimal(0)
+
+
+def test_product_pricing_parses_fixed_fee():
+    from aleph.toolkit.constants import DEFAULT_PRICE_AGGREGATE, ProductPriceType
+    from aleph.types.cost import ProductPricing
+
+    pricing = ProductPricing.from_aggregate(
+        ProductPriceType.IPNS, DEFAULT_PRICE_AGGREGATE
+    )
+    assert pricing.price.fixed is not None
+    assert pricing.price.fixed.holding == Decimal("1")
+    assert pricing.price.fixed.credit == Decimal("0.5")

--- a/tests/services/test_ipfs_ipns.py
+++ b/tests/services/test_ipfs_ipns.py
@@ -1,0 +1,83 @@
+import base64
+import datetime as dt
+
+import pytest
+
+from aleph.services.ipfs.service import (
+    InvalidIpnsRecordError,
+    IpfsService,
+    IpnsRecordInfo,
+    IpnsResolutionError,
+)
+
+IPNS_NAME = "k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8"
+CID = "QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB"
+
+INSPECT_OK = {
+    "Entry": {
+        "Value": f"/ipfs/{CID}",
+        "ValidityType": 0,
+        "Validity": "2028-06-09T00:00:00Z",
+        "Sequence": 2,
+    },
+    "Validation": {"Valid": True, "Reason": ""},
+}
+
+
+@pytest.fixture
+def ipfs_service(mocker):
+    return IpfsService(
+        ipfs_client=mocker.AsyncMock(), pinning_client=mocker.AsyncMock()
+    )
+
+
+@pytest.mark.asyncio
+async def test_verify_ipns_record_ok(ipfs_service, mocker):
+    ipfs_service.storage_client.name.inspect = mocker.AsyncMock(return_value=INSPECT_OK)
+    info = await ipfs_service.verify_ipns_record(b"\x0a\x01raw", IPNS_NAME)
+    assert info == IpnsRecordInfo(
+        value_cid=CID,
+        sequence=2,
+        validity=dt.datetime(2028, 6, 9, tzinfo=dt.timezone.utc),
+    )
+    _, kwargs = ipfs_service.storage_client.name.inspect.call_args
+    assert kwargs["verify"] == IPNS_NAME
+
+
+@pytest.mark.asyncio
+async def test_verify_ipns_record_invalid_signature(ipfs_service, mocker):
+    bad = {**INSPECT_OK, "Validation": {"Valid": False, "Reason": "bad signature"}}
+    ipfs_service.storage_client.name.inspect = mocker.AsyncMock(return_value=bad)
+    with pytest.raises(InvalidIpnsRecordError, match="bad signature"):
+        await ipfs_service.verify_ipns_record(b"\x0a\x01raw", IPNS_NAME)
+
+
+@pytest.mark.asyncio
+async def test_verify_ipns_record_rejects_subpath_value(ipfs_service, mocker):
+    sub = {
+        **INSPECT_OK,
+        "Entry": {**INSPECT_OK["Entry"], "Value": f"/ipfs/{CID}/sub/path"},
+    }
+    ipfs_service.storage_client.name.inspect = mocker.AsyncMock(return_value=sub)
+    with pytest.raises(InvalidIpnsRecordError, match="sub-path"):
+        await ipfs_service.verify_ipns_record(b"\x0a\x01raw", IPNS_NAME)
+
+
+@pytest.mark.asyncio
+async def test_resolve_ipns_record_ok(ipfs_service, mocker):
+    raw = b"\x0a\x01record-bytes"
+    ipfs_service.storage_client.routing.get = mocker.AsyncMock(
+        return_value={"Extra": base64.b64encode(raw).decode(), "Type": 5}
+    )
+    record = await ipfs_service.resolve_ipns_record(IPNS_NAME, timeout=5)
+    assert record == raw
+    ipfs_service.storage_client.routing.get.assert_awaited_once_with(
+        f"/ipns/{IPNS_NAME}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_ipns_record_not_found(ipfs_service, mocker):
+    ipfs_service.storage_client.routing.get = mocker.AsyncMock(return_value=None)
+    with pytest.raises(IpnsResolutionError):
+        await ipfs_service.resolve_ipns_record(IPNS_NAME, timeout=5)

--- a/tests/services/test_ipfs_ipns.py
+++ b/tests/services/test_ipfs_ipns.py
@@ -1,6 +1,10 @@
+import asyncio
 import base64
 import datetime as dt
+import sys
+from unittest.mock import MagicMock
 
+import aioipfs
 import pytest
 
 from aleph.services.ipfs.service import (
@@ -42,6 +46,7 @@ async def test_verify_ipns_record_ok(ipfs_service, mocker):
     )
     _, kwargs = ipfs_service.storage_client.name.inspect.call_args
     assert kwargs["verify"] == IPNS_NAME
+    assert kwargs["dump"] is False
 
 
 @pytest.mark.asyncio
@@ -81,3 +86,66 @@ async def test_resolve_ipns_record_not_found(ipfs_service, mocker):
     ipfs_service.storage_client.routing.get = mocker.AsyncMock(return_value=None)
     with pytest.raises(IpnsResolutionError):
         await ipfs_service.resolve_ipns_record(IPNS_NAME, timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_verify_ipns_record_rejects_non_ipfs_value(ipfs_service, mocker):
+    bad = {
+        **INSPECT_OK,
+        "Entry": {**INSPECT_OK["Entry"], "Value": f"/ipns/{IPNS_NAME}"},
+    }
+    ipfs_service.storage_client.name.inspect = mocker.AsyncMock(return_value=bad)
+    with pytest.raises(InvalidIpnsRecordError, match="unsupported"):
+        await ipfs_service.verify_ipns_record(b"\x0a\x01raw", IPNS_NAME)
+
+
+@pytest.mark.asyncio
+async def test_resolve_ipns_record_timeout(ipfs_service, mocker):
+    async def hang(*args, **kwargs):
+        await asyncio.sleep(10)
+
+    ipfs_service.storage_client.routing.get = hang
+    with pytest.raises(IpnsResolutionError):
+        await ipfs_service.resolve_ipns_record(IPNS_NAME, timeout=0)
+
+
+@pytest.mark.asyncio
+async def test_resolve_ipns_record_api_error(ipfs_service, mocker):
+    ipfs_service.storage_client.routing.get = mocker.AsyncMock(
+        side_effect=aioipfs.APIError()
+    )
+    with pytest.raises(IpnsResolutionError):
+        await ipfs_service.resolve_ipns_record(IPNS_NAME, timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_put_ipns_record_posts_multipart(ipfs_service, mocker):
+    routing = ipfs_service.storage_client.routing
+    routing.url = mocker.Mock(return_value="http://ipfs/api/v0/routing/put")
+    routing.post = mocker.AsyncMock(return_value={})
+
+    # Mock tempfile
+    mock_file = MagicMock()
+    mock_file.name = "/tmp/mock_file"
+    mock_tempfile = MagicMock()
+    mock_tempfile.__enter__.return_value = mock_file
+    mock_tempfile.__exit__.return_value = None
+    mocker.patch("tempfile.NamedTemporaryFile", return_value=mock_tempfile)
+
+    # Mock aioipfs.multi.bytes_payload_from_file
+    mock_payload = MagicMock()
+    mocker.patch("aioipfs.multi.bytes_payload_from_file", return_value=mock_payload)
+
+    # Mock FormDataWriter
+    mock_writer = MagicMock()
+    mock_writer.__enter__.return_value = mock_writer
+    mock_writer.__exit__.return_value = None
+    mocker.patch("aioipfs.multi.FormDataWriter", return_value=mock_writer)
+
+    await ipfs_service.put_ipns_record(IPNS_NAME, b"\x0a\x01record-bytes")
+
+    routing.url.assert_called_once_with("routing/put")
+    args, kwargs = routing.post.call_args
+    assert args[0] == "http://ipfs/api/v0/routing/put"
+    assert kwargs["params"] == {"arg": f"/ipns/{IPNS_NAME}"}
+    assert kwargs["outformat"] == "json"

--- a/tests/services/test_ipns_republisher.py
+++ b/tests/services/test_ipns_republisher.py
@@ -1,0 +1,283 @@
+"""
+Tests for aleph.services.ipns.republisher.IpnsRepublisher.
+
+Five cases:
+1. Republish within validity  - put_ipns_record called, last_republished set.
+2. Expiry                     - past validity: status EXPIRED, put_ipns_record NOT called.
+3. Adopt newer record         - resolve returns seq+1: row updated, pin re-pointed, old CID grace-pinned.
+4. Newer record over quota    - stats exceed quota: OVER_QUOTA, resolved_cid unchanged, no grace pin.
+5. Resolution failure         - IpnsResolutionError: cycle completes, record still republished.
+"""
+
+import datetime as dt
+
+import pytest
+
+from aleph.db.accessors.files import (
+    get_ipns_file_pin,
+    insert_ipns_file_pin,
+    upsert_file,
+)
+from aleph.db.accessors.ipns import get_ipns_record, upsert_ipns_record
+from aleph.db.models.files import GracePeriodFilePinDb
+from aleph.services.ipfs.service import IpnsRecordInfo, IpnsResolutionError
+from aleph.services.ipns.republisher import IpnsRepublisher
+from aleph.types.db_session import DbSessionFactory
+from aleph.types.files import FileType
+from aleph.types.ipns import IpnsStatus
+
+IPNS_NAME = "k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8"
+OWNER = "0xA07B1214bAe0D5ccAA25449C3149c0aC83658874"
+ITEM_HASH = "abcd" * 16
+OLD_CID = "Qm" + "a" * 44
+NEW_CID = "Qm" + "b" * 44
+RECORD_BYTES = b"\x0a\x01record"
+NEW_RECORD_BYTES = b"\x0a\x02new-record"
+
+FUTURE = dt.datetime(2099, 1, 1, tzinfo=dt.timezone.utc)
+PAST = dt.datetime(2000, 1, 1, tzinfo=dt.timezone.utc)
+NOW = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+
+
+def _seed_record(
+    session_factory: DbSessionFactory,
+    *,
+    validity: dt.datetime,
+    record: bytes = RECORD_BYTES,
+    sequence: int = 1,
+    resolved_cid: str = OLD_CID,
+    status: IpnsStatus = IpnsStatus.OK,
+    max_size_mib: int = 100,
+) -> None:
+    with session_factory() as session:
+        # Ensure the old CID file exists so resolved_cid FK is satisfied.
+        upsert_file(
+            session=session,
+            file_hash=resolved_cid,
+            file_type=FileType.FILE,
+            size=1024,
+        )
+        session.flush()
+        upsert_ipns_record(
+            session=session,
+            name=IPNS_NAME,
+            owner=OWNER,
+            item_hash=ITEM_HASH,
+            record=record,
+            record_sequence=sequence,
+            record_validity=validity,
+            max_size_mib=max_size_mib,
+            resolved_cid=resolved_cid,
+            last_resolved=NOW,
+            status=status,
+            created=NOW,
+        )
+        session.flush()
+        insert_ipns_file_pin(
+            session=session,
+            file_hash=resolved_cid,
+            owner=OWNER,
+            item_hash=ITEM_HASH,
+            name=IPNS_NAME,
+            created=NOW,
+        )
+        session.commit()
+
+
+def _make_republisher(session_factory, ipfs_service):
+    return IpnsRepublisher(
+        session_factory=session_factory,
+        ipfs_service=ipfs_service,
+        grace_period_hours=24,
+        stat_timeout=10,
+        resolve_timeout=10,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 1: Republish within validity
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_republish_within_validity(session_factory: DbSessionFactory, mocker):
+    _seed_record(session_factory, validity=FUTURE)
+
+    ipfs_service = mocker.MagicMock()
+    ipfs_service.put_ipns_record = mocker.AsyncMock(return_value=None)
+    # resolve raises so _re_resolve is a no-op
+    ipfs_service.resolve_ipns_record = mocker.AsyncMock(
+        side_effect=IpnsResolutionError(IPNS_NAME)
+    )
+
+    republisher = _make_republisher(session_factory, ipfs_service)
+    await republisher.run_cycle()
+
+    ipfs_service.put_ipns_record.assert_awaited_once_with(IPNS_NAME, RECORD_BYTES)
+
+    with session_factory() as session:
+        row = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        assert row is not None
+        assert row.last_republished is not None
+        assert row.status == IpnsStatus.OK
+
+
+# ---------------------------------------------------------------------------
+# Case 2: Expiry - validity in the past
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_expiry_flips_status(session_factory: DbSessionFactory, mocker):
+    _seed_record(session_factory, validity=PAST)
+
+    ipfs_service = mocker.MagicMock()
+    ipfs_service.put_ipns_record = mocker.AsyncMock(return_value=None)
+    ipfs_service.resolve_ipns_record = mocker.AsyncMock(
+        side_effect=IpnsResolutionError(IPNS_NAME)
+    )
+
+    republisher = _make_republisher(session_factory, ipfs_service)
+    await republisher.run_cycle()
+
+    ipfs_service.put_ipns_record.assert_not_awaited()
+
+    with session_factory() as session:
+        row = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        assert row is not None
+        assert row.status == IpnsStatus.EXPIRED
+        assert row.resolved_cid == OLD_CID
+
+
+# ---------------------------------------------------------------------------
+# Case 3: Adopt newer record (within quota)
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_adopt_newer_record(session_factory: DbSessionFactory, mocker):
+    _seed_record(session_factory, validity=FUTURE, sequence=1)
+
+    ipfs_service = mocker.MagicMock()
+    ipfs_service.put_ipns_record = mocker.AsyncMock(return_value=None)
+    ipfs_service.resolve_ipns_record = mocker.AsyncMock(return_value=NEW_RECORD_BYTES)
+    ipfs_service.verify_ipns_record = mocker.AsyncMock(
+        return_value=IpnsRecordInfo(
+            value_cid=NEW_CID,
+            sequence=2,
+            validity=FUTURE,
+        )
+    )
+    ipfs_service.pin_add = mocker.AsyncMock(return_value=None)
+
+    from aleph.handlers.content.store import IpfsFileStats
+
+    mocker.patch(
+        "aleph.services.ipns.republisher._get_file_stats_from_ipfs",
+        return_value=IpfsFileStats(size=1024, file_type=FileType.FILE),
+    )
+
+    republisher = _make_republisher(session_factory, ipfs_service)
+    await republisher.run_cycle()
+
+    ipfs_service.pin_add.assert_awaited_once_with(cid=NEW_CID)
+
+    with session_factory() as session:
+        row = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        assert row is not None
+        assert row.resolved_cid == NEW_CID
+        assert row.record_sequence == 2
+        assert row.record == NEW_RECORD_BYTES
+        assert row.status == IpnsStatus.OK
+
+        pin = get_ipns_file_pin(session, name=IPNS_NAME, owner=OWNER)
+        assert pin is not None
+        assert pin.file_hash == NEW_CID
+
+        # Old CID should be grace-period-pinned (it has no other pin)
+        grace_pins = (
+            session.query(GracePeriodFilePinDb)
+            .filter(GracePeriodFilePinDb.file_hash == OLD_CID)
+            .all()
+        )
+        assert len(grace_pins) == 1
+        assert grace_pins[0].delete_by > dt.datetime.now(tz=dt.timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Case 4: Newer record over quota
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_newer_record_over_quota(session_factory: DbSessionFactory, mocker):
+    _seed_record(
+        session_factory, validity=FUTURE, sequence=1, max_size_mib=1
+    )  # 1 MiB quota
+
+    ipfs_service = mocker.MagicMock()
+    ipfs_service.put_ipns_record = mocker.AsyncMock(return_value=None)
+    ipfs_service.resolve_ipns_record = mocker.AsyncMock(return_value=NEW_RECORD_BYTES)
+    ipfs_service.verify_ipns_record = mocker.AsyncMock(
+        return_value=IpnsRecordInfo(
+            value_cid=NEW_CID,
+            sequence=2,
+            validity=FUTURE,
+        )
+    )
+    ipfs_service.pin_add = mocker.AsyncMock(return_value=None)
+
+    from aleph.handlers.content.store import IpfsFileStats
+
+    # 2 MiB > 1 MiB quota
+    mocker.patch(
+        "aleph.services.ipns.republisher._get_file_stats_from_ipfs",
+        return_value=IpfsFileStats(size=2 * 1024 * 1024, file_type=FileType.FILE),
+    )
+
+    republisher = _make_republisher(session_factory, ipfs_service)
+    await republisher.run_cycle()
+
+    # pin_add must NOT have been called for the over-quota CID
+    ipfs_service.pin_add.assert_not_awaited()
+
+    with session_factory() as session:
+        row = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        assert row is not None
+        assert row.status == IpnsStatus.OVER_QUOTA
+        # resolved_cid stays at old value (we did not update it)
+        assert row.resolved_cid == OLD_CID
+        # But sequence and record are updated so republish stays current
+        assert row.record_sequence == 2
+        assert row.record == NEW_RECORD_BYTES
+
+        pin = get_ipns_file_pin(session, name=IPNS_NAME, owner=OWNER)
+        assert pin is not None
+        assert pin.file_hash == OLD_CID  # pin not re-pointed
+
+        # No grace-period pin for OLD_CID
+        grace_pins = (
+            session.query(GracePeriodFilePinDb)
+            .filter(GracePeriodFilePinDb.file_hash == OLD_CID)
+            .all()
+        )
+        assert len(grace_pins) == 0
+
+
+# ---------------------------------------------------------------------------
+# Case 5: Resolution failure tolerated
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_resolution_failure_tolerated(session_factory: DbSessionFactory, mocker):
+    _seed_record(session_factory, validity=FUTURE)
+
+    ipfs_service = mocker.MagicMock()
+    ipfs_service.put_ipns_record = mocker.AsyncMock(return_value=None)
+    ipfs_service.resolve_ipns_record = mocker.AsyncMock(
+        side_effect=IpnsResolutionError(IPNS_NAME)
+    )
+
+    republisher = _make_republisher(session_factory, ipfs_service)
+    # Must not raise
+    await republisher.run_cycle()
+
+    # republish still happened
+    ipfs_service.put_ipns_record.assert_awaited_once_with(IPNS_NAME, RECORD_BYTES)
+
+    with session_factory() as session:
+        row = get_ipns_record(session, name=IPNS_NAME, owner=OWNER)
+        assert row is not None
+        assert row.last_republished is not None
+        assert row.status == IpnsStatus.OK

--- a/tests/services/test_ipns_republisher.py
+++ b/tests/services/test_ipns_republisher.py
@@ -281,3 +281,128 @@ async def test_resolution_failure_tolerated(session_factory: DbSessionFactory, m
         assert row is not None
         assert row.last_republished is not None
         assert row.status == IpnsStatus.OK
+
+
+# ---------------------------------------------------------------------------
+# Case 6: Isolation of per-record failures
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_per_record_failure_isolation(session_factory: DbSessionFactory, mocker):
+    """One record whose _re_resolve fails must not prevent processing of the next record."""
+    # Seed two records with different names
+    IPNS_NAME_1 = IPNS_NAME
+    IPNS_NAME_2 = "k51qzi5uqu5dgy0oo3su6gmrqe3typv1qfx4f2nltgaha8t77ai4rlbrwlqj66"
+
+    with session_factory() as session:
+        # First record
+        upsert_file(
+            session=session,
+            file_hash=OLD_CID,
+            file_type=FileType.FILE,
+            size=1024,
+        )
+        session.flush()
+        upsert_ipns_record(
+            session=session,
+            name=IPNS_NAME_1,
+            owner=OWNER,
+            item_hash=ITEM_HASH,
+            record=RECORD_BYTES,
+            record_sequence=1,
+            record_validity=FUTURE,
+            max_size_mib=100,
+            resolved_cid=OLD_CID,
+            last_resolved=NOW,
+            status=IpnsStatus.OK,
+            created=NOW,
+        )
+        session.flush()
+        insert_ipns_file_pin(
+            session=session,
+            file_hash=OLD_CID,
+            owner=OWNER,
+            item_hash=ITEM_HASH,
+            name=IPNS_NAME_1,
+            created=NOW,
+        )
+        session.flush()
+
+        # Second record (different name, different owner to avoid FK conflicts)
+        OWNER_2 = "0xB07B1214bAe0D5ccAA25449C3149c0aC83658875"
+        ITEM_HASH_2 = "dcba" * 16
+        upsert_file(
+            session=session,
+            file_hash=OLD_CID,
+            file_type=FileType.FILE,
+            size=1024,
+        )
+        session.flush()
+        upsert_ipns_record(
+            session=session,
+            name=IPNS_NAME_2,
+            owner=OWNER_2,
+            item_hash=ITEM_HASH_2,
+            record=RECORD_BYTES,
+            record_sequence=1,
+            record_validity=FUTURE,
+            max_size_mib=100,
+            resolved_cid=OLD_CID,
+            last_resolved=NOW,
+            status=IpnsStatus.OK,
+            created=NOW,
+        )
+        session.flush()
+        insert_ipns_file_pin(
+            session=session,
+            file_hash=OLD_CID,
+            owner=OWNER_2,
+            item_hash=ITEM_HASH_2,
+            name=IPNS_NAME_2,
+            created=NOW,
+        )
+        session.commit()
+
+    # Mock ipfs_service to raise for first name, succeed for second
+    ipfs_service = mocker.MagicMock()
+    ipfs_service.put_ipns_record = mocker.AsyncMock(return_value=None)
+
+    def resolve_side_effect(name, timeout=None):
+        if name == IPNS_NAME_1:
+            raise RuntimeError("Simulated _re_resolve failure for first record")
+        return NEW_RECORD_BYTES
+
+    ipfs_service.resolve_ipns_record = mocker.AsyncMock(side_effect=resolve_side_effect)
+    ipfs_service.verify_ipns_record = mocker.AsyncMock(
+        return_value=IpnsRecordInfo(
+            value_cid=NEW_CID,
+            sequence=2,
+            validity=FUTURE,
+        )
+    )
+    ipfs_service.pin_add = mocker.AsyncMock(return_value=None)
+
+    from aleph.handlers.content.store import IpfsFileStats
+
+    mocker.patch(
+        "aleph.services.ipns.republisher._get_file_stats_from_ipfs",
+        return_value=IpfsFileStats(size=1024, file_type=FileType.FILE),
+    )
+
+    republisher = _make_republisher(session_factory, ipfs_service)
+    # Must not raise despite first record's _re_resolve failure
+    await republisher.run_cycle()
+
+    # Second record should have been adopted successfully
+    with session_factory() as session:
+        row_1 = get_ipns_record(session, name=IPNS_NAME_1, owner=OWNER)
+        assert row_1 is not None
+        # First record still has old CID (exception prevented adoption)
+        assert row_1.resolved_cid == OLD_CID
+
+        row_2 = get_ipns_record(session, name=IPNS_NAME_2, owner=OWNER_2)
+        assert row_2 is not None
+        # Second record was adopted successfully despite first record's failure
+        assert row_2.resolved_cid == NEW_CID
+        assert row_2.record_sequence == 2
+        assert row_2.record == NEW_RECORD_BYTES
+        assert row_2.status == IpnsStatus.OK

--- a/tests/services/test_pricing_utils.py
+++ b/tests/services/test_pricing_utils.py
@@ -179,6 +179,7 @@ class TestBuildDefaultPricingModel:
             ProductPriceType.INSTANCE_GPU_PREMIUM,
             ProductPriceType.INSTANCE_CONFIDENTIAL,
             ProductPriceType.INSTANCE_GPU_STANDARD,
+            ProductPriceType.IPNS,
             ProductPriceType.WEB3_HOSTING,
         ]
 

--- a/tests/test_utils_ipns.py
+++ b/tests/test_utils_ipns.py
@@ -1,0 +1,18 @@
+import pytest
+from aleph_message.models import ItemType
+
+from aleph.exceptions import UnknownHashError
+from aleph.utils import item_type_from_hash
+
+IPNS_NAME = "k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8"
+
+
+def test_item_type_from_hash_ipns():
+    assert item_type_from_hash(IPNS_NAME) == ItemType.ipns
+
+
+def test_item_type_from_hash_rejects_bad_ipns_shapes():
+    with pytest.raises(UnknownHashError):
+        item_type_from_hash(IPNS_NAME[:-1])
+    with pytest.raises(UnknownHashError):
+        item_type_from_hash(IPNS_NAME.upper())

--- a/tests/test_utils_ipns.py
+++ b/tests/test_utils_ipns.py
@@ -15,4 +15,10 @@ def test_item_type_from_hash_rejects_bad_ipns_shapes():
     with pytest.raises(UnknownHashError):
         item_type_from_hash(IPNS_NAME[:-1])
     with pytest.raises(UnknownHashError):
+        item_type_from_hash(IPNS_NAME + "a")
+    with pytest.raises(UnknownHashError):
         item_type_from_hash(IPNS_NAME.upper())
+    with pytest.raises(UnknownHashError):
+        # Prefix intact, one uppercase char in the suffix: exercises the
+        # charset check independently of the prefix check.
+        item_type_from_hash(IPNS_NAME[:3] + IPNS_NAME[3].upper() + IPNS_NAME[4:])


### PR DESCRIPTION
## Summary

Adds first-class, paid IPNS name support to Aleph Cloud. A STORE message with the new `item_type: ipns` registers an IPNS name (`item_hash` is the base36 `k51...` name):

- **Publish**: the message carries a user-signed IPNS record (`ipns_record`, base64, 10 KiB cap). The node verifies it against the name via kubo, pins the record's value CID within the paid quota (`max_size_mib`), stores the registration in the new `ipns_records` table and injects the record into the DHT. No node ever holds a private key.
- **Update**: same message shape with a higher record sequence number. Updates self-order by sequence, so out-of-order processing needs no chain logic (`ref` is forbidden for IPNS content). The registration keeps exactly one re-pointable pin; replaced CIDs get the existing grace-period treatment and superseded messages stop billing.
- **Track-only**: omit `ipns_record` and the node fetches the current record from the DHT, then proceeds identically (keep-alive for names managed elsewhere).
- **Republish worker**: a periodic job (default 4h, `ipfs.ipns.*` config) re-injects records (kubo DHT records expire within ~24-48h) and re-resolves names to adopt newer records, with per-record failure isolation. Over-quota content keeps the last good CID pinned (`status=over_quota`); expired records stop republishing but stay pinned (`status=expired`).
- **API**: `GET /api/v0/ipns/{name}` (registration state, used by clients to bootstrap sequence numbers), `GET /api/v0/ipns/{name}/raw` (302 to `/api/v0/storage/raw/{cid}`), `GET /api/v0/addresses/{address}/ipns`. Registered names only: CCNs are not open IPNS resolvers.
- **Uploads**: `add_file`/`add_car` accept IPNS STORE metadata; the uploaded (root) CID must match the signed record's value instead of `item_hash`.
- **Pricing**: flat name fee (new `CostType.IPNS`, covers republish work) plus storage billed on the declared quota, so billing never changes without a message. Defaults live in `DEFAULT_PRICE_AGGREGATE` under the new `ipns` product and are tunable via the network pricing aggregate.

## Dependencies and rollout

- Depends on aleph-message branch [`ipns-support`](https://github.com/aleph-im/aleph-message/tree/ipns-support) (new `ItemType.ipns` shape rule + `StoreContent` fields), consumed as a git dependency in `pyproject.toml`. To be swapped for a released version once stabilized.
- Rollout note: nodes running released aleph-message reject IPNS STOREs as malformed (k51 names fail `ItemHash` validation), a clean failure. The network needs to upgrade before IPNS traffic flows, standard for additive message-type changes.
- Migration `0060_c7d2e9f4a1b8` creates `ipns_records`; `file_pins` gains only a new polymorphic type value.

## Test plan

- [x] aleph-message: 17 new unit tests (shape rule, StoreContent validators); suite at baseline (90 passed)
- [x] pyaleph: 44 new tests across models, accessors, IpfsService kubo wrappers, pricing, handler (publish/update/track/stale/forget/quota/cost-migration), republish worker, API endpoints, uploads
- [x] Full suite: 864 passed, 10 skipped; only pre-existing environmental errors (ethereum tests need a local anvil)
- [ ] End-to-end against a live kubo daemon (record signing via SDK, DHT round-trip)