### PR TITLE
feat(api): resource filter for credit history and summary endpoints

### DIFF
--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -867,6 +867,7 @@ def _apply_credit_history_filters(
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
     resource_types: Optional[List[MessageType]] = None,
+    vm_hash: Optional[str] = None,
 ) -> Select:
     """Apply common filters to a credit history query."""
     if tx_hash is not None:
@@ -912,6 +913,14 @@ def _apply_credit_history_filters(
             )
             .exists()
         )
+    if vm_hash is not None:
+        query = query.where(
+            func.coalesce(
+                func.nullif(AlephCreditHistoryDb.origin, ""),
+                AlephCreditHistoryDb.origin_ref,
+            )
+            == vm_hash
+        )
     return query
 
 
@@ -933,6 +942,7 @@ def get_address_credit_history(
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
     resource_types: Optional[List[MessageType]] = None,
+    vm_hash: Optional[str] = None,
     sort_by: SortByCreditHistory = SortByCreditHistory.MESSAGE_TIMESTAMP,
     sort_order: SortOrder = SortOrder.DESCENDING,
     after_sort_value: Optional[Any] = None,
@@ -989,6 +999,7 @@ def get_address_credit_history(
         end_date=end_date,
         direction=direction,
         resource_types=resource_types,
+        vm_hash=vm_hash,
     )
 
     # Cursor-based keyset pagination
@@ -1075,6 +1086,7 @@ def count_address_credit_history(
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
     resource_types: Optional[List[MessageType]] = None,
+    vm_hash: Optional[str] = None,
 ) -> int:
     """
     Count total credit history entries for a specific address with optional filters.
@@ -1098,6 +1110,7 @@ def count_address_credit_history(
         end_date=end_date,
         direction=direction,
         resource_types=resource_types,
+        vm_hash=vm_hash,
     )
 
     return session.execute(query).scalar_one()
@@ -1126,6 +1139,7 @@ def get_address_credit_history_summary(
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
     resource_types: Optional[List[MessageType]] = None,
+    vm_hash: Optional[str] = None,
 ) -> CreditHistorySummary:
     """
     Aggregates over all credit history entries matching the filters, in a
@@ -1159,6 +1173,7 @@ def get_address_credit_history_summary(
         end_date=end_date,
         direction=direction,
         resource_types=resource_types,
+        vm_hash=vm_hash,
     )
     row = session.execute(query).one()
     return CreditHistorySummary(

--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -867,7 +867,7 @@ def _apply_credit_history_filters(
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
     resource_types: Optional[List[MessageType]] = None,
-    vm_hash: Optional[str] = None,
+    resource: Optional[str] = None,
 ) -> Select:
     """Apply common filters to a credit history query."""
     if tx_hash is not None:
@@ -913,13 +913,13 @@ def _apply_credit_history_filters(
             )
             .exists()
         )
-    if vm_hash is not None:
+    if resource is not None:
         query = query.where(
             func.coalesce(
                 func.nullif(AlephCreditHistoryDb.origin, ""),
                 AlephCreditHistoryDb.origin_ref,
             )
-            == vm_hash
+            == resource
         )
     return query
 
@@ -942,7 +942,7 @@ def get_address_credit_history(
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
     resource_types: Optional[List[MessageType]] = None,
-    vm_hash: Optional[str] = None,
+    resource: Optional[str] = None,
     sort_by: SortByCreditHistory = SortByCreditHistory.MESSAGE_TIMESTAMP,
     sort_order: SortOrder = SortOrder.DESCENDING,
     after_sort_value: Optional[Any] = None,
@@ -999,7 +999,7 @@ def get_address_credit_history(
         end_date=end_date,
         direction=direction,
         resource_types=resource_types,
-        vm_hash=vm_hash,
+        resource=resource,
     )
 
     # Cursor-based keyset pagination
@@ -1086,7 +1086,7 @@ def count_address_credit_history(
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
     resource_types: Optional[List[MessageType]] = None,
-    vm_hash: Optional[str] = None,
+    resource: Optional[str] = None,
 ) -> int:
     """
     Count total credit history entries for a specific address with optional filters.
@@ -1110,7 +1110,7 @@ def count_address_credit_history(
         end_date=end_date,
         direction=direction,
         resource_types=resource_types,
-        vm_hash=vm_hash,
+        resource=resource,
     )
 
     return session.execute(query).scalar_one()
@@ -1139,7 +1139,7 @@ def get_address_credit_history_summary(
     end_date: Optional[dt.datetime] = None,
     direction: Optional[CreditFlow] = None,
     resource_types: Optional[List[MessageType]] = None,
-    vm_hash: Optional[str] = None,
+    resource: Optional[str] = None,
 ) -> CreditHistorySummary:
     """
     Aggregates over all credit history entries matching the filters, in a
@@ -1173,7 +1173,7 @@ def get_address_credit_history_summary(
         end_date=end_date,
         direction=direction,
         resource_types=resource_types,
-        vm_hash=vm_hash,
+        resource=resource,
     )
     row = session.execute(query).one()
     return CreditHistorySummary(

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -202,15 +202,14 @@ class CreditHistoryFilterParams(BaseModel):
         "the given values. Entries whose origin does not resolve to a known "
         "message (including forgotten messages) never match.",
     )
-    vm_hash: Optional[str] = Field(
+    resource: Optional[str] = Field(
         default=None,
-        alias="vmHash",
         description="Filter by the hash of the billed resource (e.g. a VM's "
-        "INSTANCE/PROGRAM message hash). Matches the entry's effective origin "
-        "(coalesce(nullif(origin, ''), origin_ref)) — the message hash of the "
-        "resource being billed. Unlike resourceTypes this compares the entry's "
-        "own columns and does not require the referenced message to still "
-        "exist, so forgotten resources still match.",
+        "INSTANCE/PROGRAM message hash, or a STORE file's message hash). Matches "
+        "the entry's effective origin (coalesce(nullif(origin, ''), origin_ref)) "
+        "- the message hash of the resource being billed. Unlike resourceTypes "
+        "this compares the entry's own columns and does not require the "
+        "referenced message to still exist, so forgotten resources still match.",
     )
 
     @field_validator("exclude_payment_method", "resource_types", mode="before")

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -202,6 +202,16 @@ class CreditHistoryFilterParams(BaseModel):
         "the given values. Entries whose origin does not resolve to a known "
         "message (including forgotten messages) never match.",
     )
+    vm_hash: Optional[str] = Field(
+        default=None,
+        alias="vmHash",
+        description="Filter by the hash of the billed resource (e.g. a VM's "
+        "INSTANCE/PROGRAM message hash). Matches the entry's effective origin "
+        "(coalesce(nullif(origin, ''), origin_ref)) — the message hash of the "
+        "resource being billed. Unlike resourceTypes this compares the entry's "
+        "own columns and does not require the referenced message to still "
+        "exist, so forgotten resources still match.",
+    )
 
     @field_validator("exclude_payment_method", "resource_types", mode="before")
     def split_comma_separated(cls, v):

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -828,11 +828,11 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
         schema:
           type: string
         description: "Comma-separated billed resource message types to match (e.g. STORE for storage, INSTANCE,PROGRAM for compute); allowed values: POST, AGGREGATE, STORE, PROGRAM, INSTANCE, FORGET. Entries with no resolvable resource match no type"
-      - name: vmHash
+      - name: resource
         in: query
         schema:
           type: string
-        description: "Filter by the billed resource's message hash (e.g. a VM's INSTANCE/PROGRAM hash); matches the entry's effective origin (coalesce(nullif(origin,''), origin_ref))"
+        description: "Filter by the billed resource's message hash (e.g. a VM's INSTANCE/PROGRAM hash, or a STORE file's hash); matches the entry's effective origin (coalesce(nullif(origin,''), origin_ref))"
       - name: sort_by
         in: query
         schema:
@@ -927,7 +927,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
                     end_date=query_params.end_date,
                     direction=query_params.direction,
                     resource_types=query_params.resource_types,
-                    vm_hash=query_params.vm_hash,
+                    resource=query_params.resource,
                     sort_by=query_params.sort_by,
                     sort_order=query_params.sort_order,
                     after_sort_value=after_sort_value,
@@ -1004,7 +1004,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             end_date=query_params.end_date,
             direction=query_params.direction,
             resource_types=query_params.resource_types,
-            vm_hash=query_params.vm_hash,
+            resource=query_params.resource,
             sort_by=query_params.sort_by,
             sort_order=query_params.sort_order,
         )
@@ -1028,7 +1028,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             end_date=query_params.end_date,
             direction=query_params.direction,
             resource_types=query_params.resource_types,
-            vm_hash=query_params.vm_hash,
+            resource=query_params.resource,
         )
 
         # Convert to response items
