### PR TITLE
fix(api): lift IPFS upload size cap above the global client_max_size

### DIFF
--- a/src/aleph/web/controllers/ipfs.py
+++ b/src/aleph/web/controllers/ipfs.py
@@ -99,12 +99,23 @@ async def ipfs_add_file(request: web.Request):
                 reason="Expected Content-Type: multipart/form-data"
             )
 
+        # aiohttp enforces the app-wide client_max_size (wired to
+        # storage.max_file_size) on every request body, including streamed
+        # multipart parts. Without lifting it here the IPFS upload limit could
+        # never exceed storage.max_file_size, so ipfs.max_upload_file_size
+        # would be silently capped. Clone the request with this endpoint's own
+        # cap for body reading only; the original request keeps the app state
+        # used by the rest of the handler (clone() does not carry app/match
+        # info). The clone shares the underlying payload, so this does not
+        # buffer or re-read anything.
+        body_request = request.clone(client_max_size=max_upload_file_size)
+
         # Read the largest allowed limit here; we narrow it later once we
         # know whether metadata is present. This means unauthenticated
         # requests get a two-step check: the initial streaming cap is
         # max_upload_file_size, and a secondary check afterwards enforces
         # max_unauthenticated_upload_file_size.
-        reader = await request.multipart()
+        reader = await body_request.multipart()
         async for part in reader:
             if part is None:
                 raise web.HTTPBadRequest(reason="Invalid multipart structure")
@@ -340,7 +351,12 @@ async def ipfs_add_car(request: web.Request):
                 reason="Expected Content-Type: multipart/form-data"
             )
 
-        reader = await request.multipart()
+        # Lift the app-wide client_max_size (storage.max_file_size) to this
+        # endpoint's CAR cap for body reading only; see ipfs_add_file for the
+        # rationale. The clone shares the underlying payload.
+        body_request = request.clone(client_max_size=max_upload_car_size)
+
+        reader = await body_request.multipart()
         async for part in reader:
             if part is None:
                 raise web.HTTPBadRequest(reason="Invalid multipart structure")

--- a/tests/api/test_ipfs.py
+++ b/tests/api/test_ipfs.py
@@ -18,10 +18,16 @@ from aleph.chains.signature_verifier import SignatureVerifier
 from aleph.db.accessors.files import get_file
 from aleph.db.models import AlephBalanceDb, AlephCreditBalanceDb, GracePeriodFilePinDb
 from aleph.storage import StorageService
+from aleph.toolkit.constants import MiB
 from aleph.types.db_session import DbSessionFactory
 from aleph.types.files import FileType
 from aleph.types.message_status import MessageStatus
+from aleph.web import create_aiohttp_app
 from aleph.web.controllers.app_state_getters import (
+    APP_STATE_CONFIG,
+    APP_STATE_NODE_CACHE,
+    APP_STATE_P2P_CLIENT,
+    APP_STATE_SESSION_FACTORY,
     APP_STATE_SIGNATURE_VERIFIER,
     APP_STATE_STORAGE_SERVICE,
 )
