### PR TITLE
perf(credits): drain expense lots set-based instead of per-address

### DIFF
--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -18,7 +18,8 @@ from typing import (
 )
 
 from aleph_message.models import Chain, MessageType
-from sqlalchemy import case, func, select, text
+from sqlalchemy import BigInteger, String, bindparam, case, func, select, text
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.sql import ColumnElement, Select
 
@@ -641,6 +642,122 @@ def update_credit_balances_distribution(
     _bulk_insert_credit_history(session, csv_rows)
 
 
+# FIFO drain of every eligible lot for a whole expense batch in one UPDATE.
+#
+# ``requested`` sums the per-entry amounts for each address (repeated addresses
+# in one message add up, exactly as sequential per-entry draining would, since
+# lots never go negative). ``ranked`` walks each address's lots in emission
+# order and exposes ``prev_cumulative``: the summed ``amount_remaining`` of all
+# strictly-earlier lots. A lot therefore yields
+# ``LEAST(amount_remaining, requested - prev_cumulative)``; lots whose earlier
+# siblings already cover the request (``prev_cumulative >= requested``) drop out
+# via the final WHERE clause, and any over-draw is silently capped because a
+# lot is never decremented below zero.
+_CONSUME_CREDITS_BATCH_SQL = text(
+    """
+    WITH requested AS (
+        SELECT address, SUM(amount)::bigint AS requested
+        FROM unnest(:addresses, :amounts) AS t(address, amount)
+        GROUP BY address
+    ),
+    ranked AS (
+        SELECT
+            cb.address,
+            cb.credit_ref,
+            cb.credit_index,
+            cb.amount_remaining,
+            r.requested,
+            COALESCE(
+                SUM(cb.amount_remaining) OVER (
+                    PARTITION BY cb.address
+                    ORDER BY
+                        cb.message_timestamp ASC,
+                        cb.credit_ref ASC,
+                        cb.credit_index ASC
+                    ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+                ),
+                0
+            ) AS prev_cumulative
+        FROM credit_balances cb
+        JOIN requested r ON r.address = cb.address
+        WHERE cb.amount_remaining > 0
+          AND cb.message_timestamp <= :expense_ts
+          AND (cb.expiration_date IS NULL OR cb.expiration_date > :expense_ts)
+    )
+    UPDATE credit_balances cb
+    SET amount_remaining =
+            cb.amount_remaining
+            - LEAST(ranked.amount_remaining, ranked.requested - ranked.prev_cumulative),
+        last_update = now()
+    FROM ranked
+    WHERE cb.address = ranked.address
+      AND cb.credit_ref = ranked.credit_ref
+      AND cb.credit_index = ranked.credit_index
+      AND ranked.requested > ranked.prev_cumulative
+    """
+).bindparams(
+    bindparam("addresses", type_=ARRAY(String)),
+    bindparam("amounts", type_=ARRAY(BigInteger)),
+)
+
+# Lock the batch's eligible lots up front in a deterministic global order.
+# A window function forbids FOR UPDATE in the same query, so the lock is a
+# separate statement; ordering by address then emission order gives every
+# concurrent writer the same lock order, serialising same-address writers (as
+# the row-by-row FOR UPDATE did) without deadlocking.
+_LOCK_CREDITS_BATCH_SQL = text(
+    """
+    SELECT 1
+    FROM credit_balances
+    WHERE address = ANY(:addresses)
+      AND amount_remaining > 0
+      AND message_timestamp <= :expense_ts
+      AND (expiration_date IS NULL OR expiration_date > :expense_ts)
+    ORDER BY address, message_timestamp, credit_ref, credit_index
+    FOR UPDATE
+    """
+).bindparams(bindparam("addresses", type_=ARRAY(String)))
+
+
+def _consume_credits_batch(
+    session: DbSession,
+    addresses: Sequence[str],
+    amounts: Sequence[int],
+    message_timestamp: dt.datetime,
+) -> None:
+    """Drain the still-valid lots of every address in an expense message at once.
+
+    ``addresses`` and ``amounts`` are parallel arrays holding one entry per
+    expense line (post precision multiplier). This is the set-based equivalent
+    of calling :func:`_consume_address_credits` once per entry: same eligibility
+    (still-funded, granted at or before the expense, not yet expired at the
+    expense instant) and same FIFO order (``message_timestamp``, ``credit_ref``,
+    ``credit_index``). Multiple lines for one address sum together; over-draw is
+    silently dropped because lots never go negative.
+    """
+    # Only positive amounts consume anything, mirroring the ``amount <= 0``
+    # short-circuit in _consume_address_credits.
+    filtered = [(addr, amt) for addr, amt in zip(addresses, amounts) if amt > 0]
+    if not filtered:
+        return
+
+    addr_array = [addr for addr, _ in filtered]
+    amt_array = [amt for _, amt in filtered]
+
+    session.execute(
+        _LOCK_CREDITS_BATCH_SQL,
+        {"addresses": addr_array, "expense_ts": message_timestamp},
+    )
+    session.execute(
+        _CONSUME_CREDITS_BATCH_SQL,
+        {
+            "addresses": addr_array,
+            "amounts": amt_array,
+            "expense_ts": message_timestamp,
+        },
+    )
+
+
 def update_credit_balances_expense(
     session: DbSession,
     credits_list: Sequence[Dict[str, Any]],
@@ -657,6 +774,8 @@ def update_credit_balances_expense(
 
     last_update = utc_now()
     csv_rows = []
+    addresses: List[str] = []
+    amounts: List[int] = []
 
     for index, credit_entry in enumerate(credits_list):
         address = credit_entry["address"]
@@ -667,12 +786,8 @@ def update_credit_balances_expense(
         tx_hash = credit_entry.get("node_id", "")
         price = credit_entry.get("price", "")
 
-        _consume_address_credits(
-            session=session,
-            address=address,
-            amount=amount,
-            message_timestamp=message_timestamp,
-        )
+        addresses.append(address)
+        amounts.append(amount)
 
         csv_rows.append(
             _format_csv_row(
@@ -694,6 +809,18 @@ def update_credit_balances_expense(
                 "credit_expense",
             )
         )
+
+    # Drain every address's lots for the whole message in two set-based
+    # statements instead of a SELECT ... FOR UPDATE + flush per address. The
+    # per-address loop turned into one DB round-trip per address (tens of
+    # thousands for a large expense batch); the set-based drain collapses that
+    # to a single lock + a single UPDATE.
+    _consume_credits_batch(
+        session=session,
+        addresses=addresses,
+        amounts=amounts,
+        message_timestamp=message_timestamp,
+    )
 
     _bulk_insert_credit_history(session, csv_rows)
 

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -3105,3 +3105,169 @@ def test_resource_filter_matches_effective_origin(session_factory: DbSessionFact
             )
             == 0
         )
+
+
+# ---------------------------------------------------------------------------
+# Batch expense semantics: one expense message carrying many addresses.
+#
+# These pin the behaviour the set-based drain must preserve: each address is
+# drained independently in FIFO order, over-draw on one address never bleeds
+# into another, and a full -amount history row is written per entry regardless
+# of how much was actually consumed.
+# ---------------------------------------------------------------------------
+
+MULT = 10_000  # precision multiplier for pre-2026-02-02 messages
+
+_T1 = dt.datetime(2024, 3, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+_T2 = dt.datetime(2024, 3, 2, 12, 0, 0, tzinfo=dt.timezone.utc)
+_EXPENSE_TS = dt.datetime(2024, 3, 3, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+
+def test_expense_batch_multiple_addresses_independent_fifo(
+    session_factory: DbSessionFactory,
+):
+    """One expense message with several addresses drains each independently.
+
+    A: two non-expiring lots (300 @ T1, 300 @ T2), expense 400 -> FIFO drains
+       the T1 lot fully then 100 from the T2 lot -> 200 remaining.
+    B: single lot 1000, expense 250 -> 750 remaining.
+    C: single lot 100, expense 500 (over-draw) -> 0 remaining, excess dropped.
+    """
+    with session_factory() as session:
+        _give_credits(session, "0xA", 300, None, "a1", _T1)
+        _give_credits(session, "0xA", 300, None, "a2", _T2)
+        _give_credits(session, "0xB", 1000, None, "b1", _T1)
+        _give_credits(session, "0xC", 100, None, "c1", _T1)
+        session.commit()
+
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {"address": "0xA", "amount": 400, "ref": "exp_a"},
+                {"address": "0xB", "amount": 250, "ref": "exp_b"},
+                {"address": "0xC", "amount": 500, "ref": "exp_c"},
+            ],
+            message_hash="batch_expense",
+            message_timestamp=_EXPENSE_TS,
+        )
+        session.commit()
+
+        assert get_credit_balance(session, "0xA") == 200 * MULT
+        assert get_credit_balance(session, "0xB") == 750 * MULT
+        assert get_credit_balance(session, "0xC") == 0
+
+        # The A lots drain in FIFO order: a1 emptied, a2 partially consumed.
+        a1 = session.execute(
+            select(AlephCreditBalanceDb.amount_remaining).where(
+                AlephCreditBalanceDb.address == "0xA",
+                AlephCreditBalanceDb.credit_ref == "a1",
+            )
+        ).scalar_one()
+        a2 = session.execute(
+            select(AlephCreditBalanceDb.amount_remaining).where(
+                AlephCreditBalanceDb.address == "0xA",
+                AlephCreditBalanceDb.credit_ref == "a2",
+            )
+        ).scalar_one()
+        assert a1 == 0
+        assert a2 == 200 * MULT
+
+        # A full -amount history row is written per entry, over-draw included.
+        rows = {
+            r.address: r.amount
+            for r in session.execute(
+                select(AlephCreditHistoryDb).where(
+                    AlephCreditHistoryDb.credit_ref == "batch_expense"
+                )
+            ).scalars()
+        }
+        assert rows == {"0xA": -400 * MULT, "0xB": -250 * MULT, "0xC": -500 * MULT}
+
+
+def test_expense_batch_matches_sequential_single_expenses(
+    session_factory: DbSessionFactory,
+):
+    """Draining N addresses in one message equals N single-address messages.
+
+    Builds identical lot state under two disjoint address namespaces, applies
+    the expenses as one batch on one side and as separate messages on the
+    other, and asserts every resulting balance matches.
+    """
+    specs = [
+        # (suffix, lots [(amount, ts, ref)], expense_amount)
+        ("p", [(500, _T1, "l1"), (500, _T2, "l2")], 700),
+        ("q", [(1000, _T1, "l1")], 999),
+        ("r", [(100, _T1, "l1"), (100, _T2, "l2")], 250),  # over-draw
+        ("s", [(0, _T1, "l1")], 0),  # empty lot, zero expense
+    ]
+
+    with session_factory() as session:
+        for suffix, lots, _ in specs:
+            for amount, ts, ref in lots:
+                if amount:
+                    _give_credits(session, f"batch_{suffix}", amount, None, ref, ts)
+                    _give_credits(session, f"seq_{suffix}", amount, None, ref, ts)
+        session.commit()
+
+        # Batch: a single expense message for all addresses.
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {"address": f"batch_{s}", "amount": amt, "ref": f"e_{s}"}
+                for s, _, amt in specs
+            ],
+            message_hash="equiv_batch",
+            message_timestamp=_EXPENSE_TS,
+        )
+
+        # Sequential: one expense message per address.
+        for suffix, _, amt in specs:
+            update_credit_balances_expense(
+                session=session,
+                credits_list=[{"address": f"seq_{suffix}", "amount": amt, "ref": "e"}],
+                message_hash=f"equiv_seq_{suffix}",
+                message_timestamp=_EXPENSE_TS,
+            )
+        session.commit()
+
+        for suffix, _, _ in specs:
+            assert get_credit_balance(session, f"batch_{suffix}") == get_credit_balance(
+                session, f"seq_{suffix}"
+            ), suffix
+
+
+def test_expense_same_address_multiple_entries_drains_sequentially(
+    session_factory: DbSessionFactory,
+):
+    """Two entries for the same address in one message drain cumulatively.
+
+    A single 500 lot with two 300 expense entries: the first consumes 300, the
+    second consumes the remaining 200 (excess dropped), leaving 0. Both entries
+    still record a full -300 history row.
+    """
+    with session_factory() as session:
+        _give_credits(session, "0xD", 500, None, "d1", _T1)
+        session.commit()
+
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {"address": "0xD", "amount": 300, "ref": "d_first"},
+                {"address": "0xD", "amount": 300, "ref": "d_second"},
+            ],
+            message_hash="dup_expense",
+            message_timestamp=_EXPENSE_TS,
+        )
+        session.commit()
+
+        assert get_credit_balance(session, "0xD") == 0
+
+        history = sorted(
+            (r.credit_index, r.amount)
+            for r in session.execute(
+                select(AlephCreditHistoryDb).where(
+                    AlephCreditHistoryDb.credit_ref == "dup_expense"
+                )
+            ).scalars()
+        )
+        assert history == [(0, -300 * MULT), (1, -300 * MULT)]


