### PR TITLE
refactor(api): drop the global client_max_size override, cap uploads per-route

### DIFF
--- a/src/aleph/api_entrypoint.py
+++ b/src/aleph/api_entrypoint.py
@@ -61,9 +61,11 @@ async def configure_aiohttp_app(
         )
         signature_verifier = SignatureVerifier()
 
-        app = create_aiohttp_app(
-            max_file_size=config.storage.max_file_size.value,
-        )
+        # Use aiohttp's small default client_max_size for the app. Upload
+        # endpoints raise it per-route via Request.clone() (see ipfs.py /
+        # storage.py); wiring it to storage.max_file_size would have exposed
+        # every buffered endpoint to that size in memory.
+        app = create_aiohttp_app()
 
         # Reuse the connection of the P2P client to avoid opening two connections
         mq_conn = p2p_client.mq_client.connection

--- a/src/aleph/api_entrypoint.py
+++ b/src/aleph/api_entrypoint.py
@@ -61,10 +61,6 @@ async def configure_aiohttp_app(
         )
         signature_verifier = SignatureVerifier()
 
-        # Use aiohttp's small default client_max_size for the app. Upload
-        # endpoints raise it per-route via Request.clone() (see ipfs.py /
-        # storage.py); wiring it to storage.max_file_size would have exposed
-        # every buffered endpoint to that size in memory.
         app = create_aiohttp_app()
 
         # Reuse the connection of the P2P client to avoid opening two connections

--- a/src/aleph/web/__init__.py
+++ b/src/aleph/web/__init__.py
@@ -9,9 +9,15 @@ import jinja2
 from aiohttp import web
 from aiohttp_swagger3 import SwaggerDocs, SwaggerInfo, SwaggerUiSettings
 
-from aleph.toolkit.constants import DEFAULT_MAX_FILE_SIZE
 from aleph.version import get_version
 from aleph.web.controllers.routes import register_routes
+
+# Default app-wide aiohttp client_max_size, capping every request body read via
+# request.json()/.read()/.post(). Endpoints that accept larger uploads raise it
+# per-route with Request.clone() (see ipfs.py / storage.py). Kept at aiohttp's
+# own default (1 MiB) so buffered endpoints are not exposed to large in-memory
+# bodies; message submissions are bounded well below this by MAX_INLINE_SIZE.
+DEFAULT_CLIENT_MAX_SIZE = 1024 * 1024
 
 
 def init_cors(app: web.Application):
@@ -35,7 +41,7 @@ def init_cors(app: web.Application):
 
 def create_aiohttp_app(
     with_swagger: bool = True,
-    max_file_size: int = DEFAULT_MAX_FILE_SIZE,
+    max_file_size: int = DEFAULT_CLIENT_MAX_SIZE,
 ) -> web.Application:
     app = web.Application(client_max_size=max_file_size)
 

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -86,7 +86,14 @@ async def add_ipfs_json_controller(request: web.Request):
     config = get_config_from_request(request)
     grace_period = config.storage.grace_period.value
 
