### PR TITLE
feat(api): resourceTypes filter for credit history (storage vs compute spend)

### DIFF
--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -17,12 +17,17 @@ from typing import (
     Union,
 )
 
-from aleph_message.models import Chain
+from aleph_message.models import Chain, MessageType
 from sqlalchemy import case, func, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.sql import ColumnElement, Select
 
-from aleph.db.models import AlephBalanceDb, AlephCreditBalanceDb, AlephCreditHistoryDb
+from aleph.db.models import (
+    AlephBalanceDb,
+    AlephCreditBalanceDb,
+    AlephCreditHistoryDb,
+    MessageDb,
+)
 from aleph.toolkit.constants import (
     CREDIT_PRECISION_CUTOFF_TIMESTAMP,
     CREDIT_PRECISION_MULTIPLIER,
@@ -861,6 +866,7 @@ def _apply_credit_history_filters(
     start_date: Optional[dt.datetime] = None,
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
+    origin_type: Optional[MessageType] = None,
 ) -> Select:
     """Apply common filters to a credit history query."""
     if tx_hash is not None:
@@ -893,6 +899,19 @@ def _apply_credit_history_filters(
         query = query.where(AlephCreditHistoryDb.amount > 0)
     elif direction == CreditFlow.OUTGOING:
         query = query.where(AlephCreditHistoryDb.amount < 0)
+    if origin_type is not None:
+        effective_origin = func.coalesce(
+            func.nullif(AlephCreditHistoryDb.origin, ""),
+            AlephCreditHistoryDb.origin_ref,
+        )
+        query = query.where(
+            select(MessageDb.item_hash)
+            .where(
+                (MessageDb.item_hash == effective_origin)
+                & (MessageDb.type == origin_type)
+            )
+            .exists()
+        )
     return query
 
 
@@ -913,6 +932,7 @@ def get_address_credit_history(
     start_date: Optional[dt.datetime] = None,
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
+    origin_type: Optional[MessageType] = None,
     sort_by: SortByCreditHistory = SortByCreditHistory.MESSAGE_TIMESTAMP,
     sort_order: SortOrder = SortOrder.DESCENDING,
     after_sort_value: Optional[Any] = None,
@@ -968,6 +988,7 @@ def get_address_credit_history(
         start_date=start_date,
         end_date=end_date,
         direction=direction,
+        origin_type=origin_type,
     )
 
     # Cursor-based keyset pagination
@@ -1053,6 +1074,7 @@ def count_address_credit_history(
     start_date: Optional[dt.datetime] = None,
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
+    origin_type: Optional[MessageType] = None,
 ) -> int:
     """
     Count total credit history entries for a specific address with optional filters.
@@ -1075,6 +1097,7 @@ def count_address_credit_history(
         start_date=start_date,
         end_date=end_date,
         direction=direction,
+        origin_type=origin_type,
     )
 
     return session.execute(query).scalar_one()
@@ -1102,6 +1125,7 @@ def get_address_credit_history_summary(
     start_date: Optional[dt.datetime] = None,
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
+    origin_type: Optional[MessageType] = None,
 ) -> CreditHistorySummary:
     """
     Aggregates over all credit history entries matching the filters, in a
@@ -1134,6 +1158,7 @@ def get_address_credit_history_summary(
         start_date=start_date,
         end_date=end_date,
         direction=direction,
+        origin_type=origin_type,
     )
     row = session.execute(query).one()
     return CreditHistorySummary(

--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -866,7 +866,7 @@ def _apply_credit_history_filters(
     start_date: Optional[dt.datetime] = None,
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
-    origin_type: Optional[MessageType] = None,
+    resource_types: Optional[List[MessageType]] = None,
 ) -> Select:
     """Apply common filters to a credit history query."""
     if tx_hash is not None:
@@ -899,7 +899,7 @@ def _apply_credit_history_filters(
         query = query.where(AlephCreditHistoryDb.amount > 0)
     elif direction == CreditFlow.OUTGOING:
         query = query.where(AlephCreditHistoryDb.amount < 0)
-    if origin_type is not None:
+    if resource_types:
         effective_origin = func.coalesce(
             func.nullif(AlephCreditHistoryDb.origin, ""),
             AlephCreditHistoryDb.origin_ref,
@@ -908,7 +908,7 @@ def _apply_credit_history_filters(
             select(MessageDb.item_hash)
             .where(
                 (MessageDb.item_hash == effective_origin)
-                & (MessageDb.type == origin_type)
+                & (MessageDb.type.in_(resource_types))
             )
             .exists()
         )
@@ -932,7 +932,7 @@ def get_address_credit_history(
     start_date: Optional[dt.datetime] = None,
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
-    origin_type: Optional[MessageType] = None,
+    resource_types: Optional[List[MessageType]] = None,
     sort_by: SortByCreditHistory = SortByCreditHistory.MESSAGE_TIMESTAMP,
     sort_order: SortOrder = SortOrder.DESCENDING,
     after_sort_value: Optional[Any] = None,
@@ -988,7 +988,7 @@ def get_address_credit_history(
         start_date=start_date,
         end_date=end_date,
         direction=direction,
-        origin_type=origin_type,
+        resource_types=resource_types,
     )
 
     # Cursor-based keyset pagination
@@ -1074,7 +1074,7 @@ def count_address_credit_history(
     start_date: Optional[dt.datetime] = None,
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
-    origin_type: Optional[MessageType] = None,
+    resource_types: Optional[List[MessageType]] = None,
 ) -> int:
     """
     Count total credit history entries for a specific address with optional filters.
@@ -1097,7 +1097,7 @@ def count_address_credit_history(
         start_date=start_date,
         end_date=end_date,
         direction=direction,
-        origin_type=origin_type,
+        resource_types=resource_types,
     )
 
     return session.execute(query).scalar_one()
@@ -1125,7 +1125,7 @@ def get_address_credit_history_summary(
     start_date: Optional[dt.datetime] = None,
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
-    origin_type: Optional[MessageType] = None,
+    resource_types: Optional[List[MessageType]] = None,
 ) -> CreditHistorySummary:
     """
     Aggregates over all credit history entries matching the filters, in a
@@ -1158,7 +1158,7 @@ def get_address_credit_history_summary(
         start_date=start_date,
         end_date=end_date,
         direction=direction,
-        origin_type=origin_type,
+        resource_types=resource_types,
     )
     row = session.execute(query).one()
     return CreditHistorySummary(

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -192,18 +192,19 @@ class CreditHistoryFilterParams(BaseModel):
         "distributions, received transfers) or 'outgoing' (amount < 0: "
         "expenses, sent transfers). Zero-amount entries match neither.",
     )
-    origin_type: Optional[MessageType] = Field(
+    resource_types: Optional[List[MessageType]] = Field(
         default=None,
-        alias="originType",
-        description="Filter by the message type of the billed resource "
-        "(e.g. STORE for storage, INSTANCE or PROGRAM for compute). Matches "
-        "the type of the message referenced by origin/origin_ref; entries "
-        "whose origin does not resolve to a known message (including "
-        "forgotten messages) never match.",
+        alias="resourceTypes",
+        description="Filter by the message type(s) of the billed resource, "
+        "comma-separated (e.g. STORE for storage, INSTANCE and PROGRAM for "
+        "compute). Matches the type of the message referenced by "
+        "origin/origin_ref; an entry matches if its resource type is any of "
+        "the given values. Entries whose origin does not resolve to a known "
+        "message (including forgotten messages) never match.",
     )
 
-    @field_validator("exclude_payment_method", mode="before")
-    def split_exclude_payment_method(cls, v):
+    @field_validator("exclude_payment_method", "resource_types", mode="before")
+    def split_comma_separated(cls, v):
         if isinstance(v, str):
             return v.split(LIST_FIELD_SEPARATOR)
         return v

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -2,7 +2,7 @@ import datetime as dt
 from decimal import Decimal
 from typing import Annotated, Dict, List, Optional
 
-from aleph_message.models import Chain
+from aleph_message.models import Chain, MessageType
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -191,6 +191,15 @@ class CreditHistoryFilterParams(BaseModel):
         description="Filter by entry direction: 'incoming' (amount > 0: "
         "distributions, received transfers) or 'outgoing' (amount < 0: "
         "expenses, sent transfers). Zero-amount entries match neither.",
+    )
+    origin_type: Optional[MessageType] = Field(
+        default=None,
+        alias="originType",
+        description="Filter by the message type of the billed resource "
+        "(e.g. STORE for storage, INSTANCE or PROGRAM for compute). Matches "
+        "the type of the message referenced by origin/origin_ref; entries "
+        "whose origin does not resolve to a known message (including "
+        "forgotten messages) never match.",
     )
 
     @field_validator("exclude_payment_method", mode="before")

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -823,6 +823,11 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
           type: string
           enum: [incoming, outgoing]
         description: "Filter by amount sign: incoming (> 0) or outgoing (< 0); zero-amount entries match neither"
+      - name: originType
+        in: query
+        schema:
+          type: string
+        description: "Filter by billed resource message type (e.g. STORE, INSTANCE, PROGRAM); entries with no resolvable resource match no type"
       - name: sort_by
         in: query
         schema:
@@ -916,6 +921,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
                     start_date=query_params.start_date,
                     end_date=query_params.end_date,
                     direction=query_params.direction,
+                    origin_type=query_params.origin_type,
                     sort_by=query_params.sort_by,
                     sort_order=query_params.sort_order,
                     after_sort_value=after_sort_value,
@@ -991,6 +997,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             start_date=query_params.start_date,
             end_date=query_params.end_date,
             direction=query_params.direction,
+            origin_type=query_params.origin_type,
             sort_by=query_params.sort_by,
             sort_order=query_params.sort_order,
         )
@@ -1013,6 +1020,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             start_date=query_params.start_date,
             end_date=query_params.end_date,
             direction=query_params.direction,
+            origin_type=query_params.origin_type,
         )
 
         # Convert to response items
@@ -1121,6 +1129,11 @@ async def get_account_credit_history_summary(request: web.Request) -> web.Respon
           type: string
           enum: [incoming, outgoing]
         description: "Filter by amount sign: incoming (> 0) or outgoing (< 0); zero-amount entries match neither"
+      - name: originType
+        in: query
+        schema:
+          type: string
+        description: "Filter by billed resource message type (e.g. STORE, INSTANCE, PROGRAM); entries with no resolvable resource match no type"
     responses:
       '200':
         description: Aggregate totals over the filtered credit history
@@ -1158,6 +1171,7 @@ async def get_account_credit_history_summary(request: web.Request) -> web.Respon
             start_date=query_params.start_date,
             end_date=query_params.end_date,
             direction=query_params.direction,
+            origin_type=query_params.origin_type,
         )
 
     response = GetAccountCreditHistorySummaryResponse(

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -823,12 +823,11 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
           type: string
           enum: [incoming, outgoing]
         description: "Filter by amount sign: incoming (> 0) or outgoing (< 0); zero-amount entries match neither"
-      - name: originType
+      - name: resourceTypes
         in: query
         schema:
           type: string
-          enum: [POST, AGGREGATE, STORE, PROGRAM, INSTANCE, FORGET]
-        description: "Filter by billed resource message type (e.g. STORE, INSTANCE, PROGRAM); entries with no resolvable resource match no type"
+        description: "Comma-separated billed resource message types to match (e.g. STORE for storage, INSTANCE,PROGRAM for compute); allowed values: POST, AGGREGATE, STORE, PROGRAM, INSTANCE, FORGET. Entries with no resolvable resource match no type"
       - name: sort_by
         in: query
         schema:
@@ -922,7 +921,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
                     start_date=query_params.start_date,
                     end_date=query_params.end_date,
                     direction=query_params.direction,
-                    origin_type=query_params.origin_type,
+                    resource_types=query_params.resource_types,
                     sort_by=query_params.sort_by,
                     sort_order=query_params.sort_order,
                     after_sort_value=after_sort_value,
@@ -998,7 +997,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             start_date=query_params.start_date,
             end_date=query_params.end_date,
             direction=query_params.direction,
-            origin_type=query_params.origin_type,
+            resource_types=query_params.resource_types,
             sort_by=query_params.sort_by,
             sort_order=query_params.sort_order,
         )
@@ -1021,7 +1020,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             start_date=query_params.start_date,
             end_date=query_params.end_date,
             direction=query_params.direction,
-            origin_type=query_params.origin_type,
+            resource_types=query_params.resource_types,
         )
 
         # Convert to response items
@@ -1130,12 +1129,11 @@ async def get_account_credit_history_summary(request: web.Request) -> web.Respon
           type: string
           enum: [incoming, outgoing]
         description: "Filter by amount sign: incoming (> 0) or outgoing (< 0); zero-amount entries match neither"
-      - name: originType
+      - name: resourceTypes
         in: query
         schema:
           type: string
-          enum: [POST, AGGREGATE, STORE, PROGRAM, INSTANCE, FORGET]
-        description: "Filter by billed resource message type (e.g. STORE, INSTANCE, PROGRAM); entries with no resolvable resource match no type"
+        description: "Comma-separated billed resource message types to match (e.g. STORE for storage, INSTANCE,PROGRAM for compute); allowed values: POST, AGGREGATE, STORE, PROGRAM, INSTANCE, FORGET. Entries with no resolvable resource match no type"
     responses:
       '200':
         description: Aggregate totals over the filtered credit history
@@ -1173,7 +1171,7 @@ async def get_account_credit_history_summary(request: web.Request) -> web.Respon
             start_date=query_params.start_date,
             end_date=query_params.end_date,
             direction=query_params.direction,
-            origin_type=query_params.origin_type,
+            resource_types=query_params.resource_types,
         )
 
     response = GetAccountCreditHistorySummaryResponse(

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -827,6 +827,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
         in: query
         schema:
           type: string
+          enum: [POST, AGGREGATE, STORE, PROGRAM, INSTANCE, FORGET]
         description: "Filter by billed resource message type (e.g. STORE, INSTANCE, PROGRAM); entries with no resolvable resource match no type"
       - name: sort_by
         in: query
@@ -1133,6 +1134,7 @@ async def get_account_credit_history_summary(request: web.Request) -> web.Respon
         in: query
         schema:
           type: string
+          enum: [POST, AGGREGATE, STORE, PROGRAM, INSTANCE, FORGET]
         description: "Filter by billed resource message type (e.g. STORE, INSTANCE, PROGRAM); entries with no resolvable resource match no type"
     responses:
       '200':

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -1,11 +1,13 @@
 import datetime as dt
 
 import pytest
+from aleph_message.models import Chain, ItemType, MessageType
 
 from aleph.db.accessors.balances import (
     update_credit_balances_distribution,
     update_credit_balances_expense,
 )
+from aleph.db.models import MessageDb
 
 CREDIT_HISTORY_URI = "/api/v0/addresses/0xtest/credit_history"
 
@@ -292,3 +294,91 @@ async def test_credit_history_summary_accepts_valid_origin_type(ccn_api_client):
     assert response.status == 200
     data = await response.json()
     assert data["entry_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_credit_history_origin_type_filter_filters_entries(
+    ccn_api_client, session_factory
+):
+    with session_factory() as session:
+        session.add(
+            MessageDb(
+                item_hash="e2e_store_resource",
+                chain=Chain.ETH,
+                sender="0xe2eorigintype",
+                signature=None,
+                item_type=ItemType.storage,
+                type=MessageType.store,
+                item_content=None,
+                content={"address": "0xe2eorigintype", "time": 1772323200.0},
+                size=100,
+                time=dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc),
+            )
+        )
+        session.add(
+            MessageDb(
+                item_hash="e2e_instance_resource",
+                chain=Chain.ETH,
+                sender="0xe2eorigintype",
+                signature=None,
+                item_type=ItemType.storage,
+                type=MessageType.instance,
+                item_content=None,
+                content={"address": "0xe2eorigintype", "time": 1772323200.0},
+                size=100,
+                time=dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc),
+            )
+        )
+        session.flush()
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {
+                    "address": "0xe2eorigintype",
+                    "amount": 100,
+                    "ref": "e2e_store_resource",
+                    "execution_id": "",
+                    "node_id": "node_e2e_ot_a",
+                    "price": "0.000001",
+                }
+            ],
+            message_hash="e2e_ot_expense_store",
+            message_timestamp=dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc),
+        )
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {
+                    "address": "0xe2eorigintype",
+                    "amount": 200,
+                    "ref": "",
+                    "execution_id": "e2e_instance_resource",
+                    "node_id": "node_e2e_ot_b",
+                    "price": "0.000001",
+                }
+            ],
+            message_hash="e2e_ot_expense_instance",
+            message_timestamp=dt.datetime(2026, 4, 2, tzinfo=dt.timezone.utc),
+        )
+        session.commit()
+
+    listing_uri = "/api/v0/addresses/0xe2eorigintype/credit_history"
+    summary_uri = "/api/v0/addresses/0xe2eorigintype/credit_history/summary"
+
+    response = await ccn_api_client.get(listing_uri, params={"originType": "STORE"})
+    assert response.status == 200
+    data = await response.json()
+    refs = [entry["credit_ref"] for entry in data["credit_history"]]
+    assert refs == ["e2e_ot_expense_store"]
+
+    response = await ccn_api_client.get(listing_uri, params={"originType": "INSTANCE"})
+    assert response.status == 200
+    data = await response.json()
+    refs = [entry["credit_ref"] for entry in data["credit_history"]]
+    assert refs == ["e2e_ot_expense_instance"]
+
+    response = await ccn_api_client.get(summary_uri, params={"originType": "INSTANCE"})
+    assert response.status == 200
+    data = await response.json()
+    assert data["entry_count"] == 1
+    assert data["total_amount"] == -200

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -265,3 +265,30 @@ async def test_credit_history_summary_aggregates_entries(
     assert data["total_amount"] == -250
     assert data["total_incoming"] == 0
     assert data["total_outgoing"] == -250
+
+
+@pytest.mark.asyncio
+async def test_credit_history_rejects_invalid_origin_type(ccn_api_client):
+    response = await ccn_api_client.get(
+        CREDIT_HISTORY_URI, params={"originType": "BANANA"}
+    )
+    assert response.status == 422
+
+
+@pytest.mark.asyncio
+async def test_credit_history_accepts_valid_origin_type(ccn_api_client):
+    # No data for this address: a valid filtered query returns 404, not 422.
+    response = await ccn_api_client.get(
+        CREDIT_HISTORY_URI, params={"originType": "INSTANCE"}
+    )
+    assert response.status == 404
+
+
+@pytest.mark.asyncio
+async def test_credit_history_summary_accepts_valid_origin_type(ccn_api_client):
+    response = await ccn_api_client.get(
+        CREDIT_HISTORY_SUMMARY_URI, params={"originType": "STORE"}
+    )
+    assert response.status == 200
+    data = await response.json()
+    assert data["entry_count"] == 0

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -270,26 +270,27 @@ async def test_credit_history_summary_aggregates_entries(
 
 
 @pytest.mark.asyncio
-async def test_credit_history_rejects_invalid_origin_type(ccn_api_client):
+async def test_credit_history_rejects_invalid_resource_type(ccn_api_client):
+    # An unknown value anywhere in the comma-separated list is rejected.
     response = await ccn_api_client.get(
-        CREDIT_HISTORY_URI, params={"originType": "BANANA"}
+        CREDIT_HISTORY_URI, params={"resourceTypes": "STORE,BANANA"}
     )
     assert response.status == 422
 
 
 @pytest.mark.asyncio
-async def test_credit_history_accepts_valid_origin_type(ccn_api_client):
+async def test_credit_history_accepts_valid_resource_types(ccn_api_client):
     # No data for this address: a valid filtered query returns 404, not 422.
     response = await ccn_api_client.get(
-        CREDIT_HISTORY_URI, params={"originType": "INSTANCE"}
+        CREDIT_HISTORY_URI, params={"resourceTypes": "INSTANCE,PROGRAM"}
     )
     assert response.status == 404
 
 
 @pytest.mark.asyncio
-async def test_credit_history_summary_accepts_valid_origin_type(ccn_api_client):
+async def test_credit_history_summary_accepts_valid_resource_types(ccn_api_client):
     response = await ccn_api_client.get(
-        CREDIT_HISTORY_SUMMARY_URI, params={"originType": "STORE"}
+        CREDIT_HISTORY_SUMMARY_URI, params={"resourceTypes": "STORE"}
     )
     assert response.status == 200
     data = await response.json()
@@ -297,7 +298,7 @@ async def test_credit_history_summary_accepts_valid_origin_type(ccn_api_client):
 
 
 @pytest.mark.asyncio
-async def test_credit_history_origin_type_filter_filters_entries(
+async def test_credit_history_resource_types_filter_filters_entries(
     ccn_api_client, session_factory
 ):
     with session_factory() as session:
@@ -365,19 +366,32 @@ async def test_credit_history_origin_type_filter_filters_entries(
     listing_uri = "/api/v0/addresses/0xe2eorigintype/credit_history"
     summary_uri = "/api/v0/addresses/0xe2eorigintype/credit_history/summary"
 
-    response = await ccn_api_client.get(listing_uri, params={"originType": "STORE"})
+    response = await ccn_api_client.get(listing_uri, params={"resourceTypes": "STORE"})
     assert response.status == 200
     data = await response.json()
     refs = [entry["credit_ref"] for entry in data["credit_history"]]
     assert refs == ["e2e_ot_expense_store"]
 
-    response = await ccn_api_client.get(listing_uri, params={"originType": "INSTANCE"})
+    response = await ccn_api_client.get(
+        listing_uri, params={"resourceTypes": "INSTANCE"}
+    )
     assert response.status == 200
     data = await response.json()
     refs = [entry["credit_ref"] for entry in data["credit_history"]]
     assert refs == ["e2e_ot_expense_instance"]
 
-    response = await ccn_api_client.get(summary_uri, params={"originType": "INSTANCE"})
+    # A comma-separated list matches entries of any of the given types.
+    response = await ccn_api_client.get(
+        listing_uri, params={"resourceTypes": "STORE,INSTANCE"}
+    )
+    assert response.status == 200
+    data = await response.json()
+    refs = {entry["credit_ref"] for entry in data["credit_history"]}
+    assert refs == {"e2e_ot_expense_store", "e2e_ot_expense_instance"}
+
+    response = await ccn_api_client.get(
+        summary_uri, params={"resourceTypes": "INSTANCE"}
+    )
     assert response.status == 200
     data = await response.json()
     assert data["entry_count"] == 1

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -2851,10 +2851,10 @@ def test_get_address_credit_history_summary(session_factory: DbSessionFactory):
         assert empty.total_outgoing == 0
 
 
-# ── origin_type filter tests ───────────────────────────────────────────
+# ── resource_types filter tests ───────────────────────────────────────────
 
 
-def _insert_origin_type_fixtures(session) -> None:
+def _insert_resource_type_fixtures(session) -> None:
     """Two resource messages (one STORE, one INSTANCE) and one expense row
     billed against each, plus a third unresolvable expense, for address 0xorigintype."""
     session.add(
@@ -2900,7 +2900,7 @@ def _insert_origin_type_fixtures(session) -> None:
                 "price": "0.000001",
             }
         ],
-        message_hash="origin_type_expense_store",
+        message_hash="resource_type_expense_store",
         message_timestamp=dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc),
     )
     # Instance billing: resource referenced via execution_id (origin)
@@ -2916,7 +2916,7 @@ def _insert_origin_type_fixtures(session) -> None:
                 "price": "0.000001",
             }
         ],
