### PR TITLE
feat(api): credit history summary endpoint

### DIFF
--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -5,10 +5,20 @@ import time
 from dataclasses import dataclass
 from decimal import Decimal
 from io import StringIO
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from aleph_message.models import Chain
-from sqlalchemy import func, select, text
+from sqlalchemy import case, func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.sql import ColumnElement, Select
 
@@ -1068,6 +1078,70 @@ def count_address_credit_history(
     )
 
     return session.execute(query).scalar_one()
+
+
+class CreditHistorySummary(NamedTuple):
+    entry_count: int
+    total_amount: int
+    total_incoming: int
+    total_outgoing: int
+
+
+def get_address_credit_history_summary(
+    session: DbSession,
+    address: str,
+    tx_hash: Optional[str] = None,
+    token: Optional[str] = None,
+    chain: Optional[str] = None,
+    provider: Optional[str] = None,
+    origin: Optional[str] = None,
+    origin_ref: Optional[str] = None,
+    payment_method: Optional[str] = None,
+    has_expiration: Optional[bool] = None,
+    exclude_payment_method: Optional[List[str]] = None,
+    start_date: Optional[dt.datetime] = None,
+    end_date: Optional[dt.datetime] = None,
+    direction: Optional[CreditFlow] = None,
+) -> CreditHistorySummary:
+    """
+    Aggregates over all credit history entries matching the filters, in a
+    single query. Pagination-independent. total_outgoing keeps its negative
+    sign so that total_amount == total_incoming + total_outgoing.
+    """
+    incoming_amount = case(
+        (AlephCreditHistoryDb.amount > 0, AlephCreditHistoryDb.amount), else_=0
+    )
+    outgoing_amount = case(
+        (AlephCreditHistoryDb.amount < 0, AlephCreditHistoryDb.amount), else_=0
+    )
+    query = select(
+        func.count().label("entry_count"),
+        func.coalesce(func.sum(AlephCreditHistoryDb.amount), 0).label("total_amount"),
+        func.coalesce(func.sum(incoming_amount), 0).label("total_incoming"),
+        func.coalesce(func.sum(outgoing_amount), 0).label("total_outgoing"),
+    ).where(AlephCreditHistoryDb.address == address)
+    query = _apply_credit_history_filters(
+        query,
+        tx_hash=tx_hash,
+        token=token,
+        chain=chain,
+        provider=provider,
+        origin=origin,
+        origin_ref=origin_ref,
+        payment_method=payment_method,
+        has_expiration=has_expiration,
+        exclude_payment_method=exclude_payment_method,
+        start_date=start_date,
+        end_date=end_date,
+        direction=direction,
+    )
+    row = session.execute(query).one()
+    return CreditHistorySummary(
+        entry_count=row.entry_count,
+        total_amount=row.total_amount,
+        total_incoming=row.total_incoming,
+        total_outgoing=row.total_outgoing,
+    )
 
 
 def get_total_consumed_credits(

--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -1138,9 +1138,9 @@ def get_address_credit_history_summary(
     row = session.execute(query).one()
     return CreditHistorySummary(
         entry_count=row.entry_count,
-        total_amount=row.total_amount,
-        total_incoming=row.total_incoming,
-        total_outgoing=row.total_outgoing,
+        total_amount=int(row.total_amount),
+        total_incoming=int(row.total_incoming),
+        total_outgoing=int(row.total_outgoing),
     )
 
 

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -146,18 +146,11 @@ class GetAccountFilesResponse(BaseModel):
     pagination_per_page: int
 
 
-class GetAccountCreditHistoryQueryParams(BaseModel):
-    pagination: int = Field(
-        default=0,
-        ge=0,
-        description="Maximum number of credit history entries to return. Specifying 0 returns all entries.",
-    )
-    page: int = Field(
-        default=DEFAULT_PAGE, ge=1, description="Offset in pages. Starts at 1."
-    )
-    cursor: Optional[str] = Field(
-        default=None, description="Opaque cursor for cursor-based pagination."
-    )
+class CreditHistoryFilterParams(BaseModel):
+    """Filters shared by the credit history listing and summary endpoints."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
     tx_hash: Optional[str] = Field(
         default=None, description="Filter by transaction hash"
     )
@@ -199,16 +192,6 @@ class GetAccountCreditHistoryQueryParams(BaseModel):
         "distributions, received transfers) or 'outgoing' (amount < 0: "
         "expenses, sent transfers). Zero-amount entries match neither.",
     )
-    sort_by: SortByCreditHistory = Field(
-        default=SortByCreditHistory.MESSAGE_TIMESTAMP,
-        description="Field to sort by.",
-    )
-    sort_order: SortOrder = Field(
-        default=SortOrder.DESCENDING,
-        description="Sort direction: 1 (ASC) or -1 (DESC).",
-    )
-
-    model_config = ConfigDict(populate_by_name=True)
 
     @field_validator("exclude_payment_method", mode="before")
     def split_exclude_payment_method(cls, v):
@@ -239,6 +222,32 @@ class GetAccountCreditHistoryQueryParams(BaseModel):
         return self
 
 
+class GetAccountCreditHistoryQueryParams(CreditHistoryFilterParams):
+    pagination: int = Field(
+        default=0,
+        ge=0,
+        description="Maximum number of credit history entries to return. Specifying 0 returns all entries.",
+    )
+    page: int = Field(
+        default=DEFAULT_PAGE, ge=1, description="Offset in pages. Starts at 1."
+    )
+    cursor: Optional[str] = Field(
+        default=None, description="Opaque cursor for cursor-based pagination."
+    )
+    sort_by: SortByCreditHistory = Field(
+        default=SortByCreditHistory.MESSAGE_TIMESTAMP,
+        description="Field to sort by.",
+    )
+    sort_order: SortOrder = Field(
+        default=SortOrder.DESCENDING,
+        description="Sort direction: 1 (ASC) or -1 (DESC).",
+    )
+
+
+class GetAccountCreditHistorySummaryQueryParams(CreditHistoryFilterParams):
+    """The summary endpoint takes only the shared filters."""
+
+
 class CreditHistoryResponseItem(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -264,6 +273,14 @@ class GetAccountCreditHistoryResponse(BaseModel):
     pagination_page: int
     pagination_total: int
     pagination_per_page: int
+
+
+class GetAccountCreditHistorySummaryResponse(BaseModel):
+    address: str
+    entry_count: int
+    total_amount: int
+    total_incoming: int
+    total_outgoing: int
 
 
 class GetResourceConsumedCreditsResponse(BaseModel):

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -13,6 +13,7 @@ from aleph.db.accessors.balances import (
     count_balances_by_chain,
     count_credit_balances,
     get_address_credit_history,
+    get_address_credit_history_summary,
     get_balances_by_chain,
     get_credit_balance,
     get_credit_balance_with_details,
@@ -37,6 +38,8 @@ from aleph.schemas.api.accounts import (
     GetAccountChannelsResponse,
     GetAccountCreditHistoryQueryParams,
     GetAccountCreditHistoryResponse,
+    GetAccountCreditHistorySummaryQueryParams,
+    GetAccountCreditHistorySummaryResponse,
     GetAccountFilesQueryParams,
     GetAccountFilesResponse,
     GetAccountFilesResponseItem,
@@ -1043,6 +1046,128 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
         )
 
         return web.json_response(text=response.model_dump_json())
+
+
+async def get_account_credit_history_summary(request: web.Request) -> web.Response:
+    """
+    Returns aggregate totals over an account's credit history.
+
+    Accepts the same filters as the credit history listing endpoint and
+    aggregates the whole filtered set in a single query. Always returns 200,
+    with zeros when no entry matches. total_outgoing keeps its negative sign
+    so that total_amount == total_incoming + total_outgoing.
+
+    ---
+    summary: Get account credit history summary
+    tags:
+      - Accounts
+    parameters:
+      - name: address
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: tx_hash
+        in: query
+        schema:
+          type: string
+      - name: token
+        in: query
+        schema:
+          type: string
+      - name: chain
+        in: query
+        schema:
+          type: string
+      - name: provider
+        in: query
+        schema:
+          type: string
+      - name: origin
+        in: query
+        schema:
+          type: string
+      - name: origin_ref
+        in: query
+        schema:
+          type: string
+      - name: payment_method
+        in: query
+        schema:
+          type: string
+      - name: has_expiration
+        in: query
+        schema:
+          type: boolean
+        description: "Filter by presence of expiration_date (true/false)"
+      - name: exclude_payment_method
+        in: query
+        schema:
+          type: string
+        description: "Comma-separated payment methods to exclude"
+      - name: startDate
+        in: query
+        schema:
+          type: number
+        description: "Only count entries with message_timestamp >= this Unix timestamp (seconds)"
+      - name: endDate
+        in: query
+        schema:
+          type: number
+        description: "Only count entries with message_timestamp <= this Unix timestamp (seconds)"
+      - name: direction
+        in: query
+        schema:
+          type: string
+          enum: [incoming, outgoing]
+        description: "Filter by amount sign: incoming (> 0) or outgoing (< 0); zero-amount entries match neither"
+    responses:
+      '200':
+        description: Aggregate totals over the filtered credit history
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetAccountCreditHistorySummaryResponse'
+      '422':
+        description: Validation error
+    """
+    address = _get_address_from_request(request)
+
+    try:
+        query_params = GetAccountCreditHistorySummaryQueryParams.model_validate(
+            request.query
+        )
+    except ValidationError as e:
+        raise web.HTTPUnprocessableEntity(text=e.json())
+
+    session_factory: DbSessionFactory = get_session_factory_from_request(request)
+
+    with session_factory() as session:
+        summary = get_address_credit_history_summary(
+            session=session,
+            address=address,
+            tx_hash=query_params.tx_hash,
+            token=query_params.token,
+            chain=query_params.chain,
+            provider=query_params.provider,
+            origin=query_params.origin,
+            origin_ref=query_params.origin_ref,
+            payment_method=query_params.payment_method,
+            has_expiration=query_params.has_expiration,
+            exclude_payment_method=query_params.exclude_payment_method,
+            start_date=query_params.start_date,
+            end_date=query_params.end_date,
+            direction=query_params.direction,
+        )
+
+    response = GetAccountCreditHistorySummaryResponse(
+        address=address,
+        entry_count=summary.entry_count,
+        total_amount=summary.total_amount,
+        total_incoming=summary.total_incoming,
+        total_outgoing=summary.total_outgoing,
+    )
+    return web.json_response(text=response.model_dump_json())
 
 
 async def get_resource_consumed_credits_controller(

--- a/src/aleph/web/controllers/components.yaml
+++ b/src/aleph/web/controllers/components.yaml
@@ -222,6 +222,20 @@ components:
         pagination_per_page:
           type: integer
 
+    GetAccountCreditHistorySummaryResponse:
+      type: object
+      properties:
+        address:
+          type: string
+        entry_count:
+          type: integer
+        total_amount:
+          type: integer
+        total_incoming:
+          type: integer
+        total_outgoing:
+          type: integer
+
     GetResourceConsumedCreditsResponse:
       type: object
       properties:

--- a/src/aleph/web/controllers/routes.py
+++ b/src/aleph/web/controllers/routes.py
@@ -130,6 +130,10 @@ def register_routes(app: web.Application, swagger: Optional[SwaggerDocs]):
             accounts.get_account_credit_history,
         ),
         web.get(
+            "/api/v0/addresses/{address}/credit_history/summary",
+            accounts.get_account_credit_history_summary,
+        ),
+        web.get(
             "/api/v0/messages/{item_hash}/consumed_credits",
             accounts.get_resource_consumed_credits_controller,
         ),

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -169,3 +169,36 @@ async def test_credit_history_direction_filter_filters_entries(
     refs = [entry["credit_ref"] for entry in data["credit_history"]]
     assert refs == ["e2e_dir_expense"]
     assert all(entry["amount"] < 0 for entry in data["credit_history"])
+
+
+CREDIT_HISTORY_SUMMARY_URI = "/api/v0/addresses/0xtest/credit_history/summary"
+
+
+@pytest.mark.asyncio
+async def test_credit_history_summary_returns_zeros_for_unknown_address(
+    ccn_api_client,
+):
+    response = await ccn_api_client.get(CREDIT_HISTORY_SUMMARY_URI)
+    assert response.status == 200
+    data = await response.json()
+    assert data["address"] == "0xtest"
+    assert data["entry_count"] == 0
+    assert data["total_amount"] == 0
+    assert data["total_incoming"] == 0
+    assert data["total_outgoing"] == 0
+
+
+@pytest.mark.asyncio
+async def test_credit_history_summary_rejects_negative_start_date(ccn_api_client):
+    response = await ccn_api_client.get(
+        CREDIT_HISTORY_SUMMARY_URI, params={"startDate": "-1"}
+    )
+    assert response.status == 422
+
+
+@pytest.mark.asyncio
+async def test_credit_history_summary_rejects_invalid_direction(ccn_api_client):
+    response = await ccn_api_client.get(
+        CREDIT_HISTORY_SUMMARY_URI, params={"direction": "sideways"}
+    )
+    assert response.status == 422

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -202,3 +202,66 @@ async def test_credit_history_summary_rejects_invalid_direction(ccn_api_client):
         CREDIT_HISTORY_SUMMARY_URI, params={"direction": "sideways"}
     )
     assert response.status == 422
+
+
+@pytest.mark.asyncio
+async def test_credit_history_summary_aggregates_entries(
+    ccn_api_client, session_factory
+):
+    with session_factory() as session:
+        update_credit_balances_distribution(
+            session=session,
+            credits_list=[
+                {
+                    "address": "0xe2esummary",
+                    "amount": 1000,
+                    "price": "0.000001",
+                    "tx_hash": "0xtx_e2e_summary",
+                    "provider": "test_provider",
+                    "expiration": None,
+                    "origin": "test_origin",
+                    "ref": "ref_e2e_summary",
+                    "payment_method": "test_payment",
+                }
+            ],
+            token="ALEPH",
+            chain="ETH",
+            message_hash="e2e_summary_dist",
+            message_timestamp=dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc),
+        )
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {
+                    "address": "0xe2esummary",
+                    "amount": 250,
+                    "ref": "expense_ref_e2e_summary",
+                    "execution_id": "exec_e2e_summary",
+                    "node_id": "node_e2e_summary",
+                    "price": "0.000001",
+                }
+            ],
+            message_hash="e2e_summary_expense",
+            message_timestamp=dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc),
+        )
+        session.commit()
+
+    uri = "/api/v0/addresses/0xe2esummary/credit_history/summary"
+
+    response = await ccn_api_client.get(uri)
+    assert response.status == 200
+    data = await response.json()
+    assert data["address"] == "0xe2esummary"
+    assert data["entry_count"] == 2
+    assert data["total_amount"] == 750
+    assert data["total_incoming"] == 1000
+    assert data["total_outgoing"] == -250
+
+    # A filter flows through to the aggregate
+    response = await ccn_api_client.get(uri, params={"direction": "outgoing"})
+    assert response.status == 200
+    data = await response.json()
+    assert data["entry_count"] == 1
+    assert data["total_amount"] == -250
+    assert data["total_incoming"] == 0
+    assert data["total_outgoing"] == -250

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -2788,6 +2788,14 @@ def test_credit_history_direction_filter_excludes_zero_amounts(
             == []
         )
 
+        zero_summary = get_address_credit_history_summary(
+            session=session, address="0xzero_dir_recipient"
+        )
+        assert zero_summary.entry_count == 1
+        assert zero_summary.total_amount == 0
+        assert zero_summary.total_incoming == 0
+        assert zero_summary.total_outgoing == 0
+
 
 def test_get_address_credit_history_summary(session_factory: DbSessionFactory):
     with session_factory() as session:
@@ -2801,6 +2809,10 @@ def test_get_address_credit_history_summary(session_factory: DbSessionFactory):
         assert summary.total_amount == 2700
         assert summary.total_incoming == 3000
         assert summary.total_outgoing == -300
+        assert summary.total_amount == summary.total_incoming + summary.total_outgoing
+        assert all(
+            isinstance(value, int) and not isinstance(value, bool) for value in summary
+        )
 
         # Composes with time filters
         window = get_address_credit_history_summary(
@@ -2813,6 +2825,7 @@ def test_get_address_credit_history_summary(session_factory: DbSessionFactory):
         assert window.total_amount == -300
         assert window.total_incoming == 0
         assert window.total_outgoing == -300
+        assert window.total_amount == window.total_incoming + window.total_outgoing
 
         # Composes with the direction filter
         outgoing_only = get_address_credit_history_summary(
@@ -2821,8 +2834,13 @@ def test_get_address_credit_history_summary(session_factory: DbSessionFactory):
             direction=CreditFlow.OUTGOING,
         )
         assert outgoing_only.entry_count == 1
+        assert outgoing_only.total_amount == -300
         assert outgoing_only.total_incoming == 0
         assert outgoing_only.total_outgoing == -300
+        assert (
+            outgoing_only.total_amount
+            == outgoing_only.total_incoming + outgoing_only.total_outgoing
+        )
 
         # Empty filtered set: all zeros, no error
         empty = get_address_credit_history_summary(session=session, address="0xnobody")

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -9,6 +9,7 @@ from sqlalchemy import update as sql_update
 from aleph.db.accessors.balances import (
     count_address_credit_history,
     get_address_credit_history,
+    get_address_credit_history_summary,
     get_consumed_credits_by_resource,
     get_credit_balance,
     get_credit_balance_with_details,
@@ -2786,3 +2787,46 @@ def test_credit_history_direction_filter_excludes_zero_amounts(
             )
             == []
         )
+
+
+def test_get_address_credit_history_summary(session_factory: DbSessionFactory):
+    with session_factory() as session:
+        # Rows for 0xtimefilter: +1000 (March), -300 (April), +2000 (May)
+        _insert_time_window_fixtures(session)
+
+        summary = get_address_credit_history_summary(
+            session=session, address="0xtimefilter"
+        )
+        assert summary.entry_count == 3
+        assert summary.total_amount == 2700
+        assert summary.total_incoming == 3000
+        assert summary.total_outgoing == -300
+
+        # Composes with time filters
+        window = get_address_credit_history_summary(
+            session=session,
+            address="0xtimefilter",
+            start_date=dt.datetime(2026, 3, 15, tzinfo=dt.timezone.utc),
+            end_date=dt.datetime(2026, 4, 15, tzinfo=dt.timezone.utc),
+        )
+        assert window.entry_count == 1
+        assert window.total_amount == -300
+        assert window.total_incoming == 0
+        assert window.total_outgoing == -300
+
+        # Composes with the direction filter
+        outgoing_only = get_address_credit_history_summary(
+            session=session,
+            address="0xtimefilter",
+            direction=CreditFlow.OUTGOING,
+        )
+        assert outgoing_only.entry_count == 1
+        assert outgoing_only.total_incoming == 0
+        assert outgoing_only.total_outgoing == -300
+
+        # Empty filtered set: all zeros, no error
+        empty = get_address_credit_history_summary(session=session, address="0xnobody")
+        assert empty.entry_count == 0
+        assert empty.total_amount == 0
+        assert empty.total_incoming == 0
+        assert empty.total_outgoing == 0


### PR DESCRIPTION
Adds GET /api/v0/addresses/{address}/credit_history/summary: aggregates over the whole filtered credit history in a single query, returning {address, entry_count, total_amount, total_incoming, total_outgoing}. It accepts exactly the listing endpoint's filters (extracted into a shared pydantic base class) but no pagination/sort/cursor params, and always returns 200 with zeros when nothing matches. Callers wanting totals do not need detail rows and vice versa, so a sibling endpoint with its own response shape keeps both endpoints simple. startDate=... answers 'how much did I spend in the last N hours' (total_outgoing) and 'did this address top up' (total_incoming) in one request. total_outgoing keeps its negative sign so total_amount == total_incoming + total_outgoing. Stacked on the direction-filter PR (#1186).