@@ -1142,11 +1142,11 @@ async def get_account_credit_history_summary(request: web.Request) -> web.Respon
         schema:
           type: string
         description: "Comma-separated billed resource message types to match (e.g. STORE for storage, INSTANCE,PROGRAM for compute); allowed values: POST, AGGREGATE, STORE, PROGRAM, INSTANCE, FORGET. Entries with no resolvable resource match no type"
-      - name: vmHash
+      - name: resource
         in: query
         schema:
           type: string
-        description: "Filter by the billed resource's message hash (e.g. a VM's INSTANCE/PROGRAM hash); matches the entry's effective origin (coalesce(nullif(origin,''), origin_ref))"
+        description: "Filter by the billed resource's message hash (e.g. a VM's INSTANCE/PROGRAM hash, or a STORE file's hash); matches the entry's effective origin (coalesce(nullif(origin,''), origin_ref))"
     responses:
       '200':
         description: Aggregate totals over the filtered credit history
@@ -1185,7 +1185,7 @@ async def get_account_credit_history_summary(request: web.Request) -> web.Respon
             end_date=query_params.end_date,
             direction=query_params.direction,
             resource_types=query_params.resource_types,
-            vm_hash=query_params.vm_hash,
+            resource=query_params.resource,
         )
 
     response = GetAccountCreditHistorySummaryResponse(

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -828,6 +828,11 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
         schema:
           type: string
         description: "Comma-separated billed resource message types to match (e.g. STORE for storage, INSTANCE,PROGRAM for compute); allowed values: POST, AGGREGATE, STORE, PROGRAM, INSTANCE, FORGET. Entries with no resolvable resource match no type"
+      - name: vmHash
+        in: query
+        schema:
+          type: string
+        description: "Filter by the billed resource's message hash (e.g. a VM's INSTANCE/PROGRAM hash); matches the entry's effective origin (coalesce(nullif(origin,''), origin_ref))"
       - name: sort_by
         in: query
         schema:
@@ -922,6 +927,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
                     end_date=query_params.end_date,
                     direction=query_params.direction,
                     resource_types=query_params.resource_types,
+                    vm_hash=query_params.vm_hash,
                     sort_by=query_params.sort_by,
                     sort_order=query_params.sort_order,
                     after_sort_value=after_sort_value,
@@ -998,6 +1004,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             end_date=query_params.end_date,
             direction=query_params.direction,
             resource_types=query_params.resource_types,
+            vm_hash=query_params.vm_hash,
             sort_by=query_params.sort_by,
             sort_order=query_params.sort_order,
         )
