### PR TITLE
fix(credit): correct daily cost accounting and removal reason for credit payments

### DIFF
--- a/src/aleph/jobs/cron/credit_balance_job.py
+++ b/src/aleph/jobs/cron/credit_balance_job.py
@@ -23,7 +23,7 @@ from aleph.db.models.cron_jobs import CronJobDb
 from aleph.db.models.messages import MessageDb, MessageStatusDb
 from aleph.jobs.cron.cron_job import BaseCronJob
 from aleph.services.cost import calculate_storage_size
-from aleph.toolkit.constants import CREDIT_ONLY_CUTOFF_TIMESTAMP, MiB
+from aleph.toolkit.constants import CREDIT_ONLY_CUTOFF_TIMESTAMP, DAY, MiB
 from aleph.toolkit.timestamp import utc_now
 from aleph.types.db_session import DbSession, DbSessionFactory
 from aleph.types.message_status import MessageStatus
@@ -65,11 +65,18 @@ class CreditBalanceCronJob(BaseCronJob):
                         f"Checking credit message {item_hash} with cost {cost} credits"
                     )
 
-                    # For credits, check if balance is insufficient for minimum 1-day runtime
-                    # Cost is per hour, so multiply by 24 for daily requirement
-                    daily_cost = cost * 24
+                    # For credits, check if balance is insufficient for minimum 1-day
+                    # runtime. Costs in account_costs are stored per-second, so multiply
+                    # by DAY (seconds per day) to get the per-day requirement, matching
+                    # the ingest-time check in cost_validation.validate_balance_for_payment.
+                    daily_cost = cost * DAY
                     should_remove = remaining_credits < daily_cost
-                    remaining_credits = max(0, remaining_credits - cost)
+                    # Reserve a full day of this resource's runtime so the next
+                    # resource is checked against what is actually left, matching the
+                    # per-day threshold above (decrementing by the per-second cost
+                    # would let an account keep many resources it cannot afford for a
+                    # day, which the ingest-time check already rejects).
+                    remaining_credits = max(0, remaining_credits - daily_cost)
 
                     status = get_message_status(session, item_hash)
                     if status is None:

--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 import aio_pika.abc
 import aiohttp.web_ws
 from aiohttp import WSCloseCode, WSMsgType, web
-from aleph_message.models import ItemHash, MessageType
+from aleph_message.models import ItemHash, MessageType, PaymentType
 from configmanager import Config
 from pydantic import ValidationError
 from sqlalchemy.orm import defer
@@ -966,6 +966,23 @@ async def messages_ws(request: web.Request) -> web.WebSocketResponse:
     return ws
 
 