### PR DESCRIPTION
## Problem

Applying a credit expense message drained each address's lots in a Python loop: one `SELECT ... FOR UPDATE` plus a `session.flush()` per address (`_consume_address_credits`). A large expense turned into tens of thousands of synchronous DB round-trips, and the ever-growing SQLAlchemy identity map made each per-address flush progressively more expensive. Observed on a production node: a 27,143-address expense ran for 2+ minutes and appeared to stall near the end.

```
[INFO] Updating credit balances expense for 27143 addresses   19:33:59
[INFO] Done updating credit balances                          19:36:08   (2m09s)
```

## Change

Replace the per-address loop with a set-based drain that processes the whole message in **two statements**:

1. `SELECT ... FOR UPDATE` that locks every eligible lot for the batch in a deterministic global order (`address, message_timestamp, credit_ref, credit_index`), preserving the old per-address lock serialization and avoiding deadlocks. It is a separate statement because Postgres forbids `FOR UPDATE` alongside a window function.
2. A single `UPDATE ... FROM` whose window function does the FIFO allocation: `prev_cumulative` is the summed `amount_remaining` of strictly-earlier lots per address, so each lot yields `LEAST(amount_remaining, requested - prev_cumulative)`; fully-covered lots drop out via the `WHERE`, and over-draw is capped because a lot is never decremented below zero.

The history-row build and the bulk `COPY` are unchanged. The transfer path keeps the per-lot `_consume_address_credits` helper (single sender, not the hotspot).

### Semantics preserved
Lot eligibility (still-funded, granted at or before the expense, not yet expired at the expense instant), FIFO order, over-draw dropping, per-entry `-amount` history rows, the `amount <= 0` no-op, and the precision multiplier (still applied in Python before the arrays are built).

## Impact

~55,000+ round-trips (plus the growing identity-map flush cost) collapse to 2 statements + the existing history COPY. The expense should drop from minutes to well under a second, and it no longer holds `FOR UPDATE` locks for the whole duration.

## Tests

- `tests/db/test_credit_balances.py`: 57 passed (54 pre-existing + 3 new).
- `tests/message_processing/test_process_posts.py`: 11 passed.
- The 3 new characterization tests were confirmed green against the old loop first, then against the new implementation: independent per-address FIFO, over-draw isolation, batch-vs-sequential equivalence, and same-address-twice cumulative draining.

## Follow-up (not in this PR)

Worth checking `credit_balances` bloat / autovacuum on the slow node, since table bloat also inflates the per-query latency.