### PR TITLE
fix(api): catch base ConnectionError when streaming WS history

### DIFF
--- a/src/aleph/web/controllers/main.py
+++ b/src/aleph/web/controllers/main.py
@@ -139,7 +139,7 @@ class StatusBroadcaster:
         try:
             await ws.send_json(payload)
             return True
-        except (ConnectionResetError, ConnectionError):
+        except ConnectionError:
             return False
 
 

--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -300,7 +300,7 @@ class MessageBroadcaster:
             payload = json_no_content if client.exclude_content else json_full
             await client.ws.send_str(payload)
             return True
-        except (ConnectionResetError, ConnectionError):
+        except ConnectionError:
             return False
 
 
@@ -750,7 +750,7 @@ async def messages_ws(request: web.Request) -> web.WebSocketResponse:
                     history=history,
                     query_params=query_params,
                 )
-            except ConnectionResetError:
+            except ConnectionError:
                 LOGGER.info("Could not send history, aborting message websocket")
                 return ws
 

--- a/tests/api/test_list_messages.py
+++ b/tests/api/test_list_messages.py
@@ -938,6 +938,60 @@ async def test_exclude_content_ws_history_default(
 
 
 @pytest.mark.asyncio
+async def test_ws_history_connection_error_is_swallowed(mocker):
+    """A lost peer during history streaming must abort the WS, not 500.
+
+    aiohttp raises a *bare* ``ConnectionError("Connection lost")`` (not
+    ``ConnectionResetError``) when the client drops mid-stream. ``messages_ws``
+    must catch it and return cleanly instead of letting it escape to the request
+    handler and be logged as a server error.
+    """
+    from contextlib import asynccontextmanager
+    from unittest.mock import AsyncMock, MagicMock
+
+    import aleph.web.controllers.messages as messages_module
+
+    # messages_ws builds its own WebSocketResponse; swap it for a mock.
+    ws = AsyncMock()
+    ws.closed = False
+    mocker.patch.object(messages_module.web, "WebSocketResponse", return_value=ws)
+
+    # The history send blows up the way aiohttp does on a vanished peer.
+    mocker.patch.object(
+        messages_module,
+        "_send_history_to_ws",
+        side_effect=ConnectionError("Connection lost"),
+    )
+
+    config = MagicMock()
+    config.websocket.heartbeat.value = 1
+    mocker.patch.object(messages_module, "get_config_from_request", return_value=config)
+    mocker.patch.object(
+        messages_module, "get_session_factory_from_request", return_value=MagicMock()
+    )
+
+    @asynccontextmanager
+    async def _slot():
+        yield
+
+    broadcaster = MagicMock()
+    broadcaster.is_at_capacity = False
+    broadcaster.acquire_slot = _slot
+    broadcaster.add = AsyncMock()
+    broadcaster.remove = AsyncMock()
+
+    request = MagicMock()
+    request.query = {"history": "10"}
+    request.app.__getitem__.return_value = broadcaster
+
+    # Must not raise, and must bail out before registering the client.
+    result = await messages_module.messages_ws(request)
+
+    assert result is ws
+    broadcaster.add.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_owners_filter_ws_logic(owners_test_messages):
     # Test the logic used by WebSocket filtering
     # hash1: sender1, owner1


### PR DESCRIPTION
## Problem

On 0.10.2, the messages WebSocket endpoint logs `[ERROR] Error handling request` with a `ConnectionError: Connection lost` (direct cause `BrokenPipeError`) whenever a client disconnects while the server is still streaming the `history` backlog. These benign client disconnects get logged as server errors and forwarded to Sentry, drowning out real errors.

```
File "/opt/pyaleph/src/aleph/web/controllers/messages.py", line 655, in _send_history_to_ws
    await ws.send_str(aleph_json.dumps(msg_dict).decode("utf-8"))
  ...
ConnectionError: Connection lost
```

## Root cause

`messages_ws` wrapped the history send in `except ConnectionResetError`. But when the peer is gone, aiohttp's `_drain_helper` raises a **bare** `ConnectionError("Connection lost")`. In Python's hierarchy:

```
OSError → ConnectionError → {ConnectionResetError, BrokenPipeError, ...}
```

`ConnectionResetError` and `BrokenPipeError` are *siblings*; both derive from `ConnectionError`. A bare `ConnectionError` is the **parent**, so `except ConnectionResetError` does not catch it — the exception escapes and is logged as a 500.

## Change

Catch the base `ConnectionError` in the history path (the actual fix). The two other WS send paths already caught `(ConnectionResetError, ConnectionError)`; simplified those to the base class for consistency (no behavior change):

- `messages.py` — history send (the bug)
- `messages.py` — live broadcast send (cleanup)
- `main.py` — metrics WS send (cleanup)

## Test

Adds `test_ws_history_connection_error_is_swallowed`, which drives `messages_ws` with a mocked history send that raises the exact bare `ConnectionError("Connection lost")` and asserts the handler returns cleanly without registering the client (would fail against the old `except ConnectionResetError`).

> Note: tests run in CI — local hatch/venv environments are currently broken (stale SQLAlchemy 1.4 in `.venv`; the hatch testing env can't build a native Rust dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)