@@ -1151,3 +1157,92 @@ async def test_add_car_dag_import_failure(
 
     with session_factory() as session:
         assert get_file(session=session, file_hash=DIR_ROOT_CID) is None
+
+
+# Global aiohttp body cap for the app below. Deliberately smaller than the
+# IPFS upload limit so an upload sized between the two exercises the per-route
+# client_max_size lift.
+SMALL_GLOBAL_CAP = 1 * MiB
+IPFS_ROUTE_CAP = 8 * MiB
+
+
+@pytest_asyncio.fixture
+async def small_global_cap_client(
+    mock_config, session_factory, node_cache, mocker, aiohttp_client
+):
+    """API client whose aiohttp app has a deliberately small global
+    client_max_size, smaller than ipfs.max_upload_file_size.
+
+    This mirrors production: ``api_entrypoint`` wires the app-wide
+    ``client_max_size`` to ``storage.max_file_size`` via ``create_aiohttp_app``,
+    while ``/ipfs/add_file`` is meant to allow up to
+    ``ipfs.max_upload_file_size``.
+    """
+    app = create_aiohttp_app(with_swagger=False, max_file_size=SMALL_GLOBAL_CAP)
+
+    # Per-endpoint IPFS limits, independent of the small global cap.
+    mock_config.ipfs.max_upload_file_size.value = IPFS_ROUTE_CAP
+    mock_config.ipfs.max_unauthenticated_upload_file_size.value = IPFS_ROUTE_CAP
+
+    ipfs_service = mocker.AsyncMock()
+    ipfs_service.add_bytes = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
+    ipfs_service.storage_client.files.stat = mocker.AsyncMock(
+        return_value={
+            "Hash": EXPECTED_FILE_CID,
+            "Size": MOCK_FILE_SIZE,
+            "CumulativeSize": 42,
+            "Blocks": 0,
+            "Type": "file",
+        }
+    )
+
+    app[APP_STATE_CONFIG] = mock_config
+    app[APP_STATE_NODE_CACHE] = node_cache
+    app[APP_STATE_P2P_CLIENT] = mocker.AsyncMock()
+    app[APP_STATE_SESSION_FACTORY] = session_factory
+    app[APP_STATE_STORAGE_SERVICE] = StorageService(
+        storage_engine=InMemoryStorageEngine(files={}),
+        ipfs_service=ipfs_service,
+        node_cache=mocker.AsyncMock(),
+    )
+    app[APP_STATE_SIGNATURE_VERIFIER] = SignatureVerifier()
+
+    return await aiohttp_client(app)
+
+
+@pytest.mark.asyncio
+async def test_ipfs_upload_above_global_cap_within_route_limit(small_global_cap_client):
+    """Regression: an IPFS upload larger than the app-wide client_max_size
+    (wired to storage.max_file_size) but within ipfs.max_upload_file_size must
+    succeed.
+
+    Before the per-route client_max_size lift, aiohttp >= 3.14 rejected the
+    request body at the global cap (HTTP 413 "Maximum request body size N
+    exceeded.") before the IPFS handler's own limit applied, so
+    ipfs.max_upload_file_size was unreachable above storage.max_file_size. This
+    assertion actively guards that regression on aiohttp >= 3.14 (which
+    production runs); on 3.13.x, where client_max_size did not gate streamed
+    multipart, it passes regardless.
+    """
+    # Above the 1 MiB global cap, below the 8 MiB IPFS cap.
+    payload = b"\0" * (4 * MiB)
+    form_data = aiohttp.FormData()
+    form_data.add_field("file", BytesIO(payload))
+
+    response = await small_global_cap_client.post(IPFS_ADD_FILE_URI, data=form_data)
+    assert response.status == 200, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_ipfs_upload_above_route_limit_is_rejected(small_global_cap_client):
+    """A file larger than ipfs.max_upload_file_size is still rejected, so the
+    per-route lift raises the cap to the configured limit rather than removing
+    it. Holds on every aiohttp version via the handler's own streaming check.
+    """
+    # Above the 8 MiB IPFS cap.
+    payload = b"\0" * (10 * MiB)
+    form_data = aiohttp.FormData()
+    form_data.add_field("file", BytesIO(payload))
+
+    response = await small_global_cap_client.post(IPFS_ADD_FILE_URI, data=form_data)
+    assert response.status == 413, await response.text()


### PR DESCRIPTION
## Problem

Large authenticated IPFS uploads fail at ~100 MiB regardless of `ipfs.max_upload_file_size`, with `413 Maximum request body size 104857600 exceeded.` Setting `ipfs.max_upload_file_size` to 1 GiB has no effect.

Root cause: the aiohttp application's global `client_max_size` is wired to `storage.max_file_size` (`api_entrypoint.py` -> `create_aiohttp_app`), default 100 MiB. aiohttp 3.14+ enforces `client_max_size` on streamed multipart bodies (3.13.x did not, which is why this only shows up on newer aiohttp). So the request body is rejected at the global cap before `/ipfs/add_file`'s own `ipfs.max_upload_file_size` check ever runs. The effective ceiling was `min(storage.max_file_size, ipfs.max_upload_file_size)`, making `ipfs.max_upload_file_size` (and `ipfs.max_upload_car_size`) unreachable when larger than `storage.max_file_size`.

## Fix

In `ipfs_add_file` and `ipfs_add_car`, clone the request with the endpoint's own limit (`ipfs.max_upload_file_size` / `ipfs.max_upload_car_size`) for body reading only. aiohttp reads `client_max_size` from the request when `multipart()` is called, so the clone lifts the cap for that body while the original request keeps the app state used by the rest of the handler (`clone()` does not carry `app`/match-info).

The global cap stays unchanged, so buffered endpoints (`request.json()` / `.read()` / `.post()`) remain protected at `storage.max_file_size` rather than every route inheriting a 1 GiB body limit.

`storage_add_file` is left as is: its limit already equals the global cap, so it is not silently truncated.

## Deliberately out of scope

- **Unauthenticated stream tightening:** capping the file part at `max_unauthenticated_upload_file_size` during streaming is not safe, because the server cannot know whether a `metadata` part will follow the file part (multipart order is not guaranteed), and an early cap would break authenticated clients that send the file first. The existing post-read check is kept. Disk use during an unauthenticated upload remains bounded by the operator-configured `max_upload_file_size`.
- **aiohttp pin:** the repo pins `aiohttp==3.13.5`, but production runs 3.14.1, which is the drift that surfaced this. Aligning the pin is a separate change with its own test surface and is not included here. Note: the bug only manifests on aiohttp 3.14+, so the regression test below actively guards on that version (it passes vacuously on 3.13.x, where multipart is not gated by `client_max_size`).

## Tests

`tests/api/test_ipfs.py`: a client whose app has a deliberately small global `client_max_size` (1 MiB) and a larger IPFS limit (8 MiB):
- `test_ipfs_upload_above_global_cap_within_route_limit`: a 4 MiB upload (above the global cap, below the IPFS cap) now succeeds.
- `test_ipfs_upload_above_route_limit_is_rejected`: a 10 MiB upload is still rejected, confirming the per-route lift raises the cap rather than removing it.

`test_ipfs.py` (28) and `test_storage.py` (17) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)