-        message_hash="origin_type_expense_instance",
+        message_hash="resource_type_expense_instance",
         message_timestamp=dt.datetime(2026, 4, 2, tzinfo=dt.timezone.utc),
     )
     # Unresolvable billing reference: effective origin is '' and matches no message
@@ -2932,37 +2932,37 @@ def _insert_origin_type_fixtures(session) -> None:
                 "price": "0.000001",
             }
         ],
-        message_hash="origin_type_expense_unresolvable",
+        message_hash="resource_type_expense_unresolvable",
         message_timestamp=dt.datetime(2026, 4, 3, tzinfo=dt.timezone.utc),
     )
     session.commit()
 
 
-def test_get_address_credit_history_origin_type_filter(
+def test_get_address_credit_history_resource_types_filter(
     session_factory: DbSessionFactory,
 ):
     with session_factory() as session:
-        _insert_origin_type_fixtures(session)
+        _insert_resource_type_fixtures(session)
 
         storage = get_address_credit_history(
             session=session,
             address="0xorigintype",
-            origin_type=MessageType.store,
+            resource_types=[MessageType.store],
         )
-        assert [e.credit_ref for e in storage] == ["origin_type_expense_store"]
+        assert [e.credit_ref for e in storage] == ["resource_type_expense_store"]
 
         compute = get_address_credit_history(
             session=session,
             address="0xorigintype",
-            origin_type=MessageType.instance,
+            resource_types=[MessageType.instance],
         )
-        assert [e.credit_ref for e in compute] == ["origin_type_expense_instance"]
+        assert [e.credit_ref for e in compute] == ["resource_type_expense_instance"]
 
         assert (
             count_address_credit_history(
                 session=session,
                 address="0xorigintype",
-                origin_type=MessageType.instance,
+                resource_types=[MessageType.instance],
             )
             == 1
         )
@@ -2971,10 +2971,21 @@ def test_get_address_credit_history_origin_type_filter(
         instance_summary = get_address_credit_history_summary(
             session=session,
             address="0xorigintype",
-            origin_type=MessageType.instance,
+            resource_types=[MessageType.instance],
         )
         assert instance_summary.entry_count == 1
         assert instance_summary.total_amount == -200
+
+        # A list matches entries whose resource is any of the given types
+        both = get_address_credit_history(
+            session=session,
+            address="0xorigintype",
+            resource_types=[MessageType.store, MessageType.instance],
+        )
+        assert {e.credit_ref for e in both} == {
+            "resource_type_expense_store",
+            "resource_type_expense_instance",
+        }
 
         # No PROGRAM resources billed for this address
         assert (
@@ -2982,7 +2993,7 @@ def test_get_address_credit_history_origin_type_filter(
                 get_address_credit_history(
                     session=session,
                     address="0xorigintype",
-                    origin_type=MessageType.program,
+                    resource_types=[MessageType.program],
                 )
             )
             == []
@@ -2992,7 +3003,7 @@ def test_get_address_credit_history_origin_type_filter(
         unfiltered = get_address_credit_history(session=session, address="0xorigintype")
         assert len(unfiltered) == 3
 
-        # The unresolvable row matches no origin_type value
+        # The unresolvable row matches no resource_types value
         for message_type in (
             MessageType.store,
             MessageType.instance,
@@ -3003,7 +3014,7 @@ def test_get_address_credit_history_origin_type_filter(
                 for e in get_address_credit_history(
                     session=session,
                     address="0xorigintype",
-                    origin_type=message_type,
+                    resource_types=[message_type],
                 )
             ]
-            assert "origin_type_expense_unresolvable" not in refs
+            assert "resource_type_expense_unresolvable" not in refs

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -2856,7 +2856,7 @@ def test_get_address_credit_history_summary(session_factory: DbSessionFactory):
 
 def _insert_origin_type_fixtures(session) -> None:
     """Two resource messages (one STORE, one INSTANCE) and one expense row
-    billed against each, for address 0xorigintype."""
+    billed against each, plus a third unresolvable expense, for address 0xorigintype."""
     session.add(
         MessageDb(
             item_hash="store_resource_hash",
@@ -2919,6 +2919,22 @@ def _insert_origin_type_fixtures(session) -> None:
         message_hash="origin_type_expense_instance",
         message_timestamp=dt.datetime(2026, 4, 2, tzinfo=dt.timezone.utc),
     )
+    # Unresolvable billing reference: effective origin is '' and matches no message
+    update_credit_balances_expense(
+        session=session,
+        credits_list=[
+            {
+                "address": "0xorigintype",
+                "amount": 50,
+                "ref": "",
+                "execution_id": "",
+                "node_id": "node_c",
+                "price": "0.000001",
+            }
+        ],
+        message_hash="origin_type_expense_unresolvable",
+        message_timestamp=dt.datetime(2026, 4, 3, tzinfo=dt.timezone.utc),
+    )
     session.commit()
 
 
@@ -2971,3 +2987,23 @@ def test_get_address_credit_history_origin_type_filter(
             )
             == []
         )
+
+        # Unfiltered: all three expense rows, including the unresolvable one
+        unfiltered = get_address_credit_history(session=session, address="0xorigintype")
+        assert len(unfiltered) == 3
+
+        # The unresolvable row matches no origin_type value
+        for message_type in (
+            MessageType.store,
+            MessageType.instance,
+            MessageType.program,
+        ):
+            refs = [
+                e.credit_ref
+                for e in get_address_credit_history(
+                    session=session,
+                    address="0xorigintype",
+                    origin_type=message_type,
+                )
+            ]
+            assert "origin_type_expense_unresolvable" not in refs

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -3,6 +3,7 @@ import time
 from decimal import Decimal
 from typing import Any, Dict, List
 
+from aleph_message.models import Chain, ItemType, MessageType
 from sqlalchemy import select
 from sqlalchemy import update as sql_update
 
@@ -20,7 +21,7 @@ from aleph.db.accessors.balances import (
     update_credit_balances_transfer,
     validate_credit_transfer_balance,
 )
-from aleph.db.models import AlephCreditBalanceDb, AlephCreditHistoryDb
+from aleph.db.models import AlephCreditBalanceDb, AlephCreditHistoryDb, MessageDb
 from aleph.repair import _rebuild_credit_lots_for_address
 from aleph.types.credit import CreditFlow
 from aleph.types.db_session import DbSessionFactory
@@ -2848,3 +2849,125 @@ def test_get_address_credit_history_summary(session_factory: DbSessionFactory):
         assert empty.total_amount == 0
         assert empty.total_incoming == 0
         assert empty.total_outgoing == 0
+
+
+# ── origin_type filter tests ───────────────────────────────────────────
+
+
+def _insert_origin_type_fixtures(session) -> None:
+    """Two resource messages (one STORE, one INSTANCE) and one expense row
+    billed against each, for address 0xorigintype."""
+    session.add(
+        MessageDb(
+            item_hash="store_resource_hash",
+            chain=Chain.ETH,
+            sender="0xorigintype",
+            signature=None,
+            item_type=ItemType.storage,
+            type=MessageType.store,
+            item_content=None,
+            content={"address": "0xorigintype", "time": 1772323200.0},
+            size=100,
+            time=dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc),
+        )
+    )
+    session.add(
+        MessageDb(
+            item_hash="instance_resource_hash",
+            chain=Chain.ETH,
+            sender="0xorigintype",
+            signature=None,
+            item_type=ItemType.storage,
+            type=MessageType.instance,
+            item_content=None,
+            content={"address": "0xorigintype", "time": 1772323200.0},
+            size=100,
+            time=dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc),
+        )
+    )
+    session.flush()
+
+    # Storage billing: resource referenced via ref (origin_ref), no execution_id
+    update_credit_balances_expense(
+        session=session,
+        credits_list=[
+            {
+                "address": "0xorigintype",
+                "amount": 100,
+                "ref": "store_resource_hash",
+                "execution_id": "",
+                "node_id": "node_a",
+                "price": "0.000001",
+            }
+        ],
+        message_hash="origin_type_expense_store",
+        message_timestamp=dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc),
+    )
+    # Instance billing: resource referenced via execution_id (origin)
+    update_credit_balances_expense(
+        session=session,
+        credits_list=[
+            {
+                "address": "0xorigintype",
+                "amount": 200,
+                "ref": "",
+                "execution_id": "instance_resource_hash",
+                "node_id": "node_b",
+                "price": "0.000001",
+            }
+        ],
+        message_hash="origin_type_expense_instance",
+        message_timestamp=dt.datetime(2026, 4, 2, tzinfo=dt.timezone.utc),
+    )
+    session.commit()
+
+
+def test_get_address_credit_history_origin_type_filter(
+    session_factory: DbSessionFactory,
+):
+    with session_factory() as session:
+        _insert_origin_type_fixtures(session)
+
+        storage = get_address_credit_history(
+            session=session,
+            address="0xorigintype",
+            origin_type=MessageType.store,
+        )
+        assert [e.credit_ref for e in storage] == ["origin_type_expense_store"]
+
+        compute = get_address_credit_history(
+            session=session,
+            address="0xorigintype",
+            origin_type=MessageType.instance,
+        )
+        assert [e.credit_ref for e in compute] == ["origin_type_expense_instance"]
+
+        assert (
+            count_address_credit_history(
+                session=session,
+                address="0xorigintype",
+                origin_type=MessageType.instance,
+            )
+            == 1
+        )
+
+        # Composes with the summary aggregate
+        instance_summary = get_address_credit_history_summary(
+            session=session,
+            address="0xorigintype",
+            origin_type=MessageType.instance,
+        )
+        assert instance_summary.entry_count == 1
+        assert instance_summary.total_amount == -200
+
+        # No PROGRAM resources billed for this address
+        assert (
+            list(
+                get_address_credit_history(
+                    session=session,
+                    address="0xorigintype",
+                    origin_type=MessageType.program,
+                )
+            )
+            == []
+        )


### PR DESCRIPTION
Adds an optional `resourceTypes` query param to the credit history listing and summary endpoints: a comma-separated list of message types for the billed resource (STORE for storage, INSTANCE and PROGRAM for compute). An entry matches if its resource type is any of the listed values.

Expense rows reference the billed resource via `coalesce(nullif(origin, ''), origin_ref)`, the same effective-origin rule `get_total_consumed_credits` uses; the filter resolves it against `messages.item_hash` (PK) with an EXISTS subquery. Entries whose origin does not resolve to a known message (including forgotten messages) match no type.

Combined with the time-range filter, `resourceTypes=INSTANCE,PROGRAM&startDate=...` on the summary endpoint answers "compute spend this week" in one request, and `resourceTypes=STORE` the storage equivalent.

The param is named `resourceTypes` (plural, a list) following the messages endpoint's `msgTypes` convention. No migration.
