### PR TITLE
feat(api): time-range filtering for the credit history endpoint

### DIFF
--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -847,6 +847,8 @@ def _apply_credit_history_filters(
     payment_method: Optional[str] = None,
     has_expiration: Optional[bool] = None,
     exclude_payment_method: Optional[List[str]] = None,
+    start_date: Optional[dt.datetime] = None,
+    end_date: Optional[dt.datetime] = None,
 ) -> Select:
     """Apply common filters to a credit history query."""
     if tx_hash is not None:
@@ -871,6 +873,10 @@ def _apply_credit_history_filters(
         query = query.where(
             AlephCreditHistoryDb.payment_method.notin_(exclude_payment_method)
         )
+    if start_date is not None:
+        query = query.where(AlephCreditHistoryDb.message_timestamp >= start_date)
+    if end_date is not None:
+        query = query.where(AlephCreditHistoryDb.message_timestamp <= end_date)
     return query
 
 
@@ -888,6 +894,8 @@ def get_address_credit_history(
     payment_method: Optional[str] = None,
     has_expiration: Optional[bool] = None,
     exclude_payment_method: Optional[List[str]] = None,
+    start_date: Optional[dt.datetime] = None,
+    end_date: Optional[dt.datetime] = None,
     sort_by: SortByCreditHistory = SortByCreditHistory.MESSAGE_TIMESTAMP,
     sort_order: SortOrder = SortOrder.DESCENDING,
     after_sort_value: Optional[Any] = None,
@@ -940,6 +948,8 @@ def get_address_credit_history(
         payment_method=payment_method,
         has_expiration=has_expiration,
         exclude_payment_method=exclude_payment_method,
+        start_date=start_date,
+        end_date=end_date,
     )
 
     # Cursor-based keyset pagination
@@ -1022,6 +1032,8 @@ def count_address_credit_history(
     payment_method: Optional[str] = None,
     has_expiration: Optional[bool] = None,
     exclude_payment_method: Optional[List[str]] = None,
+    start_date: Optional[dt.datetime] = None,
+    end_date: Optional[dt.datetime] = None,
 ) -> int:
     """
     Count total credit history entries for a specific address with optional filters.
@@ -1041,6 +1053,8 @@ def count_address_credit_history(
         payment_method=payment_method,
         has_expiration=has_expiration,
         exclude_payment_method=exclude_payment_method,
+        start_date=start_date,
+        end_date=end_date,
     )
 
     return session.execute(query).scalar_one()

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -173,15 +173,13 @@ class GetAccountCreditHistoryQueryParams(BaseModel):
         default=None,
         description="Exclude entries matching these payment methods (comma-separated).",
     )
-    start_date: Optional[float] = Field(
+    start_date: Optional[dt.datetime] = Field(
         default=None,
-        ge=0,
         description="Only return entries with message_timestamp greater than or "
         "equal to this Unix timestamp (seconds).",
     )
-    end_date: Optional[float] = Field(
+    end_date: Optional[dt.datetime] = Field(
         default=None,
-        ge=0,
         description="Only return entries with message_timestamp less than or "
         "equal to this Unix timestamp (seconds).",
     )
@@ -199,6 +197,18 @@ class GetAccountCreditHistoryQueryParams(BaseModel):
         if isinstance(v, str):
             return v.split(LIST_FIELD_SEPARATOR)
         return v
+
+    @field_validator("start_date", "end_date", mode="before")
+    def epoch_seconds_to_datetime(cls, v):
+        if v is None:
+            return None
+        value = float(v)
+        if value < 0:
+            raise ValueError("timestamp must not be negative")
+        try:
+            return dt.datetime.fromtimestamp(value, tz=dt.timezone.utc)
+        except (OverflowError, OSError, ValueError) as exc:
+            raise ValueError(f"invalid Unix timestamp: {v}") from exc
 
 
 class CreditHistoryResponseItem(BaseModel):

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -173,6 +173,18 @@ class GetAccountCreditHistoryQueryParams(BaseModel):
         default=None,
         description="Exclude entries matching these payment methods (comma-separated).",
     )
+    start_date: Optional[float] = Field(
+        default=None,
+        ge=0,
+        description="Only return entries with message_timestamp greater than or "
+        "equal to this Unix timestamp (seconds).",
+    )
+    end_date: Optional[float] = Field(
+        default=None,
+        ge=0,
+        description="Only return entries with message_timestamp less than or "
+        "equal to this Unix timestamp (seconds).",
+    )
     sort_by: SortByCreditHistory = Field(
         default=SortByCreditHistory.MESSAGE_TIMESTAMP,
         description="Field to sort by.",

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -3,7 +3,14 @@ from decimal import Decimal
 from typing import Annotated, Dict, List, Optional
 
 from aleph_message.models import Chain
-from pydantic import BaseModel, ConfigDict, Field, PlainSerializer, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PlainSerializer,
+    field_validator,
+    model_validator,
+)
 
 from aleph.schemas.messages_query_params import DEFAULT_PAGE, LIST_FIELD_SEPARATOR
 from aleph.types.files import FileType
@@ -213,6 +220,16 @@ class GetAccountCreditHistoryQueryParams(BaseModel):
             return dt.datetime.fromtimestamp(value, tz=dt.timezone.utc)
         except (OverflowError, OSError, ValueError) as exc:
             raise ValueError(f"invalid Unix timestamp: {v}") from exc
+
+    @model_validator(mode="after")
+    def validate_date_range(self):
+        if (
+            self.start_date is not None
+            and self.end_date is not None
+            and self.end_date < self.start_date
+        ):
+            raise ValueError("end date cannot be lower than start date.")
+        return self
 
 
 class CreditHistoryResponseItem(BaseModel):

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -175,11 +175,13 @@ class GetAccountCreditHistoryQueryParams(BaseModel):
     )
     start_date: Optional[dt.datetime] = Field(
         default=None,
+        alias="startDate",
         description="Only return entries with message_timestamp greater than or "
         "equal to this Unix timestamp (seconds).",
     )
     end_date: Optional[dt.datetime] = Field(
         default=None,
+        alias="endDate",
         description="Only return entries with message_timestamp less than or "
         "equal to this Unix timestamp (seconds).",
     )
@@ -191,6 +193,8 @@ class GetAccountCreditHistoryQueryParams(BaseModel):
         default=SortOrder.DESCENDING,
         description="Sort direction: 1 (ASC) or -1 (DESC).",
     )
+
+    model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("exclude_payment_method", mode="before")
     def split_exclude_payment_method(cls, v):

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -284,13 +284,6 @@ def _get_address_from_request(request: web.Request) -> str:
     return address
 
 
-def _utc_datetime_from_epoch(value: Optional[float]) -> Optional[dt.datetime]:
-    """Convert an epoch-seconds query param to an aware UTC datetime."""
-    if value is None:
-        return None
-    return dt.datetime.fromtimestamp(value, tz=dt.timezone.utc)
-
-
 def _get_chain_from_request(request: web.Request) -> str:
     chain = request.match_info.get("chain")
     if chain is None:
@@ -852,9 +845,6 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
     except ValidationError as e:
         raise web.HTTPUnprocessableEntity(text=e.json())
 
-    start_date = _utc_datetime_from_epoch(query_params.start_date)
-    end_date = _utc_datetime_from_epoch(query_params.end_date)
-
     cursor = query_params.cursor
     session_factory: DbSessionFactory = get_session_factory_from_request(request)
 
@@ -914,8 +904,8 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
                     payment_method=query_params.payment_method,
                     has_expiration=query_params.has_expiration,
                     exclude_payment_method=query_params.exclude_payment_method,
-                    start_date=start_date,
-                    end_date=end_date,
+                    start_date=query_params.start_date,
+                    end_date=query_params.end_date,
                     sort_by=query_params.sort_by,
                     sort_order=query_params.sort_order,
                     after_sort_value=after_sort_value,
@@ -988,8 +978,8 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             payment_method=query_params.payment_method,
             has_expiration=query_params.has_expiration,
             exclude_payment_method=query_params.exclude_payment_method,
-            start_date=start_date,
-            end_date=end_date,
+            start_date=query_params.start_date,
+            end_date=query_params.end_date,
             sort_by=query_params.sort_by,
             sort_order=query_params.sort_order,
         )
@@ -1009,8 +999,8 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             payment_method=query_params.payment_method,
             has_expiration=query_params.has_expiration,
             exclude_payment_method=query_params.exclude_payment_method,
-            start_date=start_date,
-            end_date=end_date,
+            start_date=query_params.start_date,
+            end_date=query_params.end_date,
         )
 
         # Convert to response items

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -804,12 +804,12 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
         schema:
           type: string
         description: "Comma-separated payment methods to exclude"
-      - name: start_date
+      - name: startDate
         in: query
         schema:
           type: number
         description: "Only return entries with message_timestamp >= this Unix timestamp (seconds)"
-      - name: end_date
+      - name: endDate
         in: query
         schema:
           type: number

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -284,6 +284,13 @@ def _get_address_from_request(request: web.Request) -> str:
     return address
 
 
+def _utc_datetime_from_epoch(value: Optional[float]) -> Optional[dt.datetime]:
+    """Convert an epoch-seconds query param to an aware UTC datetime."""
+    if value is None:
+        return None
+    return dt.datetime.fromtimestamp(value, tz=dt.timezone.utc)
+
+
 def _get_chain_from_request(request: web.Request) -> str:
     chain = request.match_info.get("chain")
     if chain is None:
@@ -804,6 +811,16 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
         schema:
           type: string
         description: "Comma-separated payment methods to exclude"
+      - name: start_date
+        in: query
+        schema:
+          type: number
+        description: "Only return entries with message_timestamp >= this Unix timestamp (seconds)"
+      - name: end_date
+        in: query
+        schema:
+          type: number
+        description: "Only return entries with message_timestamp <= this Unix timestamp (seconds)"
       - name: sort_by
         in: query
         schema:
@@ -834,6 +851,9 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
         query_params = GetAccountCreditHistoryQueryParams.model_validate(request.query)
     except ValidationError as e:
         raise web.HTTPUnprocessableEntity(text=e.json())
+
+    start_date = _utc_datetime_from_epoch(query_params.start_date)
+    end_date = _utc_datetime_from_epoch(query_params.end_date)
 
     cursor = query_params.cursor
     session_factory: DbSessionFactory = get_session_factory_from_request(request)
@@ -894,6 +914,8 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
                     payment_method=query_params.payment_method,
                     has_expiration=query_params.has_expiration,
                     exclude_payment_method=query_params.exclude_payment_method,
+                    start_date=start_date,
+                    end_date=end_date,
                     sort_by=query_params.sort_by,
                     sort_order=query_params.sort_order,
                     after_sort_value=after_sort_value,
@@ -966,6 +988,8 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             payment_method=query_params.payment_method,
             has_expiration=query_params.has_expiration,
             exclude_payment_method=query_params.exclude_payment_method,
+            start_date=start_date,
+            end_date=end_date,
             sort_by=query_params.sort_by,
             sort_order=query_params.sort_order,
         )
@@ -985,6 +1009,8 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             payment_method=query_params.payment_method,
             has_expiration=query_params.has_expiration,
             exclude_payment_method=query_params.exclude_payment_method,
+            start_date=start_date,
+            end_date=end_date,
         )
 
         # Convert to response items

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -40,11 +40,23 @@ async def test_credit_history_rejects_out_of_range_start_date(ccn_api_client):
 
 
 @pytest.mark.asyncio
-async def test_credit_history_snake_case_time_params_also_accepted(ccn_api_client):
+async def test_credit_history_validates_snake_case_params(ccn_api_client):
     # The model uses populate_by_name=True (mirroring the messages query params
     # convention), so snake_case spellings are also accepted as field names.
-    # A negative value is therefore still validated and returns 422.
+    # The 422 (rather than the 404 an unbound param would yield) proves the
+    # snake_case alias was bound and then validated against the negative value.
     response = await ccn_api_client.get(CREDIT_HISTORY_URI, params={"start_date": "-1"})
+    assert response.status == 422
+
+
+@pytest.mark.asyncio
+async def test_credit_history_rejects_inverted_date_range(ccn_api_client):
+    # Mirrors the messages query params convention: end_date < start_date is
+    # rejected up front rather than silently returning empty results.
+    response = await ccn_api_client.get(
+        CREDIT_HISTORY_URI,
+        params={"startDate": "1769000000", "endDate": "1768000000"},
+    )
     assert response.status == 422
 
 

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -1,4 +1,8 @@
+import datetime as dt
+
 import pytest
+
+from aleph.db.accessors.balances import update_credit_balances_distribution
 
 CREDIT_HISTORY_URI = "/api/v0/addresses/0xtest/credit_history"
 
@@ -25,3 +29,52 @@ async def test_credit_history_accepts_valid_time_filters(ccn_api_client):
         params={"start_date": "1768000000", "end_date": "1769000000"},
     )
     assert response.status == 404
+
+
+@pytest.mark.asyncio
+async def test_credit_history_rejects_out_of_range_start_date(ccn_api_client):
+    response = await ccn_api_client.get(
+        CREDIT_HISTORY_URI, params={"start_date": "1e308"}
+    )
+    assert response.status == 422
+
+
+@pytest.mark.asyncio
+async def test_credit_history_time_filter_filters_entries(
+    ccn_api_client, session_factory
+):
+    with session_factory() as session:
+        for month, message_hash in [(3, "e2e_dist_march"), (5, "e2e_dist_may")]:
+            update_credit_balances_distribution(
+                session=session,
+                credits_list=[
+                    {
+                        "address": "0xe2etimefilter",
+                        "amount": 1000,
+                        "price": "0.000001",
+                        "tx_hash": f"0xtx_{message_hash}",
+                        "provider": "test_provider",
+                        "expiration": None,
+                        "origin": "test_origin",
+                        "ref": f"ref_{message_hash}",
+                        "payment_method": "test_payment",
+                    }
+                ],
+                token="ALEPH",
+                chain="ETH",
+                message_hash=message_hash,
+                message_timestamp=dt.datetime(2026, month, 1, tzinfo=dt.timezone.utc),
+            )
+        session.commit()
+
+    # Window covering only the March entry
+    start = dt.datetime(2026, 2, 15, tzinfo=dt.timezone.utc).timestamp()
+    end = dt.datetime(2026, 4, 15, tzinfo=dt.timezone.utc).timestamp()
+    response = await ccn_api_client.get(
+        "/api/v0/addresses/0xe2etimefilter/credit_history",
+        params={"start_date": str(start), "end_date": str(end)},
+    )
+    assert response.status == 200
+    data = await response.json()
+    refs = [entry["credit_ref"] for entry in data["credit_history"]]
+    assert refs == ["e2e_dist_march"]

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -40,7 +40,7 @@ async def test_credit_history_rejects_out_of_range_start_date(ccn_api_client):
 
 
 @pytest.mark.asyncio
-async def test_credit_history_snake_case_time_params_are_ignored(ccn_api_client):
+async def test_credit_history_snake_case_time_params_also_accepted(ccn_api_client):
     # The model uses populate_by_name=True (mirroring the messages query params
     # convention), so snake_case spellings are also accepted as field names.
     # A negative value is therefore still validated and returns 422.

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -9,14 +9,14 @@ CREDIT_HISTORY_URI = "/api/v0/addresses/0xtest/credit_history"
 
 @pytest.mark.asyncio
 async def test_credit_history_rejects_negative_start_date(ccn_api_client):
-    response = await ccn_api_client.get(CREDIT_HISTORY_URI, params={"start_date": "-1"})
+    response = await ccn_api_client.get(CREDIT_HISTORY_URI, params={"startDate": "-1"})
     assert response.status == 422
 
 
 @pytest.mark.asyncio
 async def test_credit_history_rejects_non_numeric_end_date(ccn_api_client):
     response = await ccn_api_client.get(
-        CREDIT_HISTORY_URI, params={"end_date": "yesterday"}
+        CREDIT_HISTORY_URI, params={"endDate": "yesterday"}
     )
     assert response.status == 422
 
@@ -26,7 +26,7 @@ async def test_credit_history_accepts_valid_time_filters(ccn_api_client):
     # No data for this address: a valid filtered query returns 404, not 422.
     response = await ccn_api_client.get(
         CREDIT_HISTORY_URI,
-        params={"start_date": "1768000000", "end_date": "1769000000"},
+        params={"startDate": "1768000000", "endDate": "1769000000"},
     )
     assert response.status == 404
 
@@ -34,8 +34,17 @@ async def test_credit_history_accepts_valid_time_filters(ccn_api_client):
 @pytest.mark.asyncio
 async def test_credit_history_rejects_out_of_range_start_date(ccn_api_client):
     response = await ccn_api_client.get(
-        CREDIT_HISTORY_URI, params={"start_date": "1e308"}
+        CREDIT_HISTORY_URI, params={"startDate": "1e308"}
     )
+    assert response.status == 422
+
+
+@pytest.mark.asyncio
+async def test_credit_history_snake_case_time_params_are_ignored(ccn_api_client):
+    # The model uses populate_by_name=True (mirroring the messages query params
+    # convention), so snake_case spellings are also accepted as field names.
+    # A negative value is therefore still validated and returns 422.
+    response = await ccn_api_client.get(CREDIT_HISTORY_URI, params={"start_date": "-1"})
     assert response.status == 422
 
 
@@ -72,7 +81,7 @@ async def test_credit_history_time_filter_filters_entries(
     end = dt.datetime(2026, 4, 15, tzinfo=dt.timezone.utc).timestamp()
     response = await ccn_api_client.get(
         "/api/v0/addresses/0xe2etimefilter/credit_history",
-        params={"start_date": str(start), "end_date": str(end)},
+        params={"startDate": str(start), "endDate": str(end)},
     )
     assert response.status == 200
     data = await response.json()

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -1,0 +1,27 @@
+import pytest
+
+CREDIT_HISTORY_URI = "/api/v0/addresses/0xtest/credit_history"
+
+
+@pytest.mark.asyncio
+async def test_credit_history_rejects_negative_start_date(ccn_api_client):
+    response = await ccn_api_client.get(CREDIT_HISTORY_URI, params={"start_date": "-1"})
+    assert response.status == 422
+
+
+@pytest.mark.asyncio
+async def test_credit_history_rejects_non_numeric_end_date(ccn_api_client):
+    response = await ccn_api_client.get(
+        CREDIT_HISTORY_URI, params={"end_date": "yesterday"}
+    )
+    assert response.status == 422
+
+
+@pytest.mark.asyncio
+async def test_credit_history_accepts_valid_time_filters(ccn_api_client):
+    # No data for this address: a valid filtered query returns 404, not 422.
+    response = await ccn_api_client.get(
+        CREDIT_HISTORY_URI,
+        params={"start_date": "1768000000", "end_date": "1769000000"},
+    )
+    assert response.status == 404

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -2531,3 +2531,142 @@ def test_cursor_pagination_nullable_sort_nulls_on_last_page(
         )
         assert len(all_refs) == 5
         assert len(set(all_refs)) == 5
+
+
+def _insert_time_window_fixtures(session) -> None:
+    """Three credit_history rows for 0xtimefilter: distributions at
+    2026-03-01 and 2026-05-01, one expense at 2026-04-01. Timestamps are
+    after the 2026-02-02 precision cutoff so amounts are stored as-is."""
+    update_credit_balances_distribution(
+        session=session,
+        credits_list=[
+            {
+                "address": "0xtimefilter",
+                "amount": 1000,
+                "price": "0.000001",
+                "tx_hash": "0xtx_march",
+                "provider": "test_provider",
+                "expiration": None,
+                "origin": "test_origin",
+                "ref": "test_ref_march",
+                "payment_method": "credit_purchase",
+            }
+        ],
+        token="ALEPH",
+        chain="ETH",
+        message_hash="time_dist_march",
+        message_timestamp=dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc),
+    )
+    update_credit_balances_expense(
+        session=session,
+        credits_list=[
+            {
+                "address": "0xtimefilter",
+                "amount": 300,
+                "ref": "expense_ref",
+                "execution_id": "exec_1",
+                "node_id": "node_1",
+                "price": "0.000001",
+            }
+        ],
+        message_hash="time_expense_april",
+        message_timestamp=dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc),
+    )
+    update_credit_balances_distribution(
+        session=session,
+        credits_list=[
+            {
+                "address": "0xtimefilter",
+                "amount": 2000,
+                "price": "0.000001",
+                "tx_hash": "0xtx_may",
+                "provider": "test_provider",
+                "expiration": None,
+                "origin": "test_origin",
+                "ref": "test_ref_may",
+                "payment_method": "credit_purchase",
+            }
+        ],
+        token="ALEPH",
+        chain="ETH",
+        message_hash="time_dist_may",
+        message_timestamp=dt.datetime(2026, 5, 1, tzinfo=dt.timezone.utc),
+    )
+    session.commit()
+
+
+def test_get_address_credit_history_time_filters(session_factory: DbSessionFactory):
+    with session_factory() as session:
+        _insert_time_window_fixtures(session)
+
+        all_entries = get_address_credit_history(
+            session=session, address="0xtimefilter"
+        )
+        assert len(all_entries) == 3
+
+        after = get_address_credit_history(
+            session=session,
+            address="0xtimefilter",
+            start_date=dt.datetime(2026, 3, 15, tzinfo=dt.timezone.utc),
+        )
+        assert {e.credit_ref for e in after} == {
+            "time_expense_april",
+            "time_dist_may",
+        }
+
+        before = get_address_credit_history(
+            session=session,
+            address="0xtimefilter",
+            end_date=dt.datetime(2026, 3, 15, tzinfo=dt.timezone.utc),
+        )
+        assert [e.credit_ref for e in before] == ["time_dist_march"]
+
+        window = get_address_credit_history(
+            session=session,
+            address="0xtimefilter",
+            start_date=dt.datetime(2026, 3, 15, tzinfo=dt.timezone.utc),
+            end_date=dt.datetime(2026, 4, 15, tzinfo=dt.timezone.utc),
+        )
+        assert [e.credit_ref for e in window] == ["time_expense_april"]
+
+        # Bounds are inclusive on both ends
+        exact = get_address_credit_history(
+            session=session,
+            address="0xtimefilter",
+            start_date=dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc),
+            end_date=dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc),
+        )
+        assert [e.credit_ref for e in exact] == ["time_expense_april"]
+
+
+def test_count_address_credit_history_time_filters(session_factory: DbSessionFactory):
+    with session_factory() as session:
+        _insert_time_window_fixtures(session)
+
+        assert (
+            count_address_credit_history(session=session, address="0xtimefilter") == 3
+        )
+        assert (
+            count_address_credit_history(
+                session=session,
+                address="0xtimefilter",
+                start_date=dt.datetime(2026, 3, 15, tzinfo=dt.timezone.utc),
+            )
+            == 2
+        )
+        assert (
+            count_address_credit_history(
+                session=session,
+                address="0xtimefilter",
+                end_date=dt.datetime(2026, 3, 15, tzinfo=dt.timezone.utc),
+            )
+            == 1
+        )
+        assert (
+            count_address_credit_history(
+                session=session,
+                address="0xtimefilter",
+                start_date=dt.datetime(2026, 5, 2, tzinfo=dt.timezone.utc),
+            )
+            == 0
+        )


### PR DESCRIPTION
Adds optional start_date / end_date query params (Unix epoch seconds, inclusive bounds on message_timestamp) to GET /api/v0/addresses/{address}/credit_history. Applies to both pagination modes and to pagination_total. Epoch values are validated and converted to aware UTC datetimes in the pydantic schema, so malformed or out-of-range values (negative, non-numeric, inf, NaN) all return 422. Motivation: clients cannot currently answer 'what credit activity happened in the last N days' without paging through the entire history. message_timestamp is already indexed; no migration.