+def _removal_reason(payment_type: Optional[str]) -> RemovedMessageReason:
+    """Reason matching the message's payment type.
+
+    Credit-paid messages are removed by the credit balance cron when credits run
+    out; hold/superfluid messages by the token balance cron. Reporting the matching
+    reason avoids surfacing ``balance_insufficient`` for a credit shortfall.
+
+    Uses the persisted ``payment_type`` column (set at ingestion, and copied to
+    the removed_messages snapshot at removal) rather than re-parsing the content,
+    so it reflects what was stored and avoids a redundant content validation on
+    every removed-message read.
+    """
+    if payment_type == PaymentType.credit.value:
+        return RemovedMessageReason.CREDIT_INSUFFICIENT
+    return RemovedMessageReason.BALANCE_INSUFFICIENT
+
+
 def _get_message_with_status(
     session: DbSession,
     status_db: MessageStatusDb,
@@ -1040,7 +1057,7 @@ def _get_message_with_status(
             item_hash=item_hash,
             reception_time=reception_time,
             message=message,
-            reason=RemovedMessageReason.BALANCE_INSUFFICIENT,
+            reason=_removal_reason(message_db.payment_type),
         )
 
     if status == MessageStatus.REMOVED:
@@ -1054,7 +1071,7 @@ def _get_message_with_status(
             item_hash=item_hash,
             reception_time=reception_time,
             message=RemovedMessage.model_validate(removed_message_db),
-            reason=RemovedMessageReason.BALANCE_INSUFFICIENT,
+            reason=_removal_reason(removed_message_db.payment_type),
             removed_at=removed_message_db.removed_at,
             size=removed_message_db.size,
         )

--- a/tests/api/test_get_message.py
+++ b/tests/api/test_get_message.py
@@ -12,16 +12,19 @@ from aleph.db.models import (
     PendingMessageDb,
     RejectedMessageDb,
 )
+from aleph.db.models.messages import RemovedMessageDb
 from aleph.schemas.api.messages import (
     ForgottenMessageStatus,
     PendingMessageStatus,
     ProcessedMessageStatus,
     RejectedMessageStatus,
+    RemovedMessageStatus,
+    RemovingMessageStatus,
 )
 from aleph.toolkit.timestamp import timestamp_to_datetime
 from aleph.types.channel import Channel
 from aleph.types.db_session import DbSessionFactory
-from aleph.types.message_status import ErrorCode, MessageStatus
+from aleph.types.message_status import ErrorCode, MessageStatus, RemovedMessageReason
 
 MESSAGE_URI = "/api/v0/messages/{}"
 MESSAGE_CONTENT_URI = "/api/v0/messages/{}/content"
@@ -168,11 +171,54 @@ def fixture_messages_with_status(
         )
     ]
 
+    # Credit-paid store message removed for insufficient credits. The
+    # messages row is deleted at removal, so only the snapshot remains.
+    removed_messages = [
+        RemovedMessageDb(
+            item_hash="a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+            chain=Chain.ETH,
+            sender="0xD7722B35140a3E87A41003b8b6195eF918c2D727",
+            owner="0xD7722B35140a3E87A41003b8b6195eF918c2D727",
+            signature="0xremovedsig",
+            item_type=ItemType.inline,
+            type=MessageType.store,
+            payment_type="credit",
+            size=154,
+            time=timestamp_to_datetime(1645794065.439),
+            channel=Channel("TEST"),
+            removed_at=timestamp_to_datetime(1645794165.439),
+        )
+    ]
+
+    # Hold-paid store message in the removing grace period.
+    removing_messages = [
+        MessageDb(
+            item_hash="b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3",
+            chain=Chain.ETH,
+            sender="0xB68B9D4f3771c246233823ed1D3Add451055F9Ef",
+            signature="0xremovingsig",
+            item_type=ItemType.inline,
+            type=MessageType.store,
+            item_content=None,
+            content={
+                "address": "0xB68B9D4f3771c246233823ed1D3Add451055F9Ef",
+                "time": 1645794065.439,
+                "item_type": "storage",
+                "item_hash": "QmTQPocJ8n3r7jhwYxmCDR5bJ4SNsEhdVm8WwkNbGctgJF",
+            },
+            size=154,
+            time=timestamp_to_datetime(1645794065.439),
+            channel=Channel("TEST"),
+        )
+    ]
+
     messages_dict: Mapping[MessageStatus, Sequence[Any]] = {
         MessageStatus.PENDING: pending_messages,
         MessageStatus.PROCESSED: processed_messages,
         MessageStatus.FORGOTTEN: forgotten_messages,
         MessageStatus.REJECTED: rejected_messages,
+        MessageStatus.REMOVING: removing_messages,
+        MessageStatus.REMOVED: removed_messages,
     }
 
     with session_factory() as session:
@@ -256,6 +302,40 @@ async def test_get_rejected_message_status(
 
         # Check that the traceback is not included in the response
         assert "traceback" not in response_json
+
+
+@pytest.mark.parametrize(
+    "status, status_cls, expected_reason",
+    [
+        (
+            MessageStatus.REMOVED,
+            RemovedMessageStatus,
+            RemovedMessageReason.CREDIT_INSUFFICIENT,
+        ),
+        (
+            MessageStatus.REMOVING,
+            RemovingMessageStatus,
+            RemovedMessageReason.BALANCE_INSUFFICIENT,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_removed_message_reason_matches_payment_type(
+    fixture_messages_with_status: Mapping[MessageStatus, Sequence[Any]],
+    ccn_api_client,
+    status,
+    status_cls,
+    expected_reason,
+):
+    """The removal reason reflects the message payment type: credit-paid removals
+    report credit_insufficient, hold/superfluid ones report balance_insufficient."""
+    for message in fixture_messages_with_status[status]:
+        response = await ccn_api_client.get(MESSAGE_URI.format(message.item_hash))
+        assert response.status == 200, await response.text()
+        parsed_response = status_cls.model_validate(await response.json())
+        assert parsed_response.status == status
+        assert parsed_response.item_hash == message.item_hash
+        assert parsed_response.reason == expected_reason
 
 
 @pytest.mark.asyncio

--- a/tests/jobs/test_credit_balance_job.py
+++ b/tests/jobs/test_credit_balance_job.py
@@ -1,7 +1,15 @@
+import datetime as dt
+from decimal import Decimal
+
 import pytest
-from aleph_message.models import Chain, ItemHash, ItemType, MessageType
+import pytest_asyncio
+from aleph_message.models import Chain, ItemHash, ItemType, MessageType, PaymentType
 
 from aleph.db.accessors.messages import get_message_status, get_removed_message
+from aleph.db.models import AlephCreditBalanceDb, AlephCreditHistoryDb
+from aleph.db.models.account_costs import AccountCostsDb
+from aleph.db.models.chains import ChainTxDb
+from aleph.db.models.cron_jobs import CronJobDb
 from aleph.db.models.files import (
     FilePinType,
     GracePeriodFilePinDb,
@@ -10,8 +18,14 @@ from aleph.db.models.files import (
 )
 from aleph.db.models.messages import MessageDb, MessageStatusDb, RemovedMessageDb
 from aleph.jobs.cron.credit_balance_job import CreditBalanceCronJob
-from aleph.toolkit.constants import DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE, MiB
+from aleph.toolkit.constants import (
+    DAY,
+    DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE,
+    MiB,
+)
 from aleph.toolkit.timestamp import utc_now
+from aleph.types.chain_sync import ChainSyncProtocol
+from aleph.types.cost import CostType
 from aleph.types.db_session import DbSessionFactory
 from aleph.types.files import FileType
 from aleph.types.message_status import MessageStatus
@@ -202,3 +216,237 @@ async def test_credit_balance_job_delete_keeps_removed_status(
         removed_message = get_removed_message(session=session, item_hash=MESSAGE_HASH)
         assert removed_message is not None
         assert removed_message.removed_at == removed_at
+
+
+@pytest.fixture
+def now():
+    return utc_now()
+
+
+def _create_cron_job(id, now):
+    return CronJobDb(
+        id=id,
+        interval=1,
+        last_run=now - dt.timedelta(hours=1),
+    )
+
+
+def _create_credit_instance(
+    session_factory,
+    now,
+    *,
+    address,
+    item_hash,
+    cost_credit_per_second,
+):
+    """Create a credit-paid INSTANCE message with a PROCESSED status and a per-second
+    credit cost record. The address balance is created separately so several
+    instances can share one balance."""
+    message = MessageDb(
+        item_hash=item_hash,
+        sender=address,
+        chain=Chain.ETH,
+        type=MessageType.instance,
+        time=now,
+        item_type=ItemType.inline,
+        signature=f"sig_{item_hash[:8]}",
+        size=1000,
+        content={
+            "address": address,
+            "time": now.timestamp(),
+            "payment": {"type": "credit", "chain": "ETH"},
+        },
+    )
+
+    chain_tx = ChainTxDb(
+        hash=f"0xtx_{item_hash[:8]}",
+        chain=Chain.ETH,
+        height=1_000_000,
+        datetime=now,
+        publisher="0xabadbabe",
+        protocol=ChainSyncProtocol.OFF_CHAIN_SYNC,
+        protocol_version=1,
+        content="Qmsomething",
+    )
+    message.confirmations = [chain_tx]
+
+    message_status = MessageStatusDb(
+        item_hash=item_hash,
+        status=MessageStatus.PROCESSED,
+        reception_time=now,
+    )
+
+    cost = AccountCostsDb(
+        owner=address,
+        item_hash=item_hash,
+        type=CostType.EXECUTION,
+        name="instance",
+        payment_type=PaymentType.credit,
+        cost_hold=Decimal("0"),
+        cost_stream=Decimal("0"),
+        cost_credit=Decimal(str(cost_credit_per_second)),
+    )
+
+    with session_factory() as session:
+        session.add(message)
+        session.commit()
+        session.add_all([message_status, cost])
+        session.commit()
+
+
+def _create_credit_balance(session_factory, now, *, address, amount, ref="grant"):
+    """Give ``address`` a single non-expiring credit lot of ``amount`` plus a fresh
+    credit-history row so get_updated_credit_balance_accounts surfaces the account."""
+    credit_lot = AlephCreditBalanceDb(
+        address=address,
+        credit_ref=ref,
+        credit_index=0,
+        amount_remaining=int(amount),
+        expiration_date=None,
+        message_timestamp=now - dt.timedelta(days=1),
+        last_update=now,
+    )
+    credit_history = AlephCreditHistoryDb(
+        address=address,
+        amount=int(amount),
+        credit_ref=ref,
+        credit_index=0,
+        expiration_date=None,
+        message_timestamp=now - dt.timedelta(days=1),
+        last_update=now,
+    )
+    with session_factory() as session:
+        session.add_all([credit_lot, credit_history])
+        session.commit()
+
+
+@pytest_asyncio.fixture
+async def fixture_base_cron(session_factory, now):
+    with session_factory() as session:
+        session.add(_create_cron_job("credit_check_base", now))
+        session.commit()
+    return "credit_check_base"
+
+
+@pytest.mark.asyncio
+async def test_credit_job_removes_instance_that_cannot_afford_one_day(
+    session_factory, credit_balance_job, fixture_base_cron, now
+):
+    """An instance whose credit balance covers far less than one day of runtime must
+    be marked for removal.
+
+    Costs in account_costs are stored per-second. With a per-second cost of 1 credit,
+    one day of runtime requires ``1 * DAY`` (86400) credits. A balance of 3600 credits
+    (one hour) is therefore insufficient and the instance must enter REMOVING.
+
+    This fails while the cron multiplies the per-second cost by 24 (treating it as an
+    hourly rate): the threshold becomes 24 credits, 3600 >= 24, and the instance is
+    wrongly kept PROCESSED.
+    """
+    address = "0xcreditunderfunded"
+    item_hash = "ab" * 32
+
+    _create_credit_instance(
+        session_factory,
+        now,
+        address=address,
+        item_hash=item_hash,
+        cost_credit_per_second=1,
+    )
+    _create_credit_balance(
+        session_factory, now, address=address, amount=3600
+    )  # one hour of runtime
+
+    with session_factory() as session:
+        cron_job = session.query(CronJobDb).filter_by(id=fixture_base_cron).one()
+
+    await credit_balance_job.run(now, cron_job)
+
+    with session_factory() as session:
+        status = get_message_status(session=session, item_hash=item_hash)
+        assert status is not None
+        assert status.status == MessageStatus.REMOVING
+
+
+@pytest.mark.asyncio
+async def test_credit_job_keeps_instance_that_can_afford_one_day(
+    session_factory, credit_balance_job, fixture_base_cron, now
+):
+    """An instance whose credit balance comfortably covers more than one day of runtime
+    must stay PROCESSED (guard against over-removal after the unit fix)."""
+    address = "0xcreditfunded"
+    item_hash = "cd" * 32
+
+    _create_credit_instance(
+        session_factory,
+        now,
+        address=address,
+        item_hash=item_hash,
+        cost_credit_per_second=1,
+    )
+    _create_credit_balance(
+        session_factory, now, address=address, amount=2 * DAY
+    )  # two days of runtime
+
+    with session_factory() as session:
+        cron_job = session.query(CronJobDb).filter_by(id=fixture_base_cron).one()
+
+    await credit_balance_job.run(now, cron_job)
+
+    with session_factory() as session:
+        status = get_message_status(session=session, item_hash=item_hash)
+        assert status is not None
+        assert status.status == MessageStatus.PROCESSED
+
+
+@pytest.mark.asyncio
+async def test_credit_job_reserves_a_full_day_per_instance(
+    session_factory, credit_balance_job, fixture_base_cron, now
+):
+    """The running-balance check must reserve one full day of runtime per instance,
+    not one second.
+
+    Two instances cost 1 credit/second each (86400/day each, 172800/day combined).
+    The address holds 90000 credits: enough for a full day of ONE instance, but not
+    both. Exactly one instance must be removed.
+
+    This fails when the loop decrements the running balance by the per-second cost
+    instead of the per-day cost: after the first instance the balance barely drops
+    (90000 -> 89999), so the second instance is also compared against ~90000 >= 86400
+    and wrongly kept, leaving the account running two instances it cannot afford for a
+    day -- exactly what the ingest-time check (sum of costs * DAY) would have rejected.
+    """
+    address = "0xcredittwoinstances"
+    item_hash_a = "a1" * 32
+    item_hash_b = "b2" * 32
+
+    _create_credit_instance(
+        session_factory,
+        now,
+        address=address,
+        item_hash=item_hash_a,
+        cost_credit_per_second=1,
+    )
+    _create_credit_instance(
+        session_factory,
+        now,
+        address=address,
+        item_hash=item_hash_b,
+        cost_credit_per_second=1,
+    )
+    # One full day for a single instance plus a margin, far below two days.
+    _create_credit_balance(session_factory, now, address=address, amount=DAY + 3600)
+
+    with session_factory() as session:
+        cron_job = session.query(CronJobDb).filter_by(id=fixture_base_cron).one()
+
+    await credit_balance_job.run(now, cron_job)
+
+    with session_factory() as session:
+        statuses = {
+            get_message_status(session=session, item_hash=h).status
+            for h in (item_hash_a, item_hash_b)
+        }
+
+    # Exactly one instance affordable for a full day, the other removed.
+    assert statuses == {MessageStatus.PROCESSED, MessageStatus.REMOVING}


### PR DESCRIPTION
Three related fixes around credit-paid message removal, found while debugging an instance that was "removed" on one node and "processed" on another.

1. Credit balance cron daily-cost accounting. Costs in account_costs are stored per-second, but the cron treated them as hourly: it compared the balance against `cost * 24` (3600x too low) and then decremented the running balance by only `cost` (one second) per resource. Use `cost * DAY` (86400) for both the threshold and the per-resource reservation, so the check matches the ingest-time guard in cost_validation.validate_balance_for_payment (sum of per-second costs * DAY) and an account cannot keep more resources than it can fund for a day.

2. Removal reason in the message status endpoint. It hardcoded balance_insufficient for every REMOVING/REMOVED message, even credit-paid ones. Derive the reason from the persisted payment_type column so credit-paid removals report credit_insufficient and hold/superfluid ones report balance_insufficient.

Tests: tests/jobs/test_credit_balance_job.py covers the credit cron removal threshold and the per-resource daily reservation; tests/api/test_get_message.py covers the API removal reason for both payment types.