### PR TITLE
perf(db): composite index for credit-history address+timestamp queries

### DIFF
--- a/deployment/migrations/versions/0060_a1d4e7b2c9f6_credit_history_address_timestamp_index.py
+++ b/deployment/migrations/versions/0060_a1d4e7b2c9f6_credit_history_address_timestamp_index.py
@@ -1,0 +1,83 @@
+"""Add composite index credit_history(address, message_timestamp, credit_ref, credit_index)
+
+Revision ID: a1d4e7b2c9f6
+Revises: b9c4f1e6a2d7
+Create Date: 2026-06-16
+
+The credit-history endpoint filters by address and orders by
+(message_timestamp, credit_ref, credit_index) - the default sort. With only
+single-column indexes on address and message_timestamp, the planner either
+sorts the full per-address set or scans the whole message_timestamp index
+filtering by address, costing ~10s on high-volume addresses.
+
+This composite index serves the filter and the full sort key in one index
+range scan; the single btree covers both ASC and DESC because all sort keys
+share direction. It is a left-prefix superset of the standalone
+ix_credit_history_address index, which is therefore dropped here.
+"""
+
+import logging
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "a1d4e7b2c9f6"
+down_revision = "b9c4f1e6a2d7"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    was_in_transaction = connection.in_transaction()
+    if was_in_transaction:
+        connection.execute(text("COMMIT"))
+
+    engine = connection.engine
+    with engine.connect() as conn:
+        conn = conn.execution_options(isolation_level="AUTOCOMMIT")
+        conn.execute(
+            text(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+                "ix_credit_history_address_timestamp "
+                "ON credit_history "
+                "(address, message_timestamp, credit_ref, credit_index)"
+            )
+        )
+        # Redundant now: superseded by the composite index above.
+        conn.execute(
+            text("DROP INDEX CONCURRENTLY IF EXISTS ix_credit_history_address")
+        )
+
+    if was_in_transaction:
+        connection.execute(text("BEGIN"))
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+
+    was_in_transaction = connection.in_transaction()
+    if was_in_transaction:
+        connection.execute(text("COMMIT"))
+
+    engine = connection.engine
+    with engine.connect() as conn:
+        conn = conn.execution_options(isolation_level="AUTOCOMMIT")
+        conn.execute(
+            text(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+                "ix_credit_history_address ON credit_history (address)"
+            )
+        )
+        conn.execute(
+            text(
+                "DROP INDEX CONCURRENTLY IF EXISTS "
+                "ix_credit_history_address_timestamp"
+            )
+        )
+
+    if was_in_transaction:
+        connection.execute(text("BEGIN"))

--- a/src/aleph/db/models/balances.py
+++ b/src/aleph/db/models/balances.py
@@ -3,7 +3,15 @@ from decimal import Decimal
 from typing import Optional
 
 from aleph_message.models import Chain
-from sqlalchemy import DECIMAL, TIMESTAMP, BigInteger, Integer, String, UniqueConstraint
+from sqlalchemy import (
+    DECIMAL,
+    TIMESTAMP,
+    BigInteger,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 from sqlalchemy_utils.types.choice import ChoiceType
@@ -40,7 +48,7 @@ class AlephCreditHistoryDb(Base):
 
     id: Mapped[int] = mapped_column(BigInteger, autoincrement=True)
 
-    address: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    address: Mapped[str] = mapped_column(String, nullable=False)
     amount: Mapped[int] = mapped_column(BigInteger, nullable=False)
     price: Mapped[Optional[Decimal]] = mapped_column(DECIMAL, nullable=True)
     bonus_amount: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
@@ -66,6 +74,20 @@ class AlephCreditHistoryDb(Base):
         nullable=False,
         server_default=func.now(),
         onupdate=func.now(),
+    )
+
+    __table_args__ = (
+        # Serves the credit-history endpoint: filter by address, ordered by
+        # (message_timestamp, credit_ref, credit_index). The single btree
+        # covers both ASC and DESC since all sort keys share direction, and
+        # supersedes the former standalone index on address.
+        Index(
+            "ix_credit_history_address_timestamp",
+            "address",
+            "message_timestamp",
+            "credit_ref",
+            "credit_index",
+        ),
     )
 
 


### PR DESCRIPTION
## Problem

A production slow-query log showed the credit-history query taking **~10s**:

```
duration: 10249.229 ms  statement: SELECT credit_history.* FROM credit_history
WHERE credit_history.address = '0x...'
ORDER BY credit_history.message_timestamp ASC, credit_history.credit_ref ASC, credit_history.credit_index ASC
```

This is the default invocation of `get_address_credit_history()` (`GET /api/v1/accounts/{address}/credit-history`): filter by `address`, order by `(message_timestamp, credit_ref, credit_index)`, no LIMIT.

`credit_history` only had single-column indexes on `address` and `message_timestamp`, so the planner had to either sort the entire per-address result set or scan the whole `message_timestamp` index filtering by address. Both are slow on high-volume addresses.

## Fix

Add a composite btree index on `(address, message_timestamp, credit_ref, credit_index)`. The query becomes a single index range scan on `address` with rows already in sort order, eliminating the sort node. A single index serves both ASC and DESC because all sort keys share direction.

The new index is a left-prefix superset of `ix_credit_history_address`, so that standalone index is dropped in the same migration.

## Changes

- `src/aleph/db/models/balances.py`: drop `index=True` on `address`, add the composite `Index` via `__table_args__`.
- `deployment/migrations/versions/0060_a1d4e7b2c9f6_*.py`: `CREATE INDEX CONCURRENTLY` the composite index + `DROP INDEX CONCURRENTLY ix_credit_history_address` (downgrade reverses both). Follows the autocommit pattern from migration 0058.

## Testing

- `tests/api/test_credit_history.py` (17), `tests/db/test_credit_balances.py` + `tests/api/test_cursor_pagination.py` (64): all pass. The suite runs the full alembic chain, so the migration applies cleanly.
- Formatting (black/isort) and ruff: clean. Alembic: single head `a1d4e7b2c9f6`.

## Out of scope

- Non-default `sort_by` values (expiration_date, amount, etc.) still sort; rare enough to defer.
- The `pagination=0` default still returns all rows for an address (separate API-behavior concern).