### PR TITLE
fix(ipfs): build add_file multipart with BufferedReaderPayload

### DIFF
--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -333,23 +333,26 @@ class IpfsService:
         ``AttributeError`` on aiohttp >= 3.13. ``BufferedReaderPayload`` is the
         correct payload for a file object and streams it straight from disk.
         """
-        file_path = str(file_path)
-        # add_generic and _build_add_params live on the CoreAPI, which
-        # AsyncIPFS exposes as ``.core`` (only a handful of core methods are
-        # proxied on the client itself, and these two are not among them).
+        path = pathlib.Path(file_path)
+        # ``cid-version`` is a kubo /api/v0/add query parameter (stable across
+        # aioipfs versions), so we build the params dict directly rather than
+        # coupling to aioipfs's private _build_add_params. add_generic and the
+        # FormDataWriter have no public equivalent, so those we do reach for on
+        # the CoreAPI (AsyncIPFS.core): the client proxies only a handful of
+        # core methods and add_generic is not among them.
+        params = {"cid-version": str(cid_version)}
         core = self.storage_client.core
-        params = core._build_add_params(cid_version=cid_version)
 
         result: Optional[Dict] = None
-        with open(file_path, "rb") as fd:
+        with open(path, "rb") as fd:
             with aioipfs.multi.FormDataWriter() as mpwriter:
                 file_payload = aiohttp.payload.BufferedReaderPayload(
                     fd,
                     content_type="application/octet-stream",
-                    headers={"Abspath": file_path},
+                    headers={"Abspath": str(path)},
                 )
                 file_payload.set_content_disposition(
-                    "form-data", name="file", filename=pathlib.Path(file_path).name
+                    "form-data", name="file", filename=path.name
                 )
                 mpwriter.append_payload(file_payload)
 

--- a/src/aleph/services/ipfs/service.py
+++ b/src/aleph/services/ipfs/service.py
@@ -7,7 +7,9 @@ from typing import AsyncIterable, Dict, Optional, Self, Union, cast
 
 import aiofiles
 import aiohttp
+import aiohttp.payload
 import aioipfs
+import aioipfs.multi
 from configmanager import Config
 
 from aleph.services.ipfs.common import make_ipfs_p2p_client, make_ipfs_pinning_client
@@ -314,24 +316,48 @@ class IpfsService:
     ) -> str:
         """Add a file to IPFS by streaming it from disk.
 
-        Unlike add_bytes, this does not buffer the whole file in memory:
-        aioipfs streams the file from ``file_path`` in chunks. Used by the
-        upload endpoints, where a single file can be up to 1 GiB and reading
-        it fully into RAM would be wasteful (and, at scale, a memory-pressure
-        risk).
+        Unlike add_bytes, this does not buffer the whole file in memory: the
+        file is streamed from ``file_path`` in chunks. Used by the upload
+        endpoints, where a single file can be up to 1 GiB and reading it fully
+        into RAM would be wasteful (and, at scale, a memory-pressure risk).
 
         The resulting CID is identical to ``add_bytes`` for the same content:
         the CID is derived from the file bytes only. The filename is not part
         of it because we do not wrap the file in a directory.
