### PR TITLE
fix(ipfs): stream uploads to IPFS instead of buffering in memory

### DIFF
--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -309,6 +309,35 @@ class IpfsService:
         result = await self.storage_client.add_bytes(value, cid_version=cid_version)
         return result["Hash"]
 
+    async def add_file(
+        self, file_path: Union[str, pathlib.Path], cid_version: int = 0
+    ) -> str:
+        """Add a file to IPFS by streaming it from disk.
+
+        Unlike add_bytes, this does not buffer the whole file in memory:
+        aioipfs streams the file from ``file_path`` in chunks. Used by the
+        upload endpoints, where a single file can be up to 1 GiB and reading
+        it fully into RAM would be wasteful (and, at scale, a memory-pressure
+        risk).
+
+        The resulting CID is identical to ``add_bytes`` for the same content:
+        the CID is derived from the file bytes only. The filename is not part
+        of it because we do not wrap the file in a directory.
+        """
+        # ``add`` is an async generator yielding one entry per file added.
+        # We add a single file (no directory wrapping), so exactly one entry
+        # is produced; keep the last one defensively.
+        result: Optional[Dict] = None
+        async for entry in self.storage_client.add(
+            str(file_path), cid_version=cid_version
+        ):
+            result = entry
+
+        if result is None:
+            raise ValueError(f"IPFS add returned no entry for {file_path}")
+
+        return result["Hash"]
+
     async def _pin_add(self, cid: str, timeout: int = 30):
         # ipfs pin add returns a dictionary with a progress report in terms of blocks
         # and a "Pins" key if the pinning is complete. The dictionary is empty if the daemon

--- a/src/aleph/web/controllers/ipfs.py
+++ b/src/aleph/web/controllers/ipfs.py
@@ -191,12 +191,10 @@ async def ipfs_add_file(request: web.Request):
                 _verify_user_balance(session=session, content=message_content)
 
         # Pin to IPFS, side effect: file is now on the local IPFS node.
-        temp_file = await uploaded_file.open_temp_file()
-        file_content = await temp_file.read()
-        if isinstance(file_content, str):
-            file_content = file_content.encode("utf-8")
-
-        cid = await ipfs_service.add_bytes(file_content)
+        # Stream the file straight from its temp path instead of reading it
+        # fully into memory: uploads can be up to 1 GiB and add_bytes would
+        # buffer the whole payload in RAM.
+        cid = await ipfs_service.add_file(uploaded_file.get_temp_file_path())
 
         # Post-pin: stat, CID match, persist.
         # Failures from this point on must leave the pin covered by the

