### PR TITLE
fix(ipfs): drop the dead pinning timeout knob

### DIFF
--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -263,8 +263,10 @@ def get_defaults():
                 "port": 5001,
                 # Scheme of the ipfs pinning service.
                 "scheme": "http",
-                # Timeout for pinning operations (seconds)
-                "timeout": 60,
+                # NOTE: there is deliberately no pinning timeout here. The
+                # aioipfs client ignores read_timeout (see make_ipfs_client),
+                # so the pin duration is governed by aioipfs's own session
+                # defaults (30 min total / 10 min inter-read).
             },
             # Timeout for file stat requests (seconds)
             "stat_timeout": 30,

--- a/src/aleph/services/ipfs/common.py
+++ b/src/aleph/services/ipfs/common.py
@@ -11,22 +11,27 @@ async def get_base_url(config):
 def make_ipfs_client(
     host: str,
     port: int,
-    timeout: int = 60,
     scheme: str = "http",
     debug_level: int = logging.WARNING,
 ) -> aioipfs.AsyncIPFS:
+    # We do not pass a read_timeout: aioipfs 0.7.1 ignores that argument.
+    # AsyncIPFS.__init__ stores it in self._read_timeout but builds its client
+    # session via get_session() called with no arguments, so the value never
+    # reaches aiohttp. The effective timeouts are aioipfs's own session
+    # defaults (total=1800s / 30 min, sock_read=600s / 10 min), which are
+    # generous enough for large uploads. Passing a value here would be
+    # silently discarded, so we keep the surface honest by not accepting one.
     return aioipfs.AsyncIPFS(
         host=host,
         port=port,
         scheme=scheme,
-        read_timeout=timeout,
         conns_max=25,
         conns_max_per_host=10,
         debug=debug_level,
     )
 
 
-def make_ipfs_p2p_client(config: Config, timeout: int = 60) -> aioipfs.AsyncIPFS:
+def make_ipfs_p2p_client(config: Config) -> aioipfs.AsyncIPFS:
     """Create IPFS client for P2P operations (pubsub, content retrieval)."""
     # Always use main IPFS config for P2P operations
     host = config.ipfs.host.value
@@ -34,10 +39,10 @@ def make_ipfs_p2p_client(config: Config, timeout: int = 60) -> aioipfs.AsyncIPFS
     scheme = config.ipfs.scheme.value
     debug_level = config.logging.level.value <= logging.DEBUG
 
-    return make_ipfs_client(host, port, timeout, scheme, debug_level)
+    return make_ipfs_client(host, port, scheme, debug_level)
 
 
-def make_ipfs_pinning_client(config: Config, timeout: int = 60) -> aioipfs.AsyncIPFS:
+def make_ipfs_pinning_client(config: Config) -> aioipfs.AsyncIPFS:
     """Create IPFS client for pinning operations."""
     # Use pinning specific config if provided, otherwise use main config
     if (
@@ -54,13 +59,9 @@ def make_ipfs_pinning_client(config: Config, timeout: int = 60) -> aioipfs.Async
         port = int(config.ipfs.port.value)
         scheme = config.ipfs.scheme.value
 
-    # Get pinning-specific timeout if available
-    if hasattr(config.ipfs, "pinning") and hasattr(config.ipfs.pinning, "timeout"):
-        timeout = int(config.ipfs.pinning.timeout.value)
-
     debug_level = config.logging.level.value <= logging.DEBUG
 
-    return make_ipfs_client(host, port, timeout, scheme, debug_level)
+    return make_ipfs_client(host, port, scheme, debug_level)
 
 
 def get_cid_version(ipfs_hash: str) -> int:

--- a/tests/services/test_ipfs_common.py
+++ b/tests/services/test_ipfs_common.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch
+
+from configmanager import Config
+
+from aleph.config import get_defaults
+from aleph.services.ipfs.common import (
+    make_ipfs_client,
+    make_ipfs_p2p_client,
+    make_ipfs_pinning_client,
+)
+
+
+def _make_config() -> Config:
+    config = Config(schema=get_defaults())
+    return config
+
+
+def test_make_ipfs_client_does_not_pass_read_timeout():
+    """aioipfs 0.7.1 silently ignores read_timeout: AsyncIPFS stores it in
+    self._read_timeout but builds its session via get_session() with no
+    arguments, so the value never reaches aiohttp. Passing it would advertise
+    a configurable pin timeout that does not exist, so we must not pass it."""
+    with patch("aleph.services.ipfs.common.aioipfs.AsyncIPFS") as mock_cls:
+        make_ipfs_client("localhost", 5001)
+
+    _, kwargs = mock_cls.call_args
+    assert "read_timeout" not in kwargs
+
+
+def test_pinning_client_falls_back_to_main_config():
+    """With no separate pinning daemon configured, the pinning client is built
+    against the main IPFS host/port. It takes no timeout: the effective
+    timeouts are aioipfs's session defaults."""
+    config = _make_config()
+
+    with patch("aleph.services.ipfs.common.aioipfs.AsyncIPFS") as mock_cls:
+        make_ipfs_pinning_client(config)
+
+    _, kwargs = mock_cls.call_args
+    assert kwargs["host"] == config.ipfs.host.value
+    assert kwargs["port"] == int(config.ipfs.port.value)
+    assert "read_timeout" not in kwargs
+
+
+def test_p2p_client_uses_main_config():
+    config = _make_config()
+
+    with patch("aleph.services.ipfs.common.aioipfs.AsyncIPFS") as mock_cls:
+        make_ipfs_p2p_client(config)
+
+    _, kwargs = mock_cls.call_args
+    assert kwargs["host"] == config.ipfs.host.value
+    assert kwargs["port"] == int(config.ipfs.port.value)
+    assert "read_timeout" not in kwargs


### PR DESCRIPTION
## Context

While investigating a 1 GiB IPFS upload timing out via the Rust CLI, the suspected cause was the server-side IPFS pin timeout in `/api/v0/ipfs/add_file`. Investigation showed that timeout does not actually exist at runtime.

## The bug

`config.ipfs.pinning.timeout` (default 60s) and the `timeout` parameters on the IPFS client factories are passed to `aioipfs.AsyncIPFS(read_timeout=...)`, but **aioipfs 0.7.1 silently ignores `read_timeout`**: `AsyncIPFS.__init__` stores it in `self._read_timeout`, then builds its client session via `get_session()` called with no arguments, so the value never reaches aiohttp.

The effective timeouts are aioipfs's own session defaults: `total=1800s` (30 min) and `sock_read=600s` (10 min). Those are generous, which is also why the 1 GiB failure surfaced as a client-side abort rather than a server pin timeout.

This made the knob a footgun:
- Bumping the default looked like a fix but was a no-op.
- Wiring it through would newly impose a low cap that does not exist today.

## The fix

Remove the dead `timeout` / `read_timeout` plumbing and the `config.ipfs.pinning.timeout` key, and document that aioipfs's session defaults govern the pin duration. No runtime behavior change.

## Tests

Adds `tests/services/test_ipfs_common.py` asserting the client factories never forward `read_timeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)