-    data = await request.json()
+    # Unauthenticated JSON upload, buffered fully in memory by request.json().
+    # The app-wide client_max_size is now aiohttp's small default, so lift it to
+    # this endpoint's own cap (the unauthenticated content limit) for the body
+    # read only. The original request keeps the app state used afterwards.
+    body_request = request.clone(
+        client_max_size=config.ipfs.max_unauthenticated_upload_file_size.value
+    )
+    data = await body_request.json()
     with session_factory() as session:
         output = {
             "status": "success",
@@ -129,7 +136,14 @@ async def add_storage_json_controller(request: web.Request):
     config = get_config_from_request(request)
     grace_period = config.storage.grace_period.value
 
-    data = await request.json()
+    # Unauthenticated JSON upload, buffered fully in memory by request.json().
+    # The app-wide client_max_size is now aiohttp's small default, so lift it to
+    # this endpoint's own cap (the unauthenticated content limit) for the body
+    # read only. The original request keeps the app state used afterwards.
+    body_request = request.clone(
+        client_max_size=config.storage.max_unauthenticated_upload_file_size.value
+    )
+    data = await body_request.json()
     with session_factory() as session:
         output = {
             "status": "success",
@@ -426,9 +440,15 @@ async def storage_add_file(request: web.Request):
     metadata = None
     uploaded_file: Optional[UploadedFile] = None
 
+    # The app-wide client_max_size is now aiohttp's small default; lift it to
+    # this endpoint's own cap for body reading (both the multipart and raw
+    # paths). The original request keeps the app state used by the rest of the
+    # handler; the clone shares the underlying payload.
+    body_request = request.clone(client_max_size=max_file_size)
+
     try:
         if request.content_type == "multipart/form-data":
-            reader = await request.multipart()
+            reader = await body_request.multipart()
             async for part in reader:
                 if part is None:
                     raise web.HTTPBadRequest(
@@ -444,7 +464,7 @@ async def storage_add_file(request: web.Request):
                     metadata = await part.read(decode=True)
         else:
             uploaded_file = RawUploadedFile(
-                request=request, max_size=max_unauthenticated_upload_file_size
+                request=body_request, max_size=max_unauthenticated_upload_file_size
             )
             await uploaded_file.read_and_validate()
 

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -819,3 +819,49 @@ async def test_get_file_metadata(api_client, session_factory: DbSessionFactory):
         assert data["type"] == "dir"
         assert data["size"] == dir_size
         assert data["download_url"] == f"/api/v0/storage/raw/{dir_hash}"
+
+
+# The app-wide client_max_size is now aiohttp's 1 MiB default; these guard the
+# per-route caps that keep the larger endpoints working after that change.
+_ONE_MIB = 1024 * 1024
+
+
+@pytest.mark.asyncio
+async def test_add_storage_json_above_global_cap(
+    api_client, session_factory: DbSessionFactory
+):
+    """JSON larger than the app-wide client_max_size (1 MiB) but within the
+    unauthenticated limit must be accepted. add_storage_json reads the body
+    with request.json() (buffered), which aiohttp gates by client_max_size on
+    every version, so this actively guards the per-route lift even on the
+    pinned aiohttp 3.13.x. Without the lift the request would 413 at 1 MiB.
+    """
+    big_json = {"data": "x" * (2 * _ONE_MIB)}  # ~2 MiB, above the 1 MiB global
+    response = await api_client.post(STORAGE_ADD_JSON_URI, json=big_json)
+    assert response.status == 200, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_add_storage_json_above_unauthenticated_cap(
+    api_client, session_factory: DbSessionFactory
+):
+    """JSON larger than max_unauthenticated_upload_file_size (25 MiB) is still
+    rejected, so the per-route lift raises the cap rather than removing it."""
+    huge_json = {"data": "x" * (26 * _ONE_MIB)}  # ~26 MiB, above the 25 MiB cap
+    response = await api_client.post(STORAGE_ADD_JSON_URI, json=huge_json)
+    assert response.status == 413, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_storage_add_file_above_global_cap(
+    api_client, session_factory: DbSessionFactory
+):
+    """A multipart file upload larger than the app-wide client_max_size (1 MiB)
+    but within the unauthenticated limit succeeds. Guards the per-route lift on
+    aiohttp >= 3.14 (production); on 3.13.x multipart was never gated by the
+    global cap.
+    """
+    form = aiohttp.FormData()
+    form.add_field("file", BytesIO(b"\0" * (2 * _ONE_MIB)))  # above the 1 MiB global
+    response = await api_client.post(STORAGE_ADD_FILE_URI, data=form)
+    assert response.status == 200, await response.text()


### PR DESCRIPTION
Stacked on #1208 (base is its branch; retarget to `main` once #1208 merges). It depends on #1208: dropping the global cap is only safe once the IPFS routes already clone up.

## Why

`client_max_size` is the body limit for every endpoint that reads the body buffered (`request.json()` / `.read()` / `.post()`), not just uploads. Wiring it to `storage.max_file_size` (100 MiB) meant:
- the unauthenticated `/storage/add_json` and `/ipfs/add_json` endpoints buffered up to 100 MiB of JSON in memory per request;
- unrelated limits were coupled (this is what made `ipfs.max_upload_file_size` unreachable, see #1208).

## Change

- `create_aiohttp_app` defaults to aiohttp's own 1 MiB `client_max_size`; `api_entrypoint` stops passing `storage.max_file_size`.
- Endpoints that accept larger bodies raise it per-route with `Request.clone()`:
  - `storage_add_file` -> `storage.max_file_size` (unchanged effective limit).
  - `add_storage_json` / `add_ipfs_json` -> `max_unauthenticated_upload_file_size`. These are unauthenticated and buffered in memory, so this also **tightens** them from 100 MiB to 25 MiB. Flagging the number explicitly: 25 MiB matches the existing unauthenticated content limit and is generous for JSON, but say so if you want a different value.
  - `/ipfs/add_file`, `/ipfs/add_car` already clone (#1208).
- Message / pubsub / prices endpoints keep no explicit override: their bodies are bounded by `MAX_INLINE_SIZE` (200 KB), well under 1 MiB.

Net effect: every body-size limit is now explicit and per-route, the default is aiohttp's conservative 1 MiB, and the unauthenticated JSON endpoints are no longer a 100 MiB in-memory vector.

## Tests

`tests/api/test_storage.py`:
- `test_add_storage_json_above_global_cap`: JSON above the 1 MiB global but within the unauthenticated limit is accepted. `request.json()` is gated by `client_max_size` on every aiohttp version, so this actively guards the lift even on the pinned 3.13.x.
- `test_add_storage_json_above_unauthenticated_cap`: JSON above 25 MiB is rejected.
- `test_storage_add_file_above_global_cap`: a multipart upload above the 1 MiB global succeeds.

Full `tests/api/` suite: 237 passed, 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)