@@ -1021,6 +1028,7 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
             end_date=query_params.end_date,
             direction=query_params.direction,
             resource_types=query_params.resource_types,
+            vm_hash=query_params.vm_hash,
         )
 
         # Convert to response items
@@ -1134,6 +1142,11 @@ async def get_account_credit_history_summary(request: web.Request) -> web.Respon
         schema:
           type: string
         description: "Comma-separated billed resource message types to match (e.g. STORE for storage, INSTANCE,PROGRAM for compute); allowed values: POST, AGGREGATE, STORE, PROGRAM, INSTANCE, FORGET. Entries with no resolvable resource match no type"
+      - name: vmHash
+        in: query
+        schema:
+          type: string
+        description: "Filter by the billed resource's message hash (e.g. a VM's INSTANCE/PROGRAM hash); matches the entry's effective origin (coalesce(nullif(origin,''), origin_ref))"
     responses:
       '200':
         description: Aggregate totals over the filtered credit history
@@ -1172,6 +1185,7 @@ async def get_account_credit_history_summary(request: web.Request) -> web.Respon
             end_date=query_params.end_date,
             direction=query_params.direction,
             resource_types=query_params.resource_types,
+            vm_hash=query_params.vm_hash,
         )
 
     response = GetAccountCreditHistorySummaryResponse(

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -396,3 +396,103 @@ async def test_credit_history_resource_types_filter_filters_entries(
     data = await response.json()
     assert data["entry_count"] == 1
     assert data["total_amount"] == -200
+
+
+@pytest.mark.asyncio
+async def test_credit_history_accepts_valid_vm_hash(ccn_api_client):
+    # No data for this address: a valid filtered query returns 404, not 422.
+    response = await ccn_api_client.get(
+        CREDIT_HISTORY_URI, params={"vmHash": "some_vm_hash"}
+    )
+    assert response.status == 404
+
+
+@pytest.mark.asyncio
+async def test_credit_history_summary_accepts_valid_vm_hash(ccn_api_client):
+    response = await ccn_api_client.get(
+        CREDIT_HISTORY_SUMMARY_URI, params={"vmHash": "some_vm_hash"}
+    )
+    assert response.status == 200
+    data = await response.json()
+    assert data["entry_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_credit_history_vm_hash_filter_filters_entries(
+    ccn_api_client, session_factory
+):
+    with session_factory() as session:
+        # Expense referencing the target VM via origin (execution_id).
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {
+                    "address": "0xe2evmhash",
+                    "amount": 100,
+                    "ref": "",
+                    "execution_id": "target_vm",
+                    "node_id": "node_e2e_vm_a",
+                    "price": "0.000001",
+                }
+            ],
+            message_hash="e2e_vm_expense_origin",
+            message_timestamp=dt.datetime(2026, 4, 1, tzinfo=dt.timezone.utc),
+        )
+        # Expense referencing the target VM via origin_ref (ref), origin empty.
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {
+                    "address": "0xe2evmhash",
+                    "amount": 200,
+                    "ref": "target_vm",
+                    "execution_id": "",
+                    "node_id": "node_e2e_vm_b",
+                    "price": "0.000001",
+                }
+            ],
+            message_hash="e2e_vm_expense_originref",
+            message_timestamp=dt.datetime(2026, 4, 2, tzinfo=dt.timezone.utc),
+        )
+        # Unrelated expense for a different VM.
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {
+                    "address": "0xe2evmhash",
+                    "amount": 300,
+                    "ref": "",
+                    "execution_id": "other_vm",
+                    "node_id": "node_e2e_vm_c",
+                    "price": "0.000001",
+                }
+            ],
+            message_hash="e2e_vm_expense_other",
+            message_timestamp=dt.datetime(2026, 4, 3, tzinfo=dt.timezone.utc),
+        )
+        session.commit()
+
+    listing_uri = "/api/v0/addresses/0xe2evmhash/credit_history"
+    summary_uri = "/api/v0/addresses/0xe2evmhash/credit_history/summary"
+
+    # Listing: matches the two entries for target_vm regardless of column.
+    response = await ccn_api_client.get(listing_uri, params={"vmHash": "target_vm"})
+    assert response.status == 200
+    data = await response.json()
+    refs = {entry["credit_ref"] for entry in data["credit_history"]}
+    assert refs == {"e2e_vm_expense_origin", "e2e_vm_expense_originref"}
+
+    # Summary: aggregates only the matching entries (both outgoing).
+    response = await ccn_api_client.get(summary_uri, params={"vmHash": "target_vm"})
+    assert response.status == 200
+    data = await response.json()
+    assert data["entry_count"] == 2
+    assert data["total_amount"] == -300
+    assert data["total_incoming"] == 0
+    assert data["total_outgoing"] == -300
+
+    # Composes with direction: incoming + target_vm matches nothing -> 404.
+    response = await ccn_api_client.get(
+        listing_uri, params={"vmHash": "target_vm", "direction": "incoming"}
+    )
+    assert response.status == 404

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -399,18 +399,18 @@ async def test_credit_history_resource_types_filter_filters_entries(
 
 
 @pytest.mark.asyncio
-async def test_credit_history_accepts_valid_vm_hash(ccn_api_client):
+async def test_credit_history_accepts_valid_resource(ccn_api_client):
     # No data for this address: a valid filtered query returns 404, not 422.
     response = await ccn_api_client.get(
-        CREDIT_HISTORY_URI, params={"vmHash": "some_vm_hash"}
+        CREDIT_HISTORY_URI, params={"resource": "some_resource_hash"}
     )
     assert response.status == 404
 
 
 @pytest.mark.asyncio
-async def test_credit_history_summary_accepts_valid_vm_hash(ccn_api_client):
+async def test_credit_history_summary_accepts_valid_resource(ccn_api_client):
     response = await ccn_api_client.get(
-        CREDIT_HISTORY_SUMMARY_URI, params={"vmHash": "some_vm_hash"}
+        CREDIT_HISTORY_SUMMARY_URI, params={"resource": "some_resource_hash"}
     )
     assert response.status == 200
     data = await response.json()
@@ -418,7 +418,7 @@ async def test_credit_history_summary_accepts_valid_vm_hash(ccn_api_client):
 
 
 @pytest.mark.asyncio
-async def test_credit_history_vm_hash_filter_filters_entries(
+async def test_credit_history_resource_filter_filters_entries(
     ccn_api_client, session_factory
 ):
     with session_factory() as session:
@@ -476,14 +476,14 @@ async def test_credit_history_vm_hash_filter_filters_entries(
     summary_uri = "/api/v0/addresses/0xe2evmhash/credit_history/summary"
 
     # Listing: matches the two entries for target_vm regardless of column.
-    response = await ccn_api_client.get(listing_uri, params={"vmHash": "target_vm"})
+    response = await ccn_api_client.get(listing_uri, params={"resource": "target_vm"})
     assert response.status == 200
     data = await response.json()
     refs = {entry["credit_ref"] for entry in data["credit_history"]}
     assert refs == {"e2e_vm_expense_origin", "e2e_vm_expense_originref"}
 
     # Summary: aggregates only the matching entries (both outgoing).
-    response = await ccn_api_client.get(summary_uri, params={"vmHash": "target_vm"})
+    response = await ccn_api_client.get(summary_uri, params={"resource": "target_vm"})
     assert response.status == 200
     data = await response.json()
     assert data["entry_count"] == 2
@@ -493,6 +493,6 @@ async def test_credit_history_vm_hash_filter_filters_entries(
 
     # Composes with direction: incoming + target_vm matches nothing -> 404.
     response = await ccn_api_client.get(
-        listing_uri, params={"vmHash": "target_vm", "direction": "incoming"}
+        listing_uri, params={"resource": "target_vm", "direction": "incoming"}
     )
     assert response.status == 404

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -3018,3 +3018,90 @@ def test_get_address_credit_history_resource_types_filter(
                 )
             ]
             assert "resource_type_expense_unresolvable" not in refs
+
+
+def test_vm_hash_filter_matches_effective_origin(session_factory: DbSessionFactory):
+    """vm_hash matches the entry's effective origin, whether the hash is held
+    in the origin column or the origin_ref column."""
+    ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
+
+    entries = [
+        # Hash in origin (execution_id-style expense), origin_ref empty.
+        {
+            "address": "0xvmhash",
+            "amount": -100,
+            "credit_ref": "ref_in_origin",
+            "credit_index": 0,
+            "message_timestamp": ts,
+            "last_update": ts,
+            "origin": "vm_target",
+            "origin_ref": "",
+            "payment_method": "credit_expense",
+        },
+        # Hash in origin_ref (volume-style expense), origin empty.
+        {
+            "address": "0xvmhash",
+            "amount": -200,
+            "credit_ref": "ref_in_origin_ref",
+            "credit_index": 0,
+            "message_timestamp": ts + dt.timedelta(hours=1),
+            "last_update": ts,
+            "origin": "",
+            "origin_ref": "vm_target",
+            "payment_method": "credit_expense",
+        },
+        # Unrelated entry that must not match.
+        {
+            "address": "0xvmhash",
+            "amount": 1000,
+            "credit_ref": "ref_other",
+            "credit_index": 0,
+            "message_timestamp": ts + dt.timedelta(hours=2),
+            "last_update": ts,
+            "origin": "other_vm",
+            "origin_ref": "",
+            "payment_method": "credit_distribution",
+        },
+    ]
+
+    with session_factory() as session:
+        _insert_credit_history_entries(session, entries)
+        session.commit()
+
+        results = get_address_credit_history(
+            session=session, address="0xvmhash", vm_hash="vm_target"
+        )
+        refs = {entry.credit_ref for entry in results}
+        assert refs == {"ref_in_origin", "ref_in_origin_ref"}
+
+        summary = get_address_credit_history_summary(
+            session=session, address="0xvmhash", vm_hash="vm_target"
+        )
+        assert summary.entry_count == 2
+        assert summary.total_amount == -300
+
+        assert (
+            count_address_credit_history(
+                session=session, address="0xvmhash", vm_hash="vm_target"
+            )
+            == 2
+        )
+
+        # A hash that matches nothing yields an empty result / zero summary.
+        assert (
+            get_address_credit_history(
+                session=session, address="0xvmhash", vm_hash="nonexistent"
+            )
+            == []
+        )
+        empty_summary = get_address_credit_history_summary(
+            session=session, address="0xvmhash", vm_hash="nonexistent"
+        )
+        assert empty_summary.entry_count == 0
+        assert empty_summary.total_amount == 0
+        assert (
+            count_address_credit_history(
+                session=session, address="0xvmhash", vm_hash="nonexistent"
+            )
+            == 0
+        )

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -3020,8 +3020,8 @@ def test_get_address_credit_history_resource_types_filter(
             assert "resource_type_expense_unresolvable" not in refs
 
 
-def test_vm_hash_filter_matches_effective_origin(session_factory: DbSessionFactory):
-    """vm_hash matches the entry's effective origin, whether the hash is held
+def test_resource_filter_matches_effective_origin(session_factory: DbSessionFactory):
+    """resource matches the entry's effective origin, whether the hash is held
     in the origin column or the origin_ref column."""
     ts = dt.datetime(2026, 3, 1, tzinfo=dt.timezone.utc)
 
@@ -3069,20 +3069,20 @@ def test_vm_hash_filter_matches_effective_origin(session_factory: DbSessionFacto
         session.commit()
 
         results = get_address_credit_history(
-            session=session, address="0xvmhash", vm_hash="vm_target"
+            session=session, address="0xvmhash", resource="vm_target"
         )
         refs = {entry.credit_ref for entry in results}
         assert refs == {"ref_in_origin", "ref_in_origin_ref"}
 
         summary = get_address_credit_history_summary(
-            session=session, address="0xvmhash", vm_hash="vm_target"
+            session=session, address="0xvmhash", resource="vm_target"
         )
         assert summary.entry_count == 2
         assert summary.total_amount == -300
 
         assert (
             count_address_credit_history(
-                session=session, address="0xvmhash", vm_hash="vm_target"
+                session=session, address="0xvmhash", resource="vm_target"
             )
             == 2
         )
@@ -3090,18 +3090,18 @@ def test_vm_hash_filter_matches_effective_origin(session_factory: DbSessionFacto
         # A hash that matches nothing yields an empty result / zero summary.
         assert (
             get_address_credit_history(
-                session=session, address="0xvmhash", vm_hash="nonexistent"
+                session=session, address="0xvmhash", resource="nonexistent"
             )
             == []
         )
         empty_summary = get_address_credit_history_summary(
-            session=session, address="0xvmhash", vm_hash="nonexistent"
+            session=session, address="0xvmhash", resource="nonexistent"
         )
         assert empty_summary.entry_count == 0
         assert empty_summary.total_amount == 0
         assert (
             count_address_credit_history(
-                session=session, address="0xvmhash", vm_hash="nonexistent"
+                session=session, address="0xvmhash", resource="nonexistent"
             )
             == 0
         )


### PR DESCRIPTION
## Summary

Adds an optional `resource` query filter to the credit history listing and summary endpoints, to make it easy to inspect all credit spend tied to a specific resource (a VM or a file) when debugging.

- `GET /api/v0/addresses/{address}/credit_history?resource=<hash>`
- `GET /api/v0/addresses/{address}/credit_history/summary?resource=<hash>`

An entry matches when its **effective origin** - `coalesce(nullif(origin, ''), origin_ref)` - equals the given hash. This is the same effective-origin rule the existing `resourceTypes` filter and `get_total_consumed_credits` use, so an expense matches by the resource's message hash regardless of whether the hash sits in `origin` (execution_id-style) or `origin_ref` (volume-style).

The filter is named `resource` rather than `vmHash` because it matches any billed resource message hash (VMs and files alike), not just VMs.

Unlike `resourceTypes`, this filter compares the credit-history row's own columns and does **not** join against `messages`, so entries whose resource message has been forgotten still match - which is exactly what you want when debugging. It AND-composes with the existing filters (`direction`, time range, `resourceTypes`, ...). No DB migration.

### Changes
- `schemas/api/accounts.py`: `resource` field on the shared `CreditHistoryFilterParams` (inherited by both endpoints).
- `db/accessors/balances.py`: `resource` filter in `_apply_credit_history_filters`, threaded through `get_address_credit_history`, `count_address_credit_history`, and `get_address_credit_history_summary`.
- `web/controllers/accounts.py`: wired through all four accessor call sites (listing first-page, cursor pagination, count, summary) + OpenAPI docs on both handlers.

## Test Plan
- [x] Accessor test: matches hash in `origin` and in `origin_ref`, excludes unrelated entries, summary aggregation + count, no-match case (`tests/db/test_credit_balances.py`).
- [x] Endpoint tests: listing + summary filtering on both endpoints, composition with `direction`, valid-but-no-data -> 404/zeros (`tests/api/test_credit_history.py`).
- [x] Full `tests/api/test_credit_history.py` + `tests/db/test_credit_balances.py` green.
- [x] `linting:all` clean (ruff, black, isort, mypy).
