### PR TITLE
feat(api): direction (incoming/outgoing) filter for credit history

### DIFF
--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -18,6 +18,7 @@ from aleph.toolkit.constants import (
     CREDIT_PRECISION_MULTIPLIER,
 )
 from aleph.toolkit.timestamp import timestamp_to_datetime, utc_now
+from aleph.types.credit import CreditFlow
 from aleph.types.db_session import DbSession
 from aleph.types.sort_order import SortByCreditHistory, SortOrder
 
@@ -849,6 +850,7 @@ def _apply_credit_history_filters(
     exclude_payment_method: Optional[List[str]] = None,
     start_date: Optional[dt.datetime] = None,
     end_date: Optional[dt.datetime] = None,
+    direction: Optional[CreditFlow] = None,
 ) -> Select:
     """Apply common filters to a credit history query."""
     if tx_hash is not None:
@@ -877,6 +879,10 @@ def _apply_credit_history_filters(
         query = query.where(AlephCreditHistoryDb.message_timestamp >= start_date)
     if end_date is not None:
         query = query.where(AlephCreditHistoryDb.message_timestamp <= end_date)
+    if direction == CreditFlow.INCOMING:
+        query = query.where(AlephCreditHistoryDb.amount > 0)
+    elif direction == CreditFlow.OUTGOING:
+        query = query.where(AlephCreditHistoryDb.amount < 0)
     return query
 
 
@@ -896,6 +902,7 @@ def get_address_credit_history(
     exclude_payment_method: Optional[List[str]] = None,
     start_date: Optional[dt.datetime] = None,
     end_date: Optional[dt.datetime] = None,
+    direction: Optional[CreditFlow] = None,
     sort_by: SortByCreditHistory = SortByCreditHistory.MESSAGE_TIMESTAMP,
     sort_order: SortOrder = SortOrder.DESCENDING,
     after_sort_value: Optional[Any] = None,
@@ -950,6 +957,7 @@ def get_address_credit_history(
         exclude_payment_method=exclude_payment_method,
         start_date=start_date,
         end_date=end_date,
+        direction=direction,
     )
 
     # Cursor-based keyset pagination
@@ -1034,6 +1042,7 @@ def count_address_credit_history(
     exclude_payment_method: Optional[List[str]] = None,
     start_date: Optional[dt.datetime] = None,
     end_date: Optional[dt.datetime] = None,
+    direction: Optional[CreditFlow] = None,
 ) -> int:
     """
     Count total credit history entries for a specific address with optional filters.
@@ -1055,6 +1064,7 @@ def count_address_credit_history(
         exclude_payment_method=exclude_payment_method,
         start_date=start_date,
         end_date=end_date,
+        direction=direction,
     )
 
     return session.execute(query).scalar_one()

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -13,6 +13,7 @@ from pydantic import (
 )
 
 from aleph.schemas.messages_query_params import DEFAULT_PAGE, LIST_FIELD_SEPARATOR
+from aleph.types.credit import CreditFlow
 from aleph.types.files import FileType
 from aleph.types.sort_order import SortByCreditHistory, SortOrder
 
@@ -191,6 +192,12 @@ class GetAccountCreditHistoryQueryParams(BaseModel):
         alias="endDate",
         description="Only return entries with message_timestamp less than or "
         "equal to this Unix timestamp (seconds).",
+    )
+    direction: Optional[CreditFlow] = Field(
+        default=None,
+        description="Filter by entry direction: 'incoming' (amount > 0: "
+        "distributions, received transfers) or 'outgoing' (amount < 0: "
+        "expenses, sent transfers). Zero-amount entries match neither.",
     )
     sort_by: SortByCreditHistory = Field(
         default=SortByCreditHistory.MESSAGE_TIMESTAMP,

--- a/src/aleph/types/credit.py
+++ b/src/aleph/types/credit.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class CreditFlow(str, Enum):
+    """Sign-based classification of a credit history entry.
+
+    INCOMING: amount > 0 (distributions, received transfers).
+    OUTGOING: amount < 0 (expenses, sent transfers).
+    Zero-amount entries match neither flow.
+    """
+
+    INCOMING = "incoming"
+    OUTGOING = "outgoing"

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -814,6 +814,12 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
         schema:
           type: number
         description: "Only return entries with message_timestamp <= this Unix timestamp (seconds)"
+      - name: direction
+        in: query
+        schema:
+          type: string
+          enum: [incoming, outgoing]
+        description: "Filter by amount sign: incoming (> 0) or outgoing (< 0); zero-amount entries match neither"
       - name: sort_by
         in: query
         schema:
@@ -906,6 +912,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
                     exclude_payment_method=query_params.exclude_payment_method,
                     start_date=query_params.start_date,
                     end_date=query_params.end_date,
+                    direction=query_params.direction,
                     sort_by=query_params.sort_by,
                     sort_order=query_params.sort_order,
                     after_sort_value=after_sort_value,
@@ -980,6 +987,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             exclude_payment_method=query_params.exclude_payment_method,
             start_date=query_params.start_date,
             end_date=query_params.end_date,
+            direction=query_params.direction,
             sort_by=query_params.sort_by,
             sort_order=query_params.sort_order,
         )
@@ -1001,6 +1009,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             exclude_payment_method=query_params.exclude_payment_method,
             start_date=query_params.start_date,
             end_date=query_params.end_date,
+            direction=query_params.direction,
         )
 
         # Convert to response items

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -99,3 +99,20 @@ async def test_credit_history_time_filter_filters_entries(
     data = await response.json()
     refs = [entry["credit_ref"] for entry in data["credit_history"]]
     assert refs == ["e2e_dist_march"]
+
+
+@pytest.mark.asyncio
+async def test_credit_history_rejects_invalid_direction(ccn_api_client):
+    response = await ccn_api_client.get(
+        CREDIT_HISTORY_URI, params={"direction": "sideways"}
+    )
+    assert response.status == 422
+
+
+@pytest.mark.asyncio
+async def test_credit_history_accepts_valid_direction(ccn_api_client):
+    # No data for this address: a valid filtered query returns 404, not 422.
+    response = await ccn_api_client.get(
+        CREDIT_HISTORY_URI, params={"direction": "incoming"}
+    )
+    assert response.status == 404

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -2,7 +2,10 @@ import datetime as dt
 
 import pytest
 
-from aleph.db.accessors.balances import update_credit_balances_distribution
+from aleph.db.accessors.balances import (
+    update_credit_balances_distribution,
+    update_credit_balances_expense,
+)
 
 CREDIT_HISTORY_URI = "/api/v0/addresses/0xtest/credit_history"
 
@@ -110,9 +113,59 @@ async def test_credit_history_rejects_invalid_direction(ccn_api_client):
 
 
 @pytest.mark.asyncio
-async def test_credit_history_accepts_valid_direction(ccn_api_client):
-    # No data for this address: a valid filtered query returns 404, not 422.
-    response = await ccn_api_client.get(
-        CREDIT_HISTORY_URI, params={"direction": "incoming"}
-    )
-    assert response.status == 404
+async def test_credit_history_direction_filter_filters_entries(
+    ccn_api_client, session_factory
+):
+    with session_factory() as session:
+        update_credit_balances_distribution(
+            session=session,
+            credits_list=[
+                {
+                    "address": "0xe2edirection",
+                    "amount": 1000,
+                    "price": "0.000001",
+                    "tx_hash": "0xtx_e2e_dir",
+                    "provider": "test_provider",
+                    "expiration": None,
+                    "origin": "test_origin",
+                    "ref": "ref_e2e_dir",
+                    "payment_method": "test_payment",
+                }
+            ],
+            token="ALEPH",
+            chain="ETH",
+            message_hash="e2e_dir_dist",
+            message_timestamp=dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc),
+        )
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {
+                    "address": "0xe2edirection",
+                    "amount": 250,
+                    "ref": "expense_ref_e2e_dir",
+                    "execution_id": "exec_e2e_dir",
+                    "node_id": "node_e2e_dir",
+                    "price": "0.000001",
+                }
+            ],
+            message_hash="e2e_dir_expense",
+            message_timestamp=dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc),
+        )
+        session.commit()
+
+    uri = "/api/v0/addresses/0xe2edirection/credit_history"
+
+    response = await ccn_api_client.get(uri, params={"direction": "incoming"})
+    assert response.status == 200
+    data = await response.json()
+    refs = [entry["credit_ref"] for entry in data["credit_history"]]
+    assert refs == ["e2e_dir_dist"]
+    assert all(entry["amount"] > 0 for entry in data["credit_history"])
+
+    response = await ccn_api_client.get(uri, params={"direction": "outgoing"})
+    assert response.status == 200
+    data = await response.json()
+    refs = [entry["credit_ref"] for entry in data["credit_history"]]
+    assert refs == ["e2e_dir_expense"]
+    assert all(entry["amount"] < 0 for entry in data["credit_history"])

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -2766,3 +2766,23 @@ def test_credit_history_direction_filter_excludes_zero_amounts(
             )
             == 0
         )
+        assert (
+            list(
+                get_address_credit_history(
+                    session=session,
+                    address="0xzero_dir_recipient",
+                    direction=CreditFlow.INCOMING,
+                )
+            )
+            == []
+        )
+        assert (
+            list(
+                get_address_credit_history(
+                    session=session,
+                    address="0xzero_dir_recipient",
+                    direction=CreditFlow.OUTGOING,
+                )
+            )
+            == []
+        )

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -21,6 +21,7 @@ from aleph.db.accessors.balances import (
 )
 from aleph.db.models import AlephCreditBalanceDb, AlephCreditHistoryDb
 from aleph.repair import _rebuild_credit_lots_for_address
+from aleph.types.credit import CreditFlow
 from aleph.types.db_session import DbSessionFactory
 from aleph.types.sort_order import SortByCreditHistory, SortOrder
 
@@ -2669,4 +2670,61 @@ def test_count_address_credit_history_time_filters(session_factory: DbSessionFac
                 start_date=dt.datetime(2026, 5, 2, tzinfo=dt.timezone.utc),
             )
             == 0
+        )
+
+
+def test_get_address_credit_history_direction_filter(
+    session_factory: DbSessionFactory,
+):
+    with session_factory() as session:
+        _insert_time_window_fixtures(session)
+
+        incoming = get_address_credit_history(
+            session=session,
+            address="0xtimefilter",
+            direction=CreditFlow.INCOMING,
+        )
+        assert {e.credit_ref for e in incoming} == {"time_dist_march", "time_dist_may"}
+        assert all(e.amount > 0 for e in incoming)
+
+        outgoing = get_address_credit_history(
+            session=session,
+            address="0xtimefilter",
+            direction=CreditFlow.OUTGOING,
+        )
+        assert [e.credit_ref for e in outgoing] == ["time_expense_april"]
+        assert outgoing[0].amount < 0
+        assert outgoing[0].payment_method == "credit_expense"
+
+        # Composes with time filters
+        recent_incoming = get_address_credit_history(
+            session=session,
+            address="0xtimefilter",
+            direction=CreditFlow.INCOMING,
+            start_date=dt.datetime(2026, 4, 15, tzinfo=dt.timezone.utc),
+        )
+        assert [e.credit_ref for e in recent_incoming] == ["time_dist_may"]
+
+
+def test_count_address_credit_history_direction_filter(
+    session_factory: DbSessionFactory,
+):
+    with session_factory() as session:
+        _insert_time_window_fixtures(session)
+
+        assert (
+            count_address_credit_history(
+                session=session,
+                address="0xtimefilter",
+                direction=CreditFlow.INCOMING,
+            )
+            == 2
+        )
+        assert (
+            count_address_credit_history(
+                session=session,
+                address="0xtimefilter",
+                direction=CreditFlow.OUTGOING,
+            )
+            == 1
         )

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -2728,3 +2728,41 @@ def test_count_address_credit_history_direction_filter(
             )
             == 1
         )
+
+
+def test_credit_history_direction_filter_excludes_zero_amounts(
+    session_factory: DbSessionFactory,
+):
+    with session_factory() as session:
+        update_credit_balances_transfer(
+            session=session,
+            credits_list=[{"address": "0xzero_dir_recipient", "amount": 0}],
+            sender_address="0xzero_dir_sender",
+            whitelisted_addresses=["0xzero_dir_sender"],
+            message_hash="zero_amount_direction_msg",
+            message_timestamp=dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc),
+        )
+        session.commit()
+
+        unfiltered = get_address_credit_history(
+            session=session, address="0xzero_dir_recipient"
+        )
+        assert len(unfiltered) == 1
+        assert unfiltered[0].amount == 0
+
+        assert (
+            count_address_credit_history(
+                session=session,
+                address="0xzero_dir_recipient",
+                direction=CreditFlow.INCOMING,
+            )
+            == 0
+        )
+        assert (
+            count_address_credit_history(
+                session=session,
+                address="0xzero_dir_recipient",
+                direction=CreditFlow.OUTGOING,
+            )
+            == 0
+        )


### PR DESCRIPTION
Adds an optional direction=incoming|outgoing query param to GET /api/v0/addresses/{address}/credit_history, filtering on the sign of amount. payment_method alone cannot distinguish transfer-in from transfer-out and the set of top-up payment methods is open-ended, so a sign-based filter is the robust way to split top-ups from spending. Zero-amount entries match neither direction. Composes with the time filters: direction=incoming&startDate=... answers 'did this address top up in the last X days' in one request. Stacked on the time-filter PR (#1185).