### PR TITLE
feat(api): expose upload size limits at GET /storage/limits.json

### DIFF
--- a/src/aleph/web/controllers/routes.py
+++ b/src/aleph/web/controllers/routes.py
@@ -151,6 +151,9 @@ def register_routes(app: web.Application, swagger: Optional[SwaggerDocs]):
             "/api/v0/storage/add_json",
             storage.add_storage_json_controller,
         ),
+        # Register the literal path before the {file_hash} route below, which
+        # would otherwise capture "limits.json" as a hash.
+        web.get("/api/v0/storage/limits.json", storage.get_storage_limits),
         web.get("/api/v0/storage/{file_hash}", storage.get_hash),
         web.get("/api/v0/storage/raw/{file_hash}", storage.get_raw_hash),
         web.get(

--- a/src/aleph/web/controllers/storage.py
+++ b/src/aleph/web/controllers/storage.py
@@ -927,3 +927,78 @@ async def get_file_pins_count(request: web.Request) -> web.Response:
     with session_factory() as session:
         count = count_file_pins(session=session, file_hash=item_hash)
     return web.json_response(data=count)
+
+
+class StorageEngineLimits(pydantic.BaseModel):
+    max_file_size: int
+    max_unauthenticated_upload_file_size: int
+
+
+class IpfsEngineLimits(pydantic.BaseModel):
+    max_upload_file_size: int
+    max_upload_car_size: int
+    max_unauthenticated_upload_file_size: int
+
+
+class UploadLimitsResponse(pydantic.BaseModel):
+    storage: StorageEngineLimits
+    ipfs: IpfsEngineLimits
+
+
+async def get_storage_limits(request: web.Request) -> web.Response:
+    """
+    Return this node's upload size limits, in bytes.
+
+    Lets clients pick the right storage engine for a given file size without
+    relying on trial-and-error 413s. These limits are per-node configuration
+    and may differ between CCNs, so they should be discovered rather than
+    hardcoded. Files larger than ``storage.max_file_size`` must be uploaded
+    through the IPFS engine (``/api/v0/ipfs/add_file``).
+
+    ---
+    summary: Get upload size limits
+    tags:
+      - Storage
+    responses:
+      '200':
+        description: Upload size limits in bytes, grouped by storage engine.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                storage:
+                  type: object
+                  properties:
+                    max_file_size:
+                      type: integer
+                    max_unauthenticated_upload_file_size:
+                      type: integer
+                ipfs:
+                  type: object
+                  properties:
+                    max_upload_file_size:
+                      type: integer
+                    max_upload_car_size:
+                      type: integer
+                    max_unauthenticated_upload_file_size:
+                      type: integer
+    """
+    config = get_config_from_request(request)
+
+    limits = UploadLimitsResponse(
+        storage=StorageEngineLimits(
+            max_file_size=config.storage.max_file_size.value,
+            max_unauthenticated_upload_file_size=(
+                config.storage.max_unauthenticated_upload_file_size.value
+            ),
+        ),
+        ipfs=IpfsEngineLimits(
+            max_upload_file_size=config.ipfs.max_upload_file_size.value,
+            max_upload_car_size=config.ipfs.max_upload_car_size.value,
+            max_unauthenticated_upload_file_size=(
+                config.ipfs.max_unauthenticated_upload_file_size.value
+            ),
+        ),
+    )
+    return web.json_response(data=limits.model_dump())

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -865,3 +865,47 @@ async def test_storage_add_file_above_global_cap(
     form.add_field("file", BytesIO(b"\0" * (2 * _ONE_MIB)))  # above the 1 MiB global
     response = await api_client.post(STORAGE_ADD_FILE_URI, data=form)
     assert response.status == 200, await response.text()
+
+
+STORAGE_LIMITS_URI = "/api/v0/storage/limits.json"
+
+
+@pytest.mark.asyncio
+async def test_get_storage_limits(api_client):
+    """The limits endpoint exposes the node's configured upload caps, grouped
+    by storage engine, straight from config."""
+    from aleph.toolkit.constants import (
+        DEFAULT_MAX_FILE_SIZE,
+        DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE,
+        DEFAULT_MAX_UPLOAD_CAR_SIZE,
+        DEFAULT_MAX_UPLOAD_FILE_SIZE,
+    )
+
+    response = await api_client.get(STORAGE_LIMITS_URI)
+    assert response.status == 200, await response.text()
+
+    data = await response.json()
+    assert data == {
+        "storage": {
+            "max_file_size": DEFAULT_MAX_FILE_SIZE,
+            "max_unauthenticated_upload_file_size": (
+                DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE
+            ),
+        },
+        "ipfs": {
+            "max_upload_file_size": DEFAULT_MAX_UPLOAD_FILE_SIZE,
+            "max_upload_car_size": DEFAULT_MAX_UPLOAD_CAR_SIZE,
+            "max_unauthenticated_upload_file_size": (
+                DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE
+            ),
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_storage_limits_not_captured_by_hash_route(api_client):
+    """ "limits.json" must hit the limits handler, not the /storage/{file_hash}
+    route (which would treat it as a file hash)."""
+    response = await api_client.get(STORAGE_LIMITS_URI)
+    assert response.status == 200, await response.text()
+    assert "storage" in await response.json()


### PR DESCRIPTION
## What

Adds a read-only `GET /api/v0/storage/limits.json` endpoint that returns this node's configured upload size limits (in bytes), grouped by storage engine:

```json
{
  "storage": {
    "max_file_size": 104857600,
    "max_unauthenticated_upload_file_size": 26214400
  },
  "ipfs": {
    "max_upload_file_size": 1073741824,
    "max_upload_car_size": 4294967296,
    "max_unauthenticated_upload_file_size": 26214400
  }
}
```

## Why

Clients currently have no way to discover a node's upload caps short of trial-and-error 413 responses. These limits are per-node configuration and **vary between CCNs** (this was the root cause of a recent prod incident where the effective `/ipfs/add_file` cap differed across nodes), so a client cannot safely hardcode them. With this endpoint a client can pick the right engine for a given file size: anything larger than `storage.max_file_size` must be uploaded through the IPFS engine (`/api/v0/ipfs/add_file`).

Grouping by engine (rather than a flat list) keeps the two independent `max_unauthenticated_upload_file_size` values (one under `storage`, one under `ipfs`) unambiguous.

## Security

The endpoint reflects only an explicit allowlist of size integers, never the broader config object, so it cannot grow into a config-dump. It discloses nothing that the existing aiohttp 413 responses (`Maximum request body size N exceeded`) do not already reveal, and knowing a limit does not raise it.

## Routing note

The literal `limits.json` route is registered before the `/storage/{file_hash}` dynamic route so it is not captured as a hash. A test guards this.

## Tests

- `test_get_storage_limits` — asserts the full response matches the configured defaults.
- `test_get_storage_limits_not_captured_by_hash_route` — guards the route ordering.

Full `tests/api/test_storage.py` + `tests/api/test_ipfs.py` (50 tests) pass; mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)