--- a/tests/api/test_ipfs.py
+++ b/tests/api/test_ipfs.py
@@ -85,6 +85,8 @@ IPFS_MESSAGE_DICT_CREDIT: dict[str, Any] = {
 @pytest_asyncio.fixture
 async def api_client(ccn_test_aiohttp_app, mocker, aiohttp_client):
     ipfs_service = mocker.AsyncMock()
+    # /ipfs/add_file streams the upload to IPFS via add_file (not add_bytes).
+    ipfs_service.add_file = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
     ipfs_service.add_bytes = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
     ipfs_service.storage_client.files.stat = mocker.AsyncMock(
         return_value={
@@ -219,7 +221,7 @@ async def test_auth_upload_bad_signature(
         new_callable=mocker.AsyncMock,
         side_effect=web.HTTPForbidden(),
     )
-    # Spy on add_bytes to confirm we never called it.
+    # Spy on add_file (the pin call) to confirm we never pinned.
     ipfs_service = _get_ipfs_service_mock(api_client)
 
     form_data = aiohttp.FormData()
@@ -237,7 +239,7 @@ async def test_auth_upload_bad_signature(
     # that the body contains the verifier's reason so the test can't pass on
     # an unrelated 403.
     assert "Forbidden" in body
-    ipfs_service.add_bytes.assert_not_called()
+    ipfs_service.add_file.assert_not_called()
 
     with session_factory() as session:
         assert get_file(session=session, file_hash=EXPECTED_FILE_CID) is None
@@ -283,7 +285,7 @@ async def test_auth_upload_rejects_storage_item_type(
     body = await response.text()
     assert response.status == 422, body
     assert "item_type=ipfs" in body
-    ipfs_service.add_bytes.assert_not_called()
+    ipfs_service.add_file.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -299,7 +301,7 @@ async def test_auth_upload_exceeding_authenticated_cap(
 
     # Pin the cap to a small value so the test stays fast and stays independent
     # of the production default, then send a payload one byte over it. The test
-    # fixture doesn't care about content since ipfs_service.add_bytes is mocked.
+    # fixture doesn't care about content since ipfs_service.add_file is mocked.
     cap = 1 * 1024 * 1024
     mock_config.ipfs.max_upload_file_size.value = cap
     oversized = b"x" * (cap + 1)
@@ -313,7 +315,7 @@ async def test_auth_upload_exceeding_authenticated_cap(
 
     response = await api_client.post(IPFS_ADD_FILE_URI, data=form_data)
     assert response.status == 413, await response.text()
-    ipfs_service.add_bytes.assert_not_called()
+    ipfs_service.add_file.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -344,7 +346,7 @@ async def test_auth_upload_cid_mismatch(
         )
         session.commit()
 
-    # Message claims a different CID than the fixture's mocked add_bytes.
+    # Message claims a different CID than the fixture's mocked add_file.
     mismatched = {
         **IPFS_MESSAGE_DICT,
         "item_content": json.dumps(
@@ -415,7 +417,7 @@ async def test_auth_upload_insufficient_balance(
     response = await api_client.post(IPFS_ADD_FILE_URI, data=form_data)
     assert response.status == 402, await response.text()
 
-    ipfs_service.add_bytes.assert_not_called()
+    ipfs_service.add_file.assert_not_called()
     with session_factory() as session:
         assert get_file(session=session, file_hash=EXPECTED_FILE_CID) is None
         assert not _has_grace_period(session, EXPECTED_FILE_CID)
@@ -434,7 +436,7 @@ async def test_auth_upload_malformed_metadata(
 
     response = await api_client.post(IPFS_ADD_FILE_URI, data=form_data)
     assert response.status == 422, await response.text()
-    ipfs_service.add_bytes.assert_not_called()
+    ipfs_service.add_file.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -526,7 +528,7 @@ async def test_auth_credit_upload_insufficient_credit_balance(
     response = await api_client.post(IPFS_ADD_FILE_URI, data=form_data)
     assert response.status == 402, await response.text()
 
-    ipfs_service.add_bytes.assert_not_called()
+    ipfs_service.add_file.assert_not_called()
     with session_factory() as session:
         assert get_file(session=session, file_hash=EXPECTED_FILE_CID) is None
         assert not _has_grace_period(session, EXPECTED_FILE_CID)
@@ -1185,6 +1187,7 @@ async def small_global_cap_client(
     mock_config.ipfs.max_unauthenticated_upload_file_size.value = IPFS_ROUTE_CAP
 
     ipfs_service = mocker.AsyncMock()
+    ipfs_service.add_file = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
     ipfs_service.add_bytes = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
     ipfs_service.storage_client.files.stat = mocker.AsyncMock(
         return_value={

--- a/tests/api/test_ipfs.py
+++ b/tests/api/test_ipfs.py
@@ -85,9 +85,8 @@ IPFS_MESSAGE_DICT_CREDIT: dict[str, Any] = {
 @pytest_asyncio.fixture
 async def api_client(ccn_test_aiohttp_app, mocker, aiohttp_client):
     ipfs_service = mocker.AsyncMock()
-    # /ipfs/add_file streams the upload to IPFS via add_file (not add_bytes).
+    # /ipfs/add_file streams the upload to IPFS via add_file (the pin call).
     ipfs_service.add_file = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
-    ipfs_service.add_bytes = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
     ipfs_service.storage_client.files.stat = mocker.AsyncMock(
         return_value={
             "Hash": EXPECTED_FILE_CID,
@@ -1188,7 +1187,6 @@ async def small_global_cap_client(
 
     ipfs_service = mocker.AsyncMock()
     ipfs_service.add_file = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
-    ipfs_service.add_bytes = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
     ipfs_service.storage_client.files.stat = mocker.AsyncMock(
         return_value={
             "Hash": EXPECTED_FILE_CID,

--- a/tests/api/test_storage.py
+++ b/tests/api/test_storage.py
@@ -69,13 +69,7 @@ MESSAGE_DICT = {
 async def api_client(ccn_test_aiohttp_app, mocker, aiohttp_client):
     ipfs_service = mocker.AsyncMock()
     ipfs_service.add_bytes = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
-    ipfs_service.add_file = mocker.AsyncMock(
-        return_value={
-            "Hash": EXPECTED_FILE_CID,
-            "Size": 34,
-            "Name": "hello-earthlings.txt",
-        }
-    )
+    ipfs_service.add_file = mocker.AsyncMock(return_value=EXPECTED_FILE_CID)
     ipfs_service.get_ipfs_content = mocker.AsyncMock(return_value=FILE_CONTENT)
 
     async def _mock_ipfs_content_iterator(*args, **kwargs):

--- a/tests/services/test_ipfs_service.py
+++ b/tests/services/test_ipfs_service.py
@@ -270,3 +270,43 @@ async def test_get_ipfs_size_success_after_retry():
     # Assert
     assert result == 9876
     assert ipfs_client.dag.get.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_add_file_streams_from_path_and_returns_cid():
+    """add_file streams the file from its path via aioipfs.add (an async
+    generator) instead of buffering it in memory, and returns the CID."""
+    calls = []
+
+    async def fake_add(*files, **kwargs):
+        calls.append((files, kwargs))
+        # aioipfs.add yields one entry per file added.
+        yield {"Name": files[0], "Hash": "QmStreamedCid", "Size": "34"}
+
+    ipfs_client = AsyncMock()
+    ipfs_client.add = fake_add
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    cid = await service.add_file("/tmp/upload.bin")
+
+    assert cid == "QmStreamedCid"
+    # The path is forwarded as a string; add_bytes must not be used.
+    assert calls == [(("/tmp/upload.bin",), {"cid_version": 0})]
+    ipfs_client.add_bytes.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_add_file_raises_when_no_entry_returned():
+    """If aioipfs.add yields nothing (should not happen for a real file), we
+    fail loudly rather than returning a bogus CID."""
+
+    async def empty_add(*files, **kwargs):
+        return
+        yield  # pragma: no cover - marks this as an async generator
+
+    ipfs_client = AsyncMock()
+    ipfs_client.add = empty_add
+    service = IpfsService(ipfs_client=ipfs_client)
+
+    with pytest.raises(ValueError):
+        await service.add_file("/tmp/upload.bin")


### PR DESCRIPTION
## Context

Part of investigating large (1 GiB) IPFS uploads via `/api/v0/ipfs/add_file`.

## The bug

The handler buffered the entire upload in memory before pinning:

```python
temp_file = await uploaded_file.open_temp_file()
file_content = await temp_file.read()   # entire 1 GiB into a single bytes object
...
cid = await ipfs_service.add_bytes(file_content)
```

So a 1 GiB upload was held fully in RAM (on top of the temp file already on disk) before being sent to the daemon. Under concurrent large uploads this is a real memory-pressure risk.

## The fix

Add `IpfsService.add_file`, which streams the file from its path via `aioipfs.add` (an async generator that chunks the upload to the daemon), and call it from the handler with the temp file path instead of reading the file into memory.

The stored object and the client-visible hash are unchanged:
- The CID is derived from the file bytes only (we do not wrap in a directory, so the filename is not part of it), so `add(path, cid_version=0)` yields the same CID as `add_bytes(bytes, cid_version=0)`.
- `aioipfs.add` pins by default (`pin=true`), matching the previous behavior.

## Tests

- Unit tests for `add_file` (streams from path, forwards `cid_version=0`, never calls `add_bytes`; raises if the daemon yields no entry).
- Updated `tests/api/test_ipfs.py` and `tests/api/test_storage.py` fixtures: the pin call is now `add_file`, so the "never pinned" assertions target `add_file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)