+
+        We build the multipart request ourselves instead of calling
+        ``aioipfs.AsyncIPFS.add``: aioipfs 0.7.1 (the latest release) wraps a
+        single file in aiohttp's ``BytesIOPayload``, whose ``__init__`` calls
+        ``value.getbuffer()`` on the raw file object. A plain file is an
+        ``io.BufferedReader``, which has no ``getbuffer``, so ``add`` raises
+        ``AttributeError`` on aiohttp >= 3.13. ``BufferedReaderPayload`` is the
+        correct payload for a file object and streams it straight from disk.
         """
-        # ``add`` is an async generator yielding one entry per file added.
-        # We add a single file (no directory wrapping), so exactly one entry
-        # is produced; keep the last one defensively.
+        file_path = str(file_path)
+        # add_generic and _build_add_params live on the CoreAPI, which
+        # AsyncIPFS exposes as ``.core`` (only a handful of core methods are
+        # proxied on the client itself, and these two are not among them).
+        core = self.storage_client.core
+        params = core._build_add_params(cid_version=cid_version)
+
         result: Optional[Dict] = None
-        async for entry in self.storage_client.add(
-            str(file_path), cid_version=cid_version
-        ):
-            result = entry
+        with open(file_path, "rb") as fd:
+            with aioipfs.multi.FormDataWriter() as mpwriter:
+                file_payload = aiohttp.payload.BufferedReaderPayload(
+                    fd,
+                    content_type="application/octet-stream",
+                    headers={"Abspath": file_path},
+                )
+                file_payload.set_content_disposition(
+                    "form-data", name="file", filename=pathlib.Path(file_path).name
+                )
+                mpwriter.append_payload(file_payload)
+
+                # add_generic yields one entry per file added. We add a single
+                # file (no directory wrapping), so exactly one entry is
+                # produced; keep the last one defensively.
+                async for entry in core.add_generic(mpwriter, params=params):
+                    result = entry
 
         if result is None:
             raise ValueError(f"IPFS add returned no entry for {file_path}")

--- a/tests/services/test_ipfs_service.py
+++ b/tests/services/test_ipfs_service.py
@@ -272,41 +272,73 @@ async def test_get_ipfs_size_success_after_retry():
     assert ipfs_client.dag.get.call_count == 2
 
 
-@pytest.mark.asyncio
-async def test_add_file_streams_from_path_and_returns_cid():
-    """add_file streams the file from its path via aioipfs.add (an async
-    generator) instead of buffering it in memory, and returns the CID."""
-    calls = []
+def _add_generic_capture(entries, captured):
+    """Build a fake add_generic that records the multipart/params it receives
+    and yields the given entries, mimicking aioipfs.add_generic."""
 
-    async def fake_add(*files, **kwargs):
-        calls.append((files, kwargs))
-        # aioipfs.add yields one entry per file added.
-        yield {"Name": files[0], "Hash": "QmStreamedCid", "Size": "34"}
+    async def fake_add_generic(mpart, params=None):
+        captured["mpart"] = mpart
+        captured["params"] = params
+        for entry in entries:
+            yield entry
 
+    return fake_add_generic
+
+
+def _make_storage_client(add_generic):
+    """AsyncMock storage client whose ``.core`` exposes the real
+    _build_add_params (a pure param mapper) and a caller-supplied add_generic,
+    mirroring aioipfs.AsyncIPFS.core (CoreAPI)."""
     ipfs_client = AsyncMock()
-    ipfs_client.add = fake_add
+    core = ipfs_client.core
+    core.add_generic = add_generic
+    core._build_add_params = aioipfs.api.CoreAPI._build_add_params.__get__(core)
+    return ipfs_client
+
+
+@pytest.mark.asyncio
+async def test_add_file_streams_from_disk_with_buffered_reader(tmp_path):
+    """Regression for the getbuffer crash: aioipfs 0.7.1's add() wraps a single
+    file in aiohttp's BytesIOPayload, which calls getbuffer() on the raw file
+    object and raises AttributeError on aiohttp >= 3.13. add_file must build the
+    multipart with a streaming BufferedReaderPayload (never an in-memory
+    BytesIOPayload/BytesPayload) so uploads are not buffered in RAM."""
+    from aiohttp.payload import BufferedReaderPayload, BytesIOPayload, BytesPayload
+
+    file_path = tmp_path / "upload.bin"
+    file_path.write_bytes(b"hello ipfs streaming")
+
+    captured: dict = {}
+    ipfs_client = _make_storage_client(
+        _add_generic_capture(
+            [{"Name": "upload.bin", "Hash": "QmStreamedCid", "Size": "20"}], captured
+        )
+    )
     service = IpfsService(ipfs_client=ipfs_client)
 
-    cid = await service.add_file("/tmp/upload.bin")
+    cid = await service.add_file(file_path, cid_version=0)
 
     assert cid == "QmStreamedCid"
-    # The path is forwarded as a string; add_bytes must not be used.
-    assert calls == [(("/tmp/upload.bin",), {"cid_version": 0})]
+    # cid_version is forwarded as the IPFS query param.
+    assert captured["params"]["cid-version"] == "0"
+    # The file is streamed from disk, not buffered in memory.
+    payloads = [part[0] for part in captured["mpart"]._parts]
+    assert any(isinstance(p, BufferedReaderPayload) for p in payloads)
+    assert not any(isinstance(p, (BytesIOPayload, BytesPayload)) for p in payloads)
+    # add_bytes (the in-memory path) must not be used.
     ipfs_client.add_bytes.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_add_file_raises_when_no_entry_returned():
-    """If aioipfs.add yields nothing (should not happen for a real file), we
-    fail loudly rather than returning a bogus CID."""
+async def test_add_file_raises_when_no_entry_returned(tmp_path):
+    """If the add endpoint yields nothing (should not happen for a real file),
+    we fail loudly rather than returning a bogus CID."""
+    file_path = tmp_path / "upload.bin"
+    file_path.write_bytes(b"data")
 
-    async def empty_add(*files, **kwargs):
-        return
-        yield  # pragma: no cover - marks this as an async generator
-
-    ipfs_client = AsyncMock()
-    ipfs_client.add = empty_add
+    captured: dict = {}
+    ipfs_client = _make_storage_client(_add_generic_capture([], captured))
     service = IpfsService(ipfs_client=ipfs_client)
 
     with pytest.raises(ValueError):
-        await service.add_file("/tmp/upload.bin")
+        await service.add_file(file_path)

--- a/tests/services/test_ipfs_service.py
+++ b/tests/services/test_ipfs_service.py
@@ -286,13 +286,10 @@ def _add_generic_capture(entries, captured):
 
 
 def _make_storage_client(add_generic):
-    """AsyncMock storage client whose ``.core`` exposes the real
-    _build_add_params (a pure param mapper) and a caller-supplied add_generic,
-    mirroring aioipfs.AsyncIPFS.core (CoreAPI)."""
+    """AsyncMock storage client whose ``.core`` exposes a caller-supplied
+    add_generic, mirroring aioipfs.AsyncIPFS.core (CoreAPI)."""
     ipfs_client = AsyncMock()
-    core = ipfs_client.core
-    core.add_generic = add_generic
-    core._build_add_params = aioipfs.api.CoreAPI._build_add_params.__get__(core)
+    ipfs_client.core.add_generic = add_generic
     return ipfs_client
 
 
@@ -319,8 +316,8 @@ async def test_add_file_streams_from_disk_with_buffered_reader(tmp_path):
     cid = await service.add_file(file_path, cid_version=0)
 
     assert cid == "QmStreamedCid"
-    # cid_version is forwarded as the IPFS query param.
-    assert captured["params"]["cid-version"] == "0"
+    # cid_version is forwarded as the kubo /api/v0/add query param.
+    assert captured["params"] == {"cid-version": "0"}
     # The file is streamed from disk, not buffered in memory.
     payloads = [part[0] for part in captured["mpart"]._parts]
     assert any(isinstance(p, BufferedReaderPayload) for p in payloads)


### PR DESCRIPTION
## Problem

The streaming `add_file` path merged in #1213 crashes in production on every IPFS file upload:

```
File "/opt/pyaleph/src/aleph/web/controllers/ipfs.py", line 197, in ipfs_add_file
  cid = await ipfs_service.add_file(uploaded_file.get_temp_file_path())
File "/opt/pyaleph/src/aleph/services/ipfs/service.py", line 331, in add_file
  async for entry in self.storage_client.add(...)
File ".../aioipfs/api.py", line 1399, in add
  file_payload = payload.BytesIOPayload(...)
File ".../aiohttp/payload.py", line 851, in __init__
  self._size = len(self._value.getbuffer()) - self._value.tell()
AttributeError: '_io.BufferedReader' object has no attribute 'getbuffer'
```

## Root cause

`aioipfs.AsyncIPFS.add()`, for a single file, opens it with `open(path, "rb")` (an `io.BufferedReader`) and wraps it in aiohttp's `BytesIOPayload`. On aiohttp >= 3.13, `BytesIOPayload.__init__` calls `value.getbuffer()`, which only exists on `io.BytesIO`, not on a `BufferedReader`. We ship aiohttp 3.13.5, so the call always raises.

aioipfs 0.7.1 is the latest release and still has this bug (its directory branch correctly uses `BufferedReaderPayload`; only the single-file branch is wrong), so there is no upstream version to pick up.

## Fix

Build the multipart request ourselves with aiohttp's `BufferedReaderPayload` (the correct payload for a file object, which streams it from disk in chunks) and post it through `CoreAPI.add_generic`. This keeps the memory win from #1213 (the file is never buffered in RAM) without the crash.

## Why the tests missed it

The existing tests mocked `storage_client.add`, so the real aioipfs/aiohttp payload construction never ran. The updated tests capture the multipart handed to `add_generic` and assert it carries a streaming `BufferedReaderPayload`, never an in-memory `BytesIOPayload`/`BytesPayload`, so a regression here would now fail in CI.

## Verification

- New/updated unit tests in `tests/services/test_ipfs_service.py` pass (16 passed).
- API upload suites `tests/api/test_ipfs.py` + `tests/api/test_storage.py` pass (50 passed).
- End to end against a real kubo 0.41 daemon: streaming `add_file` yields the **same CID** as `add_bytes` for the same content (`QmWiEuiWvVUE7dH3uswANBT7LRb54Nnu2YZMShaLMzkV7D`) and the content is retrievable via `cat`.