### PR TITLE
feat(billing): preserve termination metadata and price forgotten/removed STOREs

### DIFF
--- a/deployment/migrations/versions/0061_c7e2f9a4b1d3_forgotten_messages_billing_metadata.py
+++ b/deployment/migrations/versions/0061_c7e2f9a4b1d3_forgotten_messages_billing_metadata.py
@@ -1,0 +1,121 @@
+"""Preserve billing metadata on forgotten_messages
+
+Revision ID: c7e2f9a4b1d3
+Revises: a1d4e7b2c9f6
+Create Date: 2026-07-02
+
+Adds owner, payment_type, size and forgotten_at columns to
+forgotten_messages so forgotten STORE messages remain priceable and
+deletions can be windowed by deletion time.
+
+forgotten_at is backfilled from the first forgetting FORGET message still
+present in the messages table. owner/payment_type/size cannot be recovered
+for legacy rows (the source messages rows are already deleted) and stay NULL.
+
+The forgotten list endpoint filters by owner and windows/sorts on
+forgotten_at, so a composite (owner, forgotten_at) index and a plain
+forgotten_at index are added. Both are built CONCURRENTLY (same pattern as
+migration 0060) to avoid blocking writes on populated nodes.
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "c7e2f9a4b1d3"
+down_revision = "a1d4e7b2c9f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # IF NOT EXISTS: the CONCURRENT index step below commits the column
+    # additions and the backfill before alembic stamps the revision, so a
+    # rerun after an index failure must not error on the already-added
+    # columns (same reasoning as migration 0063).
+    op.execute(
+        text(
+            """
+        ALTER TABLE forgotten_messages ADD COLUMN IF NOT EXISTS owner VARCHAR;
+        ALTER TABLE forgotten_messages ADD COLUMN IF NOT EXISTS payment_type VARCHAR;
+        ALTER TABLE forgotten_messages ADD COLUMN IF NOT EXISTS size BIGINT;
+        ALTER TABLE forgotten_messages ADD COLUMN IF NOT EXISTS forgotten_at TIMESTAMPTZ;
+        """
+        )
+    )
+    op.execute(
+        text(
+            """
+        UPDATE forgotten_messages fm
+        SET forgotten_at = m.time
+        FROM messages m
+        WHERE m.item_hash = fm.forgotten_by[1]
+          AND fm.forgotten_at IS NULL
+        """
+        )
+    )
+
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+    connection = op.get_bind()
+
+    was_in_transaction = connection.in_transaction()
+    if was_in_transaction:
+        connection.execute(text("COMMIT"))
+
+    engine = connection.engine
+    with engine.connect() as conn:
+        conn = conn.execution_options(isolation_level="AUTOCOMMIT")
+        conn.execute(
+            text(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+                "ix_forgotten_messages_owner_forgotten_at "
+                "ON forgotten_messages (owner, forgotten_at)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+                "ix_forgotten_messages_forgotten_at "
+                "ON forgotten_messages (forgotten_at)"
+            )
+        )
+
+    if was_in_transaction:
+        connection.execute(text("BEGIN"))
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+
+    was_in_transaction = connection.in_transaction()
+    if was_in_transaction:
+        connection.execute(text("COMMIT"))
+
+    engine = connection.engine
+    with engine.connect() as conn:
+        conn = conn.execution_options(isolation_level="AUTOCOMMIT")
+        conn.execute(
+            text(
+                "DROP INDEX CONCURRENTLY IF EXISTS ix_forgotten_messages_forgotten_at"
+            )
+        )
+        conn.execute(
+            text(
+                "DROP INDEX CONCURRENTLY IF EXISTS "
+                "ix_forgotten_messages_owner_forgotten_at"
+            )
+        )
+
+    if was_in_transaction:
+        connection.execute(text("BEGIN"))
+
+    op.execute(
+        text(
+            """
+        ALTER TABLE forgotten_messages DROP COLUMN IF EXISTS forgotten_at;
+        ALTER TABLE forgotten_messages DROP COLUMN IF EXISTS size;
+        ALTER TABLE forgotten_messages DROP COLUMN IF EXISTS payment_type;
+        ALTER TABLE forgotten_messages DROP COLUMN IF EXISTS owner;
+        """
+        )
+    )

--- a/deployment/migrations/versions/0061_c7e2f9a4b1d3_forgotten_messages_billing_metadata.py
+++ b/deployment/migrations/versions/0061_c7e2f9a4b1d3_forgotten_messages_billing_metadata.py
@@ -8,9 +8,12 @@ Adds owner, payment_type, size and forgotten_at columns to
 forgotten_messages so forgotten STORE messages remain priceable and
 deletions can be windowed by deletion time.
 
-forgotten_at is backfilled from the first forgetting FORGET message still
-present in the messages table. owner/payment_type/size cannot be recovered
-for legacy rows (the source messages rows are already deleted) and stay NULL.
+forgotten_at is the sender-supplied time of the forgetting FORGET message,
+backfilled from the first FORGET still present in the messages table — the
+same value on every node, consistent with the declared-time semantics the
+live message list uses for sorting, date filters and cursors.
+owner/payment_type/size cannot be recovered for legacy rows (the source
+messages rows are already deleted) and stay NULL.
 
 The forgotten list endpoint filters by owner and windows/sorts on
 forgotten_at, so a composite (owner, forgotten_at) index and a plain
@@ -54,7 +57,6 @@ def upgrade() -> None:
         """
         )
     )
-
     # CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
     connection = op.get_bind()
 

--- a/deployment/migrations/versions/0062_e4a8c2d6f1b9_credit_history_expense_aggregates.py
+++ b/deployment/migrations/versions/0062_e4a8c2d6f1b9_credit_history_expense_aggregates.py
@@ -1,0 +1,42 @@
+"""Add expense_count and expense_size_mib to credit_history
+
+Revision ID: e4a8c2d6f1b9
+Revises: c7e2f9a4b1d3
+Create Date: 2026-07-02
+
+v2 storage credit-expense messages aggregate per-file lines into one entry
+per address, carrying the number of files (count) and the total billed MiB
+(size). These columns expose that breakdown in the credit history; v1
+entries leave them NULL.
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "e4a8c2d6f1b9"
+down_revision = "c7e2f9a4b1d3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        text(
+            """
+        ALTER TABLE credit_history ADD COLUMN expense_count BIGINT;
+        ALTER TABLE credit_history ADD COLUMN expense_size_mib DECIMAL;
+        """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        text(
+            """
+        ALTER TABLE credit_history DROP COLUMN IF EXISTS expense_size_mib;
+        ALTER TABLE credit_history DROP COLUMN IF EXISTS expense_count;
+        """
+        )
+    )

--- a/deployment/migrations/versions/0063_f4b8a2d7c1e9_removed_messages_table.py
+++ b/deployment/migrations/versions/0063_f4b8a2d7c1e9_removed_messages_table.py
@@ -1,20 +1,33 @@
-"""Add removed_messages billing metadata table
+"""Add removed_messages snapshot table
 
 Revision ID: f4b8a2d7c1e9
 Revises: e4a8c2d6f1b9
 Create Date: 2026-07-06
 
-Two-phase removal record: the balance/credit-balance cron jobs snapshot the
-file size at PROCESSED->REMOVING (the garbage collector deletes the files row
+Snapshot table for removed messages, mirroring forgotten_messages: at
+REMOVING->REMOVED the garbage collector copies the billing metadata of the
+messages row here and deletes the row (confirmations/costs/metrics follow
+via ON DELETE CASCADE).
+
+Two-phase lifecycle: the balance/credit-balance cron jobs snapshot the file
+size at PROCESSED->REMOVING (the garbage collector deletes the files row
 before the status flips to REMOVED, so the size must be captured while the
-message is still alive), recovery deletes the row, and the garbage collector
-stamps removed_at at REMOVING->REMOVED.
+message is still alive), recovery deletes the record, and the garbage
+collector fills the metadata and stamps removed_at at REMOVING->REMOVED.
 
-No backfill: legacy REMOVED rows have an unknown removal time (mirrors legacy
-forgotten rows).
+removed_at is node-local (each node's GC finalizes removals on its own
+schedule) and NOT deterministic across nodes — unlike forgotten_at there is
+no sender-declared removal time to share.
 
-The removed list endpoint windows/sorts on removed_at, so its index is built
-CONCURRENTLY (same pattern as migration 0060) to avoid blocking writes.
+Existing REMOVED messages are moved into the snapshot: their metadata is
+copied (size best-effort from a still-existing files row, NULL otherwise;
+removed_at unknown -> NULL, mirroring legacy forgotten rows) and their
+messages rows are deleted.
+
+The removed list endpoint filters by owner and windows/sorts on removed_at,
+so a composite (owner, removed_at) index and a plain removed_at index are
+built CONCURRENTLY (same pattern as migration 0060) to avoid blocking
+writes.
 """
 
 from alembic import op
@@ -36,9 +49,64 @@ def upgrade() -> None:
             """
         CREATE TABLE IF NOT EXISTS removed_messages (
             item_hash VARCHAR PRIMARY KEY,
+            type VARCHAR,
+            chain VARCHAR,
+            sender VARCHAR,
+            signature VARCHAR,
+            item_type VARCHAR,
+            time TIMESTAMPTZ,
+            channel VARCHAR,
+            owner VARCHAR,
+            payment_type VARCHAR,
             size BIGINT,
             removed_at TIMESTAMPTZ
         )
+        """
+        )
+    )
+
+    # Move existing REMOVED messages into the snapshot. ON CONFLICT keeps
+    # reruns (and rows already snapshotted while REMOVING) intact except for
+    # the metadata, which only the messages row knows; an existing size
+    # snapshot always wins over the files lookup.
+    op.execute(
+        text(
+            """
+        INSERT INTO removed_messages (
+            item_hash, type, chain, sender, signature, item_type, time,
+            channel, owner, payment_type, size, removed_at
+        )
+        SELECT
+            m.item_hash, m.type, m.chain, m.sender, m.signature, m.item_type,
+            m.time, m.channel, m.owner,
+            COALESCE(m.payment_type, 'hold'),
+            f.size,
+            NULL
+        FROM messages m
+        JOIN message_status ms ON ms.item_hash = m.item_hash
+        LEFT JOIN files f ON f.hash = m.content_item_hash
+        WHERE ms.status = 'removed'
+        ON CONFLICT (item_hash) DO UPDATE SET
+            type = EXCLUDED.type,
+            chain = EXCLUDED.chain,
+            sender = EXCLUDED.sender,
+            signature = EXCLUDED.signature,
+            item_type = EXCLUDED.item_type,
+            time = EXCLUDED.time,
+            channel = EXCLUDED.channel,
+            owner = EXCLUDED.owner,
+            payment_type = EXCLUDED.payment_type,
+            size = COALESCE(removed_messages.size, EXCLUDED.size)
+        """
+        )
+    )
+    op.execute(
+        text(
+            """
+        DELETE FROM messages m
+        USING message_status ms
+        WHERE ms.item_hash = m.item_hash
+          AND ms.status = 'removed'
         """
         )
     )
@@ -56,6 +124,13 @@ def upgrade() -> None:
         conn.execute(
             text(
                 "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+                "ix_removed_messages_owner_removed_at "
+                "ON removed_messages (owner, removed_at)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
                 "ix_removed_messages_removed_at "
                 "ON removed_messages (removed_at)"
             )
@@ -66,4 +141,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # The messages rows moved into the snapshot cannot be resurrected: this
+    # only drops the table (dev convenience, data-destructive).
     op.execute(text("DROP TABLE IF EXISTS removed_messages"))

--- a/deployment/migrations/versions/0063_f4b8a2d7c1e9_removed_messages_table.py
+++ b/deployment/migrations/versions/0063_f4b8a2d7c1e9_removed_messages_table.py
@@ -1,0 +1,69 @@
+"""Add removed_messages billing metadata table
+
+Revision ID: f4b8a2d7c1e9
+Revises: e4a8c2d6f1b9
+Create Date: 2026-07-06
+
+Two-phase removal record: the balance/credit-balance cron jobs snapshot the
+file size at PROCESSED->REMOVING (the garbage collector deletes the files row
+before the status flips to REMOVED, so the size must be captured while the
+message is still alive), recovery deletes the row, and the garbage collector
+stamps removed_at at REMOVING->REMOVED.
+
+No backfill: legacy REMOVED rows have an unknown removal time (mirrors legacy
+forgotten rows).
+
+The removed list endpoint windows/sorts on removed_at, so its index is built
+CONCURRENTLY (same pattern as migration 0060) to avoid blocking writes.
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "f4b8a2d7c1e9"
+down_revision = "e4a8c2d6f1b9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # IF NOT EXISTS: the CONCURRENT index step below commits this CREATE
+    # before alembic stamps the revision, so a rerun after an index failure
+    # must not error on the already-created table.
+    op.execute(
+        text(
+            """
+        CREATE TABLE IF NOT EXISTS removed_messages (
+            item_hash VARCHAR PRIMARY KEY,
+            size BIGINT,
+            removed_at TIMESTAMPTZ
+        )
+        """
+        )
+    )
+
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+    connection = op.get_bind()
+
+    was_in_transaction = connection.in_transaction()
+    if was_in_transaction:
+        connection.execute(text("COMMIT"))
+
+    engine = connection.engine
+    with engine.connect() as conn:
+        conn = conn.execution_options(isolation_level="AUTOCOMMIT")
+        conn.execute(
+            text(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+                "ix_removed_messages_removed_at "
+                "ON removed_messages (removed_at)"
+            )
+        )
+
+    if was_in_transaction:
+        connection.execute(text("BEGIN"))
+
+
+def downgrade() -> None:
+    op.execute(text("DROP TABLE IF EXISTS removed_messages"))

--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -537,7 +537,7 @@ def _bulk_insert_credit_history(
 
     # Column specification for credit history
     # Include the new message_timestamp and bonus_amount fields
-    copy_columns = "address, amount, credit_ref, credit_index, message_timestamp, last_update, price, bonus_amount, tx_hash, expiration_date, token, chain, origin, provider, origin_ref, payment_method"
+    copy_columns = "address, amount, credit_ref, credit_index, message_timestamp, last_update, price, bonus_amount, tx_hash, expiration_date, token, chain, origin, provider, origin_ref, payment_method, expense_count, expense_size_mib"
 
     csv_credit_history = StringIO("\n".join(csv_rows))
     cursor.copy_expert(
@@ -635,6 +635,8 @@ def update_credit_balances_distribution(
                 provider,
                 origin_ref,
                 payment_method,
+                "",
+                "",
             )
         )
 
@@ -666,6 +668,9 @@ def update_credit_balances_expense(
         origin = credit_entry.get("execution_id", "")
         tx_hash = credit_entry.get("node_id", "")
         price = credit_entry.get("price", "")
+        # v2 aggregated entries carry the file count and total billed MiB.
+        expense_count = credit_entry.get("count")
+        expense_size_mib = credit_entry.get("size")
 
         _consume_address_credits(
             session=session,
@@ -692,6 +697,8 @@ def update_credit_balances_expense(
                 "ALEPH",
                 origin_ref,
                 "credit_expense",
+                expense_count if expense_count is not None else "",
+                expense_size_mib if expense_size_mib is not None else "",
             )
         )
 
@@ -783,6 +790,8 @@ def update_credit_balances_transfer(
                     "ALEPH",
                     "",
                     "credit_transfer",
+                    "",
+                    "",
                 )
             )
             index += 1
@@ -806,6 +815,8 @@ def update_credit_balances_transfer(
                     "ALEPH",
                     "",
                     "credit_transfer",
+                    "",
+                    "",
                 )
             )
             index += 1

--- a/src/aleph/db/accessors/messages.py
+++ b/src/aleph/db/accessors/messages.py
@@ -23,11 +23,13 @@ from aleph.types.message_status import (
 from aleph.types.sort_order import SortBy, SortByMessageType, SortOrder
 
 from ..models.chains import ChainTxDb
+from ..models.files import StoredFileDb
 from ..models.messages import (
     ForgottenMessageDb,
     MessageDb,
     MessageStatusDb,
     RejectedMessageDb,
+    RemovedMessageDb,
     message_confirmations,
 )
 from ..models.pending_messages import PendingMessageDb
@@ -528,8 +530,263 @@ def get_forgotten_message(
     ).scalar()
 
 
+def make_matching_forgotten_messages_query(
+    hashes: Optional[Sequence[ItemHash]] = None,
+    addresses: Optional[Sequence[str]] = None,
+    owners: Optional[Sequence[str]] = None,
+    chains: Optional[Sequence[Chain]] = None,
+    message_type: Optional[MessageType] = None,
+    message_types: Optional[Sequence[MessageType]] = None,
+    channels: Optional[Sequence[str]] = None,
+    payment_types: Optional[Sequence[PaymentType]] = None,
+    start_date: Optional[Union[float, dt.datetime]] = None,
+    end_date: Optional[Union[float, dt.datetime]] = None,
+    sort_order: SortOrder = SortOrder.DESCENDING,
+    page: int = 1,
+    pagination: int = 20,
+    # Non-filter query params (sort_by, ...) are passed through by callers;
+    # unsupported narrowing filters are rejected upstream with a 400.
+    **kwargs,
+) -> Select:
+    """
+    Filters on the forgotten_messages table. Unlike live-message queries, date
+    filters and time sorting apply to `forgotten_at` (the deletion time), not
+    `time`: the purpose of this query is windowed gap-detection by deletion
+    time. Legacy rows with NULL `forgotten_at` are excluded by date filters
+    (SQL comparison semantics) and sorted last otherwise.
+    """
+    select_stmt = select(ForgottenMessageDb)
+
+    start_datetime = coerce_to_datetime(start_date)
+    end_datetime = coerce_to_datetime(end_date)
+
+    if hashes:
+        select_stmt = select_stmt.where(ForgottenMessageDb.item_hash.in_(hashes))
+    if addresses:
+        select_stmt = select_stmt.where(ForgottenMessageDb.sender.in_(addresses))
+    if owners:
+        select_stmt = select_stmt.where(ForgottenMessageDb.owner.in_(owners))
+    if chains:
+        select_stmt = select_stmt.where(ForgottenMessageDb.chain.in_(chains))
+    if message_types:
+        select_stmt = select_stmt.where(ForgottenMessageDb.type.in_(message_types))
+    if message_type:
+        select_stmt = select_stmt.where(ForgottenMessageDb.type == message_type)
+    if channels:
+        select_stmt = select_stmt.where(ForgottenMessageDb.channel.in_(channels))
+    if payment_types:
+        select_stmt = select_stmt.where(
+            ForgottenMessageDb.payment_type.in_([pt.value for pt in payment_types])
+        )
+    if start_datetime:
+        select_stmt = select_stmt.where(
+            ForgottenMessageDb.forgotten_at >= start_datetime
+        )
+    if end_datetime:
+        select_stmt = select_stmt.where(ForgottenMessageDb.forgotten_at < end_datetime)
+
+    if sort_order == SortOrder.DESCENDING:
+        order_by_columns = (
+            nullslast(ForgottenMessageDb.forgotten_at.desc()),
+            ForgottenMessageDb.item_hash.asc(),
+        )
+    else:
+        order_by_columns = (
+            nullslast(ForgottenMessageDb.forgotten_at.asc()),
+            ForgottenMessageDb.item_hash.asc(),
+        )
+    select_stmt = select_stmt.order_by(*order_by_columns)
+
+    if page > 1:
+        select_stmt = select_stmt.offset((page - 1) * pagination)
+    if pagination:
+        select_stmt = select_stmt.limit(pagination)
+
+    return select_stmt
+
+
+def count_matching_forgotten_messages(
+    session: DbSession,
+    **kwargs,  # Same as make_matching_forgotten_messages_query
+) -> int:
+    select_stmt = (
+        make_matching_forgotten_messages_query(**{**kwargs, "page": 1, "pagination": 0})
+        .order_by(None)
+        .subquery()
+    )
+    select_count_stmt = select(func.count()).select_from(select_stmt)
+    return session.execute(select_count_stmt).scalar_one()
+
+
+def get_removed_message(
+    session: DbSession, item_hash: str
+) -> Optional[RemovedMessageDb]:
+    return session.execute(
+        select(RemovedMessageDb).where(RemovedMessageDb.item_hash == item_hash)
+    ).scalar()
+
+
+def upsert_removed_message_size(session: DbSession, item_hash: str) -> None:
+    """
+    Snapshot the file size of a message entering REMOVING. The garbage
+    collector deletes the files row before the status flips to REMOVED, so
+    the size must be captured while the message is still alive. The size is
+    NULL for non-STORE messages.
+    """
+    size_subquery = (
+        select(StoredFileDb.size)
+        .where(StoredFileDb.hash == MessageDb.content_item_hash)
+        .scalar_subquery()
+    )
+    insert_stmt = insert(RemovedMessageDb).from_select(
+        ["item_hash", "size"],
+        select(MessageDb.item_hash, size_subquery).where(
+            MessageDb.item_hash == item_hash
+        ),
+    )
+    upsert_stmt = insert_stmt.on_conflict_do_update(
+        constraint="removed_messages_pkey",
+        set_={"size": insert_stmt.excluded.size},
+    )
+    session.execute(upsert_stmt)
+
+
+def delete_removed_message(session: DbSession, item_hash: str) -> None:
+    """Discard the removal record (REMOVING->PROCESSED recovery or forget)."""
+    session.execute(
+        delete(RemovedMessageDb).where(RemovedMessageDb.item_hash == item_hash)
+    )
+
+
+def mark_removed_message(
+    session: DbSession, item_hash: str, removed_at: dt.datetime
+) -> None:
+    """
+    Stamp the removal time at REMOVING->REMOVED. Inserts a row without size
+    for messages that were already REMOVING before the size snapshot existed.
+    """
+    upsert_stmt = (
+        insert(RemovedMessageDb)
+        .values(item_hash=item_hash, size=None, removed_at=removed_at)
+        .on_conflict_do_update(
+            constraint="removed_messages_pkey",
+            set_={"removed_at": removed_at},
+        )
+    )
+    session.execute(upsert_stmt)
+
+
+def make_matching_removed_messages_query(
+    hashes: Optional[Sequence[ItemHash]] = None,
+    addresses: Optional[Sequence[str]] = None,
+    owners: Optional[Sequence[str]] = None,
+    chains: Optional[Sequence[Chain]] = None,
+    message_type: Optional[MessageType] = None,
+    message_types: Optional[Sequence[MessageType]] = None,
+    channels: Optional[Sequence[str]] = None,
+    payment_types: Optional[Sequence[PaymentType]] = None,
+    start_date: Optional[Union[float, dt.datetime]] = None,
+    end_date: Optional[Union[float, dt.datetime]] = None,
+    sort_order: SortOrder = SortOrder.DESCENDING,
+    page: int = 1,
+    pagination: int = 20,
+    include_confirmations: bool = False,
+    # Non-filter query params (sort_by, ...) are passed through by callers;
+    # unsupported narrowing filters are rejected upstream with a 400.
+    **kwargs,
+) -> Select:
+    """
+    REMOVED messages joined with their removal record. Like forgotten
+    queries, date filters and time sorting apply to `removed_at`, not `time`:
+    the purpose of this query is windowed gap-detection by removal time.
+    Legacy rows without a removal record (or not yet stamped) are excluded by
+    date filters (SQL comparison semantics) and sorted last otherwise.
+    """
+    select_stmt = (
+        select(MessageDb, RemovedMessageDb)
+        .join(
+            RemovedMessageDb,
+            RemovedMessageDb.item_hash == MessageDb.item_hash,
+            isouter=True,
+        )
+        .where(MessageDb.status_value == MessageStatus.REMOVED)
+    )
+
+    if include_confirmations:
+        select_stmt = select_stmt.options(
+            selectinload(MessageDb.confirmations).options(
+                load_only(ChainTxDb.hash, ChainTxDb.chain, ChainTxDb.height)
+            )
+        )
+
+    start_datetime = coerce_to_datetime(start_date)
+    end_datetime = coerce_to_datetime(end_date)
+
+    if hashes:
+        select_stmt = select_stmt.where(MessageDb.item_hash.in_(hashes))
+    if addresses:
+        select_stmt = select_stmt.where(MessageDb.sender.in_(addresses))
+    if owners:
+        select_stmt = select_stmt.where(MessageDb.owner.in_(owners))
+    if chains:
+        select_stmt = select_stmt.where(MessageDb.chain.in_(chains))
+    if message_types:
+        select_stmt = select_stmt.where(MessageDb.type.in_(message_types))
+    if message_type:
+        select_stmt = select_stmt.where(MessageDb.type == message_type)
+    if channels:
+        select_stmt = select_stmt.where(MessageDb.channel.in_(channels))
+    if payment_types:
+        # Billing semantics: the absence of a payment field means hold, so
+        # implicit-hold messages (NULL column) must match paymentTypes=hold.
+        select_stmt = select_stmt.where(
+            func.coalesce(MessageDb.payment_type, "hold").in_(
+                [pt.value for pt in payment_types]
+            )
+        )
+    if start_datetime:
+        select_stmt = select_stmt.where(RemovedMessageDb.removed_at >= start_datetime)
+    if end_datetime:
+        select_stmt = select_stmt.where(RemovedMessageDb.removed_at < end_datetime)
+
+    if sort_order == SortOrder.DESCENDING:
+        order_by_columns = (
+            nullslast(RemovedMessageDb.removed_at.desc()),
+            MessageDb.item_hash.asc(),
+        )
+    else:
+        order_by_columns = (
+            nullslast(RemovedMessageDb.removed_at.asc()),
+            MessageDb.item_hash.asc(),
+        )
+    select_stmt = select_stmt.order_by(*order_by_columns)
+
+    if page > 1:
+        select_stmt = select_stmt.offset((page - 1) * pagination)
+    if pagination:
+        select_stmt = select_stmt.limit(pagination)
+
+    return select_stmt
+
+
+def count_matching_removed_messages(
+    session: DbSession,
+    **kwargs,  # Same as make_matching_removed_messages_query
+) -> int:
+    select_stmt = (
+        make_matching_removed_messages_query(**{**kwargs, "page": 1, "pagination": 0})
+        .order_by(None)
+        .subquery()
+    )
+    select_count_stmt = select(func.count()).select_from(select_stmt)
+    return session.execute(select_count_stmt).scalar_one()
+
+
 def forget_message(
-    session: DbSession, item_hash: str, forget_message_hash: str
+    session: DbSession,
+    item_hash: str,
+    forget_message_hash: str,
+    forgotten_at: dt.datetime,
 ) -> None:
     """
     Marks a processed message as forgotten.
@@ -540,7 +797,15 @@ def forget_message(
     :param session: DB session.
     :param item_hash: Hash of the message to forget.
     :param forget_message_hash: Hash of the forget message.
+    :param forgotten_at: Time of the FORGET message.
     """
+
+    # File size preserved for billing (STORE messages; NULL otherwise).
+    size_subquery = (
+        select(StoredFileDb.size)
+        .where(StoredFileDb.hash == MessageDb.content_item_hash)
+        .scalar_subquery()
+    )
 
     # Copy to forgotten_messages for backward compat during transition
     copy_row_stmt = insert(ForgottenMessageDb).from_select(
@@ -554,6 +819,10 @@ def forget_message(
             "time",
             "channel",
             "forgotten_by",
+            "owner",
+            "payment_type",
+            "size",
+            "forgotten_at",
         ],
         select(
             MessageDb.item_hash,
@@ -565,6 +834,12 @@ def forget_message(
             MessageDb.time,
             MessageDb.channel,
             literal(f"{{{forget_message_hash}}}"),
+            MessageDb.owner,
+            # Messages without an explicit payment field are hold-paid;
+            # capture the effective payment type so billing can rely on it.
+            func.coalesce(MessageDb.payment_type, "hold"),
+            size_subquery,
+            literal(forgotten_at),
         ).where(MessageDb.item_hash == item_hash),
     )
     session.execute(copy_row_stmt)
@@ -585,6 +860,9 @@ def forget_message(
         .values(status=MessageStatus.FORGOTTEN)
         .where(MessageStatusDb.item_hash == item_hash)
     )
+
+    # The target may have been REMOVING: forgetting supersedes removal.
+    delete_removed_message(session=session, item_hash=item_hash)
 
     delete_costs_for_message(
         session=session,

--- a/src/aleph/db/accessors/messages.py
+++ b/src/aleph/db/accessors/messages.py
@@ -552,8 +552,11 @@ def make_matching_forgotten_messages_query(
     Filters on the forgotten_messages table. Unlike live-message queries, date
     filters and time sorting apply to `forgotten_at` (the deletion time), not
     `time`: the purpose of this query is windowed gap-detection by deletion
-    time. Legacy rows with NULL `forgotten_at` are excluded by date filters
-    (SQL comparison semantics) and sorted last otherwise.
+    time. forgotten_at is the sender-supplied FORGET time — the same
+    declared-time semantics (and gap assumption) as the live list's default
+    time sort, date filters and cursors. Legacy rows with NULL `forgotten_at`
+    are excluded by date filters (SQL comparison semantics) and sorted last
+    otherwise.
     """
     select_stmt = select(ForgottenMessageDb)
 
@@ -575,8 +578,14 @@ def make_matching_forgotten_messages_query(
     if channels:
         select_stmt = select_stmt.where(ForgottenMessageDb.channel.in_(channels))
     if payment_types:
+        # Billing semantics: the absence of a payment field means hold, so
+        # legacy rows (NULL payment_type, forgotten before the metadata
+        # columns existed) must match paymentTypes=hold — same coalescing as
+        # the removed-messages query.
         select_stmt = select_stmt.where(
-            ForgottenMessageDb.payment_type.in_([pt.value for pt in payment_types])
+            func.coalesce(ForgottenMessageDb.payment_type, "hold").in_(
+                [pt.value for pt in payment_types]
+            )
         )
     if start_datetime:
         select_stmt = select_stmt.where(
@@ -658,22 +667,75 @@ def delete_removed_message(session: DbSession, item_hash: str) -> None:
     )
 
 
-def mark_removed_message(
-    session: DbSession, item_hash: str, removed_at: dt.datetime
-) -> None:
+def remove_message(session: DbSession, item_hash: str, removed_at: dt.datetime) -> None:
     """
-    Stamp the removal time at REMOVING->REMOVED. Inserts a row without size
-    for messages that were already REMOVING before the size snapshot existed.
+    Finalizes a removal at REMOVING->REMOVED, mirroring forget_message():
+    copies the billing metadata of the messages row into the removal record
+    (whose size was snapshotted when the message entered REMOVING — the
+    files row no longer exists at this point) and deletes the messages row.
+    Confirmations, costs and metrics follow via ON DELETE CASCADE.
+
+    Messages that were already REMOVING before the size snapshot existed get
+    a record without size.
+
+    removed_at is the node's own finalization time: node-local and NOT
+    deterministic across nodes (see RemovedMessageDb.removed_at).
+
+    Expects the caller to have performed the guarded REMOVING->REMOVED
+    status flip, and to call this only when the flip actually happened.
     """
-    upsert_stmt = (
-        insert(RemovedMessageDb)
-        .values(item_hash=item_hash, size=None, removed_at=removed_at)
-        .on_conflict_do_update(
-            constraint="removed_messages_pkey",
-            set_={"removed_at": removed_at},
-        )
+    copy_row_stmt = insert(RemovedMessageDb).from_select(
+        [
+            "item_hash",
+            "type",
+            "chain",
+            "sender",
+            "signature",
+            "item_type",
+            "time",
+            "channel",
+            "owner",
+            "payment_type",
+            "removed_at",
+        ],
+        select(
+            MessageDb.item_hash,
+            MessageDb.type,
+            MessageDb.chain,
+            MessageDb.sender,
+            MessageDb.signature,
+            MessageDb.item_type,
+            MessageDb.time,
+            MessageDb.channel,
+            MessageDb.owner,
+            # Messages without an explicit payment field are hold-paid;
+            # capture the effective payment type so billing can rely on it.
+            func.coalesce(MessageDb.payment_type, "hold"),
+            literal(removed_at),
+        ).where(MessageDb.item_hash == item_hash),
+    )
+    upsert_stmt = copy_row_stmt.on_conflict_do_update(
+        constraint="removed_messages_pkey",
+        # Everything except size, which only the PROCESSED->REMOVING
+        # snapshot knows.
+        set_={
+            "type": copy_row_stmt.excluded.type,
+            "chain": copy_row_stmt.excluded.chain,
+            "sender": copy_row_stmt.excluded.sender,
+            "signature": copy_row_stmt.excluded.signature,
+            "item_type": copy_row_stmt.excluded.item_type,
+            "time": copy_row_stmt.excluded.time,
+            "channel": copy_row_stmt.excluded.channel,
+            "owner": copy_row_stmt.excluded.owner,
+            "payment_type": copy_row_stmt.excluded.payment_type,
+            "removed_at": copy_row_stmt.excluded.removed_at,
+        },
     )
     session.execute(upsert_stmt)
+
+    # Delete the message from the messages table (the trigger handles
+    # message_counts; confirmations/costs/metrics cascade).
+    session.execute(delete(MessageDb).where(MessageDb.item_hash == item_hash))
 
 
 def make_matching_removed_messages_query(
@@ -690,57 +752,54 @@ def make_matching_removed_messages_query(
     sort_order: SortOrder = SortOrder.DESCENDING,
     page: int = 1,
     pagination: int = 20,
-    include_confirmations: bool = False,
     # Non-filter query params (sort_by, ...) are passed through by callers;
     # unsupported narrowing filters are rejected upstream with a 400.
     **kwargs,
 ) -> Select:
     """
-    REMOVED messages joined with their removal record. Like forgotten
-    queries, date filters and time sorting apply to `removed_at`, not `time`:
-    the purpose of this query is windowed gap-detection by removal time.
-    Legacy rows without a removal record (or not yet stamped) are excluded by
-    date filters (SQL comparison semantics) and sorted last otherwise.
+    Filters on the removed_messages snapshots. The join with message_status
+    keeps records of still-REMOVING messages (size-only phase-1 snapshots)
+    out of the results — message_status is the arbiter of the lifecycle.
+
+    Like forgotten queries, date filters and time sorting apply to
+    `removed_at`, not `time`. removed_at is node-local (each node's GC
+    finalizes removals on its own schedule — see RemovedMessageDb), so
+    windows are only meaningful against the same node. Legacy rows without a
+    removal time are excluded by date filters (SQL comparison semantics) and
+    sorted last otherwise.
     """
     select_stmt = (
-        select(MessageDb, RemovedMessageDb)
+        select(RemovedMessageDb)
         .join(
-            RemovedMessageDb,
-            RemovedMessageDb.item_hash == MessageDb.item_hash,
-            isouter=True,
+            MessageStatusDb,
+            MessageStatusDb.item_hash == RemovedMessageDb.item_hash,
         )
-        .where(MessageDb.status_value == MessageStatus.REMOVED)
+        .where(MessageStatusDb.status == MessageStatus.REMOVED)
     )
-
-    if include_confirmations:
-        select_stmt = select_stmt.options(
-            selectinload(MessageDb.confirmations).options(
-                load_only(ChainTxDb.hash, ChainTxDb.chain, ChainTxDb.height)
-            )
-        )
 
     start_datetime = coerce_to_datetime(start_date)
     end_datetime = coerce_to_datetime(end_date)
 
     if hashes:
-        select_stmt = select_stmt.where(MessageDb.item_hash.in_(hashes))
+        select_stmt = select_stmt.where(RemovedMessageDb.item_hash.in_(hashes))
     if addresses:
-        select_stmt = select_stmt.where(MessageDb.sender.in_(addresses))
+        select_stmt = select_stmt.where(RemovedMessageDb.sender.in_(addresses))
     if owners:
-        select_stmt = select_stmt.where(MessageDb.owner.in_(owners))
+        select_stmt = select_stmt.where(RemovedMessageDb.owner.in_(owners))
     if chains:
-        select_stmt = select_stmt.where(MessageDb.chain.in_(chains))
+        select_stmt = select_stmt.where(RemovedMessageDb.chain.in_(chains))
     if message_types:
-        select_stmt = select_stmt.where(MessageDb.type.in_(message_types))
+        select_stmt = select_stmt.where(RemovedMessageDb.type.in_(message_types))
     if message_type:
-        select_stmt = select_stmt.where(MessageDb.type == message_type)
+        select_stmt = select_stmt.where(RemovedMessageDb.type == message_type)
     if channels:
-        select_stmt = select_stmt.where(MessageDb.channel.in_(channels))
+        select_stmt = select_stmt.where(RemovedMessageDb.channel.in_(channels))
     if payment_types:
         # Billing semantics: the absence of a payment field means hold, so
-        # implicit-hold messages (NULL column) must match paymentTypes=hold.
+        # legacy rows (NULL payment_type) must match paymentTypes=hold —
+        # new snapshots already store the coalesced effective type.
         select_stmt = select_stmt.where(
-            func.coalesce(MessageDb.payment_type, "hold").in_(
+            func.coalesce(RemovedMessageDb.payment_type, "hold").in_(
                 [pt.value for pt in payment_types]
             )
         )
@@ -752,12 +811,12 @@ def make_matching_removed_messages_query(
     if sort_order == SortOrder.DESCENDING:
         order_by_columns = (
             nullslast(RemovedMessageDb.removed_at.desc()),
-            MessageDb.item_hash.asc(),
+            RemovedMessageDb.item_hash.asc(),
         )
     else:
         order_by_columns = (
             nullslast(RemovedMessageDb.removed_at.asc()),
-            MessageDb.item_hash.asc(),
+            RemovedMessageDb.item_hash.asc(),
         )
     select_stmt = select_stmt.order_by(*order_by_columns)
 

--- a/src/aleph/db/models/balances.py
+++ b/src/aleph/db/models/balances.py
@@ -59,6 +59,9 @@ class AlephCreditHistoryDb(Base):
     origin: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     origin_ref: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     payment_method: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    # v2 aggregated expense entries only (one entry per address); NULL otherwise.
+    expense_count: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    expense_size_mib: Mapped[Optional[Decimal]] = mapped_column(DECIMAL, nullable=True)
     credit_ref: Mapped[str] = mapped_column(String, nullable=False, primary_key=True)
     credit_index: Mapped[int] = mapped_column(Integer, nullable=False, primary_key=True)
     expiration_date: Mapped[Optional[dt.datetime]] = mapped_column(

--- a/src/aleph/db/models/messages.py
+++ b/src/aleph/db/models/messages.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
     BigInteger,
     Column,
     ForeignKey,
+    Index,
     Integer,
     String,
     Table,
@@ -342,6 +343,52 @@ class ForgottenMessageDb(Base):
         String, nullable=True, index=True
     )
     forgotten_by: Mapped[List[str]] = mapped_column(ARRAY(String), nullable=False)
+    # Billing metadata preserved at forget time. NULL for rows forgotten
+    # before these columns existed (legacy rows).
+    owner: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    payment_type: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    size: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    forgotten_at: Mapped[Optional[dt.datetime]] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+
+    __table_args__ = (
+        # The forgotten list endpoint filters by owner and windows/sorts on
+        # forgotten_at (deletion time).
+        Index(
+            "ix_forgotten_messages_owner_forgotten_at",
+            "owner",
+            "forgotten_at",
+        ),
+        Index("ix_forgotten_messages_forgotten_at", "forgotten_at"),
+    )
+
+
+class RemovedMessageDb(Base):
+    """
+    Billing metadata for messages removed by the balance/credit-balance cron
+    jobs. Two-phase lifecycle: the file size is snapshotted at
+    PROCESSED->REMOVING (while the files row still exists — the garbage
+    collector deletes it before the status flips to REMOVED), the row is
+    deleted on REMOVING->PROCESSED recovery, and removed_at is stamped by
+    the garbage collector at REMOVING->REMOVED.
+    """
+
+    __tablename__ = "removed_messages"
+
+    item_hash: Mapped[str] = mapped_column(String, primary_key=True)
+    # files.size snapshot taken while the message was alive (NULL for
+    # non-STORE messages or when the size could not be resolved).
+    size: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    # NULL while the message is still REMOVING.
+    removed_at: Mapped[Optional[dt.datetime]] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+
+    __table_args__ = (
+        # The removed list endpoint windows/sorts on removed_at.
+        Index("ix_removed_messages_removed_at", "removed_at"),
+    )
 
 
 class ErrorCodeDb(Base):

--- a/src/aleph/db/models/messages.py
+++ b/src/aleph/db/models/messages.py
@@ -348,6 +348,9 @@ class ForgottenMessageDb(Base):
     owner: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     payment_type: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     size: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    # Sender-supplied time of the forgetting FORGET message. Like the live
+    # list's default time sort/cursor, windowed consumers assume the gap a
+    # backdated FORGET can introduce.
     forgotten_at: Mapped[Optional[dt.datetime]] = mapped_column(
         TIMESTAMP(timezone=True), nullable=True
     )
@@ -366,27 +369,59 @@ class ForgottenMessageDb(Base):
 
 class RemovedMessageDb(Base):
     """
-    Billing metadata for messages removed by the balance/credit-balance cron
-    jobs. Two-phase lifecycle: the file size is snapshotted at
-    PROCESSED->REMOVING (while the files row still exists — the garbage
-    collector deletes it before the status flips to REMOVED), the row is
-    deleted on REMOVING->PROCESSED recovery, and removed_at is stamped by
-    the garbage collector at REMOVING->REMOVED.
+    Snapshot of a message removed by the balance/credit-balance cron jobs,
+    mirroring forgotten_messages: at REMOVING->REMOVED the messages row is
+    deleted and this snapshot becomes the only record of the message.
+
+    Two-phase lifecycle: the file size is snapshotted at PROCESSED->REMOVING
+    (while the files row still exists — the garbage collector deletes it
+    before the status flips to REMOVED), the row is deleted on
+    REMOVING->PROCESSED recovery, and the remaining metadata is copied from
+    the messages row and stamped with removed_at by the garbage collector at
+    REMOVING->REMOVED, right before the messages row is deleted.
     """
 
     __tablename__ = "removed_messages"
 
     item_hash: Mapped[str] = mapped_column(String, primary_key=True)
-    # files.size snapshot taken while the message was alive (NULL for
-    # non-STORE messages or when the size could not be resolved).
+    # Metadata copied from the messages row at REMOVING->REMOVED (the row is
+    # deleted right after). NULL while the message is still REMOVING — the
+    # messages row is the source of truth until the flip.
+    type: Mapped[Optional[MessageType]] = mapped_column(
+        ChoiceType(MessageType), nullable=True
+    )
+    chain: Mapped[Optional[Chain]] = mapped_column(ChoiceType(Chain), nullable=True)
+    sender: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    signature: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    item_type: Mapped[Optional[ItemType]] = mapped_column(
+        ChoiceType(ItemType), nullable=True
+    )
+    time: Mapped[Optional[dt.datetime]] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    channel: Mapped[Optional[Channel]] = mapped_column(String, nullable=True)
+    owner: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    # Effective payment type (NULL payment coalesced to hold at copy time).
+    payment_type: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    # files.size snapshot taken at PROCESSED->REMOVING while the message was
+    # alive (NULL for non-STORE messages or when the size could not be
+    # resolved).
     size: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
-    # NULL while the message is still REMOVING.
+    # Stamped by the garbage collector at REMOVING->REMOVED. Node-local and
+    # NOT deterministic across nodes: each node's GC finalizes removals on
+    # its own schedule, and — unlike forgotten_at — there is no
+    # sender-declared removal time to share (removal is a node-local balance
+    # decision). Consumers windowing on it must not expect two nodes to
+    # agree. NULL while the message is still REMOVING and for legacy rows
+    # (removed before this table recorded removal times).
     removed_at: Mapped[Optional[dt.datetime]] = mapped_column(
         TIMESTAMP(timezone=True), nullable=True
     )
 
     __table_args__ = (
-        # The removed list endpoint windows/sorts on removed_at.
+        # The removed list endpoint filters by owner and windows/sorts on
+        # removed_at.
+        Index("ix_removed_messages_owner_removed_at", "owner", "removed_at"),
         Index("ix_removed_messages_removed_at", "removed_at"),
     )
 

--- a/src/aleph/handlers/content/forget.py
+++ b/src/aleph/handlers/content/forget.py
@@ -173,6 +173,7 @@ class ForgetMessageHandler(ContentHandler):
             session=session,
             item_hash=message.item_hash,
             forget_message_hash=forgotten_by.item_hash,
+            forgotten_at=forgotten_by.time,
         )
 
         additional_messages_to_forget = await self._forget_by_message_type(
@@ -184,6 +185,7 @@ class ForgetMessageHandler(ContentHandler):
                 session=session,
                 item_hash=item_hash,
                 forget_message_hash=forgotten_by.item_hash,
+                forgotten_at=forgotten_by.time,
             )
 
     async def _forget_item_hash(

--- a/src/aleph/jobs/cron/balance_job.py
+++ b/src/aleph/jobs/cron/balance_job.py
@@ -1,17 +1,20 @@
 import datetime as dt
 import logging
-from typing import List
+from typing import List, cast
 
 from aleph_message.models import ItemHash, MessageType, PaymentType
 from sqlalchemy import update
+from sqlalchemy.engine import CursorResult
 
 from aleph.db.accessors.balances import get_total_balance, get_updated_balance_accounts
 from aleph.db.accessors.cost import get_total_costs_for_address_grouped_by_message
 from aleph.db.accessors.files import update_file_pin_grace_period
 from aleph.db.accessors.messages import (
+    delete_removed_message,
     get_message_by_item_hash,
     get_message_status,
     make_message_status_upsert_query,
+    upsert_removed_message_size,
 )
 from aleph.db.models.cron_jobs import CronJobDb
 from aleph.db.models.messages import MessageDb, MessageStatusDb
@@ -116,20 +119,33 @@ class BalanceCronJob(BaseCronJob):
                     delete_by=delete_by,
                 )
 
-            session.execute(
-                make_message_status_upsert_query(
-                    item_hash=item_hash,
-                    new_status=MessageStatus.REMOVING,
-                    reception_time=now,
-                    where=(MessageStatusDb.status == MessageStatus.PROCESSED),
+            result = cast(
+                CursorResult,
+                session.execute(
+                    make_message_status_upsert_query(
+                        item_hash=item_hash,
+                        new_status=MessageStatus.REMOVING,
+                        reception_time=now,
+                        where=(MessageStatusDb.status == MessageStatus.PROCESSED),
+                    )
+                ),
+            )
+
+            # Only when this call actually performed the PROCESSED->REMOVING
+            # flip: a message on another transition (e.g. already REMOVED)
+            # must not get its denormalized status clobbered or a removal
+            # record written under it.
+            if result.rowcount > 0:
+                # Dual-write to messages table (trigger handles message_counts)
+                session.execute(
+                    update(MessageDb)
+                    .where(MessageDb.item_hash == item_hash)
+                    .values(status_value=MessageStatus.REMOVING)
                 )
-            )
-            # Dual-write to messages table (trigger handles message_counts)
-            session.execute(
-                update(MessageDb)
-                .where(MessageDb.item_hash == item_hash)
-                .values(status_value=MessageStatus.REMOVING)
-            )
+                # Snapshot the file size while the files row still exists;
+                # the garbage collector stamps removed_at at
+                # REMOVING->REMOVED.
+                upsert_removed_message_size(session=session, item_hash=item_hash)
 
     async def recover_messages(self, session: DbSession, messages: List[ItemHash]):
         for item_hash in messages:
@@ -144,17 +160,27 @@ class BalanceCronJob(BaseCronJob):
                     delete_by=None,
                 )
 
-            session.execute(
-                make_message_status_upsert_query(
-                    item_hash=item_hash,
-                    new_status=MessageStatus.PROCESSED,
-                    reception_time=utc_now(),
-                    where=(MessageStatusDb.status == MessageStatus.REMOVING),
+            result = cast(
+                CursorResult,
+                session.execute(
+                    make_message_status_upsert_query(
+                        item_hash=item_hash,
+                        new_status=MessageStatus.PROCESSED,
+                        reception_time=utc_now(),
+                        where=(MessageStatusDb.status == MessageStatus.REMOVING),
+                    )
+                ),
+            )
+
+            # Only when this call actually performed the REMOVING->PROCESSED
+            # flip: if the garbage collector already finalized
+            # REMOVING->REMOVED, the message must not reappear as processed
+            # and the removal record (size/removed_at) must survive.
+            if result.rowcount > 0:
+                # Dual-write to messages table (trigger handles message_counts)
+                session.execute(
+                    update(MessageDb)
+                    .where(MessageDb.item_hash == item_hash)
+                    .values(status_value=MessageStatus.PROCESSED)
                 )
-            )
-            # Dual-write to messages table (trigger handles message_counts)
-            session.execute(
-                update(MessageDb)
-                .where(MessageDb.item_hash == item_hash)
-                .values(status_value=MessageStatus.PROCESSED)
-            )
+                delete_removed_message(session=session, item_hash=item_hash)

--- a/src/aleph/jobs/cron/credit_balance_job.py
+++ b/src/aleph/jobs/cron/credit_balance_job.py
@@ -1,9 +1,10 @@
 import datetime as dt
 import logging
-from typing import List
+from typing import List, cast
 
 from aleph_message.models import ItemHash, MessageType, PaymentType
 from sqlalchemy import update
+from sqlalchemy.engine import CursorResult
 
 from aleph.db.accessors.balances import (
     get_credit_balance,
@@ -12,9 +13,11 @@ from aleph.db.accessors.balances import (
 from aleph.db.accessors.cost import get_total_costs_for_address_grouped_by_message
 from aleph.db.accessors.files import update_file_pin_grace_period
 from aleph.db.accessors.messages import (
+    delete_removed_message,
     get_message_by_item_hash,
     get_message_status,
     make_message_status_upsert_query,
+    upsert_removed_message_size,
 )
 from aleph.db.models.cron_jobs import CronJobDb
 from aleph.db.models.messages import MessageDb, MessageStatusDb
@@ -130,20 +133,32 @@ class CreditBalanceCronJob(BaseCronJob):
                     delete_by=delete_by,
                 )
 
-            session.execute(
-                make_message_status_upsert_query(
-                    item_hash=item_hash,
-                    new_status=MessageStatus.REMOVING,
-                    reception_time=now,
-                    where=(MessageStatusDb.status == MessageStatus.PROCESSED),
+            result = cast(
+                CursorResult,
+                session.execute(
+                    make_message_status_upsert_query(
+                        item_hash=item_hash,
+                        new_status=MessageStatus.REMOVING,
+                        reception_time=now,
+                        where=(MessageStatusDb.status == MessageStatus.PROCESSED),
+                    )
+                ),
+            )
+            # Only when this call actually performed the PROCESSED->REMOVING
+            # flip: a message on another transition (e.g. already REMOVED)
+            # must not get its denormalized status clobbered or a removal
+            # record written under it.
+            if result.rowcount > 0:
+                # Dual-write to messages table (trigger handles message_counts)
+                session.execute(
+                    update(MessageDb)
+                    .where(MessageDb.item_hash == item_hash)
+                    .values(status_value=MessageStatus.REMOVING)
                 )
-            )
-            # Dual-write to messages table (trigger handles message_counts)
-            session.execute(
-                update(MessageDb)
-                .where(MessageDb.item_hash == item_hash)
-                .values(status_value=MessageStatus.REMOVING)
-            )
+                # Snapshot the file size while the files row still exists;
+                # the garbage collector stamps removed_at at
+                # REMOVING->REMOVED.
+                upsert_removed_message_size(session=session, item_hash=item_hash)
 
     async def recover_messages(self, session: DbSession, messages: List[ItemHash]):
         for item_hash in messages:
@@ -158,17 +173,26 @@ class CreditBalanceCronJob(BaseCronJob):
                     delete_by=None,
                 )
 
-            session.execute(
-                make_message_status_upsert_query(
-                    item_hash=item_hash,
-                    new_status=MessageStatus.PROCESSED,
-                    reception_time=utc_now(),
-                    where=(MessageStatusDb.status == MessageStatus.REMOVING),
+            result = cast(
+                CursorResult,
+                session.execute(
+                    make_message_status_upsert_query(
+                        item_hash=item_hash,
+                        new_status=MessageStatus.PROCESSED,
+                        reception_time=utc_now(),
+                        where=(MessageStatusDb.status == MessageStatus.REMOVING),
+                    )
+                ),
+            )
+            # Only when this call actually performed the REMOVING->PROCESSED
+            # flip: if the garbage collector already finalized
+            # REMOVING->REMOVED, the message must not reappear as processed
+            # and the removal record (size/removed_at) must survive.
+            if result.rowcount > 0:
+                # Dual-write to messages table (trigger handles message_counts)
+                session.execute(
+                    update(MessageDb)
+                    .where(MessageDb.item_hash == item_hash)
+                    .values(status_value=MessageStatus.PROCESSED)
                 )
-            )
-            # Dual-write to messages table (trigger handles message_counts)
-            session.execute(
-                update(MessageDb)
-                .where(MessageDb.item_hash == item_hash)
-                .values(status_value=MessageStatus.PROCESSED)
-            )
+                delete_removed_message(session=session, item_hash=item_hash)

--- a/src/aleph/schemas/api/accounts.py
+++ b/src/aleph/schemas/api/accounts.py
@@ -284,6 +284,9 @@ class CreditHistoryResponseItem(BaseModel):
     credit_index: int
     expiration_date: Optional[dt.datetime] = None
     message_timestamp: dt.datetime
+    # v2 aggregated expense entries only; NULL otherwise.
+    expense_count: Optional[int] = None
+    expense_size_mib: Optional[Decimal] = None
 
 
 class GetAccountCreditHistoryResponse(BaseModel):

--- a/src/aleph/schemas/api/messages.py
+++ b/src/aleph/schemas/api/messages.py
@@ -185,11 +185,45 @@ class RemovingMessageStatus(BaseMessageStatus):
     reason: RemovedMessageReason
 
 
+class RemovedMessage(BaseModel):
+    """
+    Skeleton of a removed message, rebuilt from the removed_messages
+    snapshot: the messages row is deleted at removal, mirroring forgotten
+    messages. Metadata fields are NULL for legacy rows (removed before the
+    snapshot existed).
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    sender: Optional[str] = None
+    chain: Optional[Chain] = None
+    signature: Optional[str] = None
+    type: Optional[MessageType] = None
+    item_type: Optional[ItemType] = None
+    item_hash: str
+    time: Optional[dt.datetime] = None
+    channel: Optional[str] = None
+    # Billing metadata preserved at removal.
+    owner: Optional[str] = None
+    payment_type: Optional[str] = None
+    size: Optional[int] = None
+    # Node-local removal finalization time — NOT deterministic across nodes
+    # (each node's GC finalizes removals on its own schedule); the removed
+    # list windows and sorts on it.
+    removed_at: Optional[dt.datetime] = None
+
+    @field_serializer("time", "removed_at")
+    def serialize_optional_datetime(
+        self, value: Optional[dt.datetime], _info
+    ) -> Optional[float]:
+        return value.timestamp() if value is not None else None
+
+
 class RemovedMessageStatus(BaseMessageStatus):
     model_config = ConfigDict(from_attributes=True)
 
     status: MessageStatus = MessageStatus.REMOVED
-    message: AlephMessage
+    message: RemovedMessage
     reason: RemovedMessageReason
     # Removal record: file-size snapshot taken at PROCESSED->REMOVING and
     # removal time stamped at REMOVING->REMOVED (NULL for legacy removals).
@@ -218,6 +252,8 @@ class ForgottenMessage(BaseModel):
     owner: Optional[str] = None
     payment_type: Optional[str] = None
     size: Optional[int] = None
+    # Sender-supplied time of the forgetting FORGET message; the forgotten
+    # list windows and sorts on it.
     forgotten_at: Optional[dt.datetime] = None
 
     @field_serializer("time")

--- a/src/aleph/schemas/api/messages.py
+++ b/src/aleph/schemas/api/messages.py
@@ -191,6 +191,16 @@ class RemovedMessageStatus(BaseMessageStatus):
     status: MessageStatus = MessageStatus.REMOVED
     message: AlephMessage
     reason: RemovedMessageReason
+    # Removal record: file-size snapshot taken at PROCESSED->REMOVING and
+    # removal time stamped at REMOVING->REMOVED (NULL for legacy removals).
+    removed_at: Optional[dt.datetime] = None
+    size: Optional[int] = None
+
+    @field_serializer("removed_at")
+    def serialize_removed_at(
+        self, value: Optional[dt.datetime], _info
+    ) -> Optional[float]:
+        return value.timestamp() if value is not None else None
 
 
 class ForgottenMessage(BaseModel):
@@ -204,6 +214,21 @@ class ForgottenMessage(BaseModel):
     item_hash: str
     time: dt.datetime
     channel: Optional[str] = None
+    # Billing metadata preserved at forget time (NULL for legacy rows).
+    owner: Optional[str] = None
+    payment_type: Optional[str] = None
+    size: Optional[int] = None
+    forgotten_at: Optional[dt.datetime] = None
+
+    @field_serializer("time")
+    def serialize_time(self, dt: dt.datetime, _info) -> float:
+        return dt.timestamp()
+
+    @field_serializer("forgotten_at")
+    def serialize_forgotten_at(
+        self, value: Optional[dt.datetime], _info
+    ) -> Optional[float]:
+        return value.timestamp() if value is not None else None
 
 
 class ForgottenMessageStatus(BaseMessageStatus):

--- a/src/aleph/schemas/cost_estimation_messages.py
+++ b/src/aleph/schemas/cost_estimation_messages.py
@@ -86,7 +86,9 @@ class CostEstimationProgramContent(ProgramContent):
 
 
 class CostEstimationStoreContent(StoreContent):
-    estimated_size_mib: Optional[int] = None
+    # float so exact byte sizes (size / MiB) can be estimated, e.g. when
+    # pricing forgotten STORE messages from their preserved metadata.
+    estimated_size_mib: Optional[float] = None
 
 
 class BaseCostEstimationMessage(AlephBaseMessage, Generic[MType, ContentType]):

--- a/src/aleph/schemas/credit_transfer.py
+++ b/src/aleph/schemas/credit_transfer.py
@@ -120,7 +120,14 @@ class CreditExpenseEntry(BaseModel):
     execution_id: Optional[str] = None
     node_id: Optional[str] = None
     price: Optional[str] = None
-    time: Optional[float] = None  # accepted but ignored
+    time: Optional[float] = None  # v2: total billed seconds; not persisted
+    # v2 aggregated entries (one entry per address); NULL on v1 entries.
+    count: Optional[int] = Field(
+        default=None, ge=0, description="Files aggregated into this entry"
+    )
+    size: Optional[Decimal] = Field(
+        default=None, ge=0, description="Total MiB billed for this address"
+    )
 
     @field_validator("address")
     @classmethod

--- a/src/aleph/services/storage/garbage_collector.py
+++ b/src/aleph/services/storage/garbage_collector.py
@@ -18,6 +18,7 @@ from aleph.db.accessors.messages import (
     get_matching_hashes,
     get_one_message_by_item_hash,
     make_message_status_upsert_query,
+    mark_removed_message,
 )
 from aleph.db.models.messages import MessageDb, MessageStatusDb
 from aleph.storage import StorageService
@@ -94,7 +95,7 @@ class GarbageCollector:
                     # If all resources have been deleted, update status to REMOVED
                     if resources_deleted:
                         now = utc_now()
-                        session.execute(
+                        result = session.execute(
                             make_message_status_upsert_query(
                                 item_hash=item_hash,
                                 new_status=MessageStatus.REMOVED,
@@ -104,12 +105,25 @@ class GarbageCollector:
                                 ),
                             )
                         )
-                        # Dual-write to messages table (trigger handles message_counts)
-                        session.execute(
-                            sa_update(MessageDb)
-                            .where(MessageDb.item_hash == item_hash)
-                            .values(status_value=MessageStatus.REMOVED)
-                        )
+                        # Only when this call actually performed the
+                        # REMOVING->REMOVED flip: a concurrent recovery may
+                        # have just returned the message to PROCESSED, and it
+                        # must not reappear as removed with a bogus
+                        # removed_at.
+                        if result.rowcount > 0:
+                            # Dual-write to messages table (trigger handles
+                            # message_counts)
+                            session.execute(
+                                sa_update(MessageDb)
+                                .where(MessageDb.item_hash == item_hash)
+                                .values(status_value=MessageStatus.REMOVED)
+                            )
+                            # Stamp the removal time on the record snapshotted
+                            # at PROCESSED->REMOVING (inserted without size if
+                            # the message predates the snapshot).
+                            mark_removed_message(
+                                session=session, item_hash=item_hash, removed_at=now
+                            )
 
                 except Exception as err:
                     LOGGER.error(

--- a/src/aleph/services/storage/garbage_collector.py
+++ b/src/aleph/services/storage/garbage_collector.py
@@ -5,7 +5,6 @@ import logging
 from aioipfs import NotPinnedError
 from aleph_message.models import ItemHash, ItemType, MessageType
 from configmanager import Config
-from sqlalchemy import update as sa_update
 
 from aleph.db.accessors.cost import delete_costs_for_forgotten_and_deleted_messages
 from aleph.db.accessors.files import delete_file as delete_file_db
@@ -18,9 +17,9 @@ from aleph.db.accessors.messages import (
     get_matching_hashes,
     get_one_message_by_item_hash,
     make_message_status_upsert_query,
-    mark_removed_message,
+    remove_message,
 )
-from aleph.db.models.messages import MessageDb, MessageStatusDb
+from aleph.db.models.messages import MessageStatusDb
 from aleph.storage import StorageService
 from aleph.toolkit.timestamp import utc_now
 from aleph.types.db_session import DbSessionFactory
@@ -79,51 +78,56 @@ class GarbageCollector:
 
             for item_hash in removing_hashes:
                 try:
-                    # For STORE messages, check if the file is still pinned
-                    # We need to get message details to check its type
-                    message = get_one_message_by_item_hash(
-                        session=session, item_hash=item_hash
-                    )
-
-                    resources_deleted = True
-
-                    if message and message.type == MessageType.store:
-                        # Check if the file is still pinned (by item_hash cause there could be other messages pinning the same file_hash)
-                        if file_pin_exists(session=session, item_hash=item_hash):
-                            resources_deleted = False
-
-                    # If all resources have been deleted, update status to REMOVED
-                    if resources_deleted:
-                        now = utc_now()
-                        result = session.execute(
-                            make_message_status_upsert_query(
-                                item_hash=item_hash,
-                                new_status=MessageStatus.REMOVED,
-                                reception_time=now,
-                                where=(
-                                    MessageStatusDb.status == MessageStatus.REMOVING
-                                ),
-                            )
+                    # One savepoint per message: the status flip, the
+                    # metadata snapshot and the messages-row deletion must
+                    # land (or roll back) together — a partial commit would
+                    # leave a REMOVED message without removal record, or a
+                    # snapshot next to a live row. The savepoint also keeps
+                    # a failed statement from poisoning the shared
+                    # transaction for the remaining messages of the batch.
+                    with session.begin_nested():
+                        # For STORE messages, check if the file is still pinned
+                        # We need to get message details to check its type
+                        message = get_one_message_by_item_hash(
+                            session=session, item_hash=item_hash
                         )
-                        # Only when this call actually performed the
-                        # REMOVING->REMOVED flip: a concurrent recovery may
-                        # have just returned the message to PROCESSED, and it
-                        # must not reappear as removed with a bogus
-                        # removed_at.
-                        if result.rowcount > 0:
-                            # Dual-write to messages table (trigger handles
-                            # message_counts)
-                            session.execute(
-                                sa_update(MessageDb)
-                                .where(MessageDb.item_hash == item_hash)
-                                .values(status_value=MessageStatus.REMOVED)
+
+                        resources_deleted = True
+
+                        if message and message.type == MessageType.store:
+                            # Check if the file is still pinned (by item_hash cause there could be other messages pinning the same file_hash)
+                            if file_pin_exists(session=session, item_hash=item_hash):
+                                resources_deleted = False
+
+                        # If all resources have been deleted, update status to REMOVED
+                        if resources_deleted:
+                            now = utc_now()
+                            result = session.execute(
+                                make_message_status_upsert_query(
+                                    item_hash=item_hash,
+                                    new_status=MessageStatus.REMOVED,
+                                    reception_time=now,
+                                    where=(
+                                        MessageStatusDb.status == MessageStatus.REMOVING
+                                    ),
+                                )
                             )
-                            # Stamp the removal time on the record snapshotted
-                            # at PROCESSED->REMOVING (inserted without size if
-                            # the message predates the snapshot).
-                            mark_removed_message(
-                                session=session, item_hash=item_hash, removed_at=now
-                            )
+                            # Only when this call actually performed the
+                            # REMOVING->REMOVED flip: a concurrent recovery may
+                            # have just returned the message to PROCESSED, and
+                            # it must not reappear as removed with a bogus
+                            # removed_at.
+                            if result.rowcount > 0:
+                                # Copy the billing metadata onto the removal
+                                # record (snapshotted at PROCESSED->REMOVING;
+                                # created without size if the message predates
+                                # the snapshot) and delete the messages row,
+                                # mirroring the forgotten flow.
+                                remove_message(
+                                    session=session,
+                                    item_hash=item_hash,
+                                    removed_at=now,
+                                )
 
                 except Exception as err:
                     LOGGER.error(

--- a/src/aleph/toolkit/constants.py
+++ b/src/aleph/toolkit/constants.py
@@ -336,13 +336,7 @@ DEFAULT_MAX_FILE_SIZE = 100 * MiB
 DEFAULT_MAX_UPLOAD_FILE_SIZE = 1 * GiB
 DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE = 25 * MiB
 DEFAULT_MAX_UPLOAD_CAR_SIZE = 4 * GiB
-# Minimum MiB billed for pure STORE messages, applied to credit payment only
-# (services/cost.py::_calculate_storage_costs). Bumped 25 -> 100 as a
-# small-file spam deterrent. Transitional inconsistency after the bump:
-# precomputed account_costs rows keep the old floor until a cost
-# recalculation runs, while estimates and forgotten/removed pricing use the
-# new floor immediately.
-MIN_STORE_COST_MIB = 100
+MIN_STORE_COST_MIB = 25  # Minimum MiB cost for pure STORE messages
 MIN_CREDIT_COST_PER_HOUR = (
     1  # Minimum cost per hour in credits for instances and volumes
 )

--- a/src/aleph/toolkit/constants.py
+++ b/src/aleph/toolkit/constants.py
@@ -336,7 +336,13 @@ DEFAULT_MAX_FILE_SIZE = 100 * MiB
 DEFAULT_MAX_UPLOAD_FILE_SIZE = 1 * GiB
 DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE = 25 * MiB
 DEFAULT_MAX_UPLOAD_CAR_SIZE = 4 * GiB
-MIN_STORE_COST_MIB = 25  # Minimum MiB cost for pure STORE messages
+# Minimum MiB billed for pure STORE messages, applied to credit payment only
+# (services/cost.py::_calculate_storage_costs). Bumped 25 -> 100 as a
+# small-file spam deterrent. Transitional inconsistency after the bump:
+# precomputed account_costs rows keep the old floor until a cost
+# recalculation runs, while estimates and forgotten/removed pricing use the
+# new floor immediately.
+MIN_STORE_COST_MIB = 100
 MIN_CREDIT_COST_PER_HOUR = (
     1  # Minimum cost per hour in credits for instances and volumes
 )

--- a/src/aleph/web/controllers/accounts.py
+++ b/src/aleph/web/controllers/accounts.py
@@ -961,6 +961,8 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
                 "credit_index": entry.credit_index,
                 "expiration_date": entry.expiration_date,
                 "message_timestamp": entry.message_timestamp,
+                "expense_count": entry.expense_count,
+                "expense_size_mib": entry.expense_size_mib,
             }
             for entry in cursor_entries
         ]
@@ -1049,6 +1051,8 @@ async def get_account_credit_history(request: web.Request) -> web.Response:
                 "credit_index": entry.credit_index,
                 "expiration_date": entry.expiration_date,
                 "message_timestamp": entry.message_timestamp,
+                "expense_count": entry.expense_count,
+                "expense_size_mib": entry.expense_size_mib,
             }
             for entry in credit_history_entries
         ]

--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -41,6 +41,7 @@ from aleph.schemas.api.messages import (
     PostMessage,
     ProcessedMessageStatus,
     RejectedMessageStatus,
+    RemovedMessage,
     RemovedMessageStatus,
     RemovingMessageStatus,
     format_message,
@@ -436,7 +437,9 @@ def _list_forgotten_messages(
         )
 
         # If the result set is smaller than the page size, we already know
-        # the total count without running a separate COUNT query.
+        # the total count without running a separate COUNT query. Known
+        # trade-off (shared with the live-message listing): a page past the
+        # end of the result set overestimates the total.
         if (
             query_params.pagination
             and len(forgotten_messages) < query_params.pagination
@@ -459,19 +462,12 @@ def _list_forgotten_messages(
     return web.json_response(text=aleph_json.dumps(response).decode("utf-8"))
 
 
-def removed_message_to_dict(
-    message: MessageDb, removed_message: Optional[RemovedMessageDb]
-) -> Dict[str, Any]:
-    message_dict = message_to_dict(message)
+def removed_message_to_dict(message: RemovedMessageDb) -> Dict[str, Any]:
+    # The RemovedMessage schema owns the serialization rules (epoch-float
+    # time fields), so both the single-message endpoint and this list share
+    # one serializer.
+    message_dict = RemovedMessage.model_validate(message).model_dump()
     message_dict["status"] = MessageStatus.REMOVED
-    # File-size snapshot taken at removal time (shadows the message content
-    # size of live items; documented in the swagger docstring).
-    message_dict["size"] = removed_message.size if removed_message else None
-    message_dict["removed_at"] = (
-        removed_message.removed_at.timestamp()
-        if removed_message is not None and removed_message.removed_at is not None
-        else None
-    )
     return message_dict
 
 
@@ -479,9 +475,10 @@ def _list_removed_messages(
     request: web.Request, query_params: MessageQueryParams
 ) -> web.Response:
     """
-    Removed-only variant of the message list: messages joined with their
-    removal record. Date filters and time sorting apply to `removed_at`
-    (removal time), not `time`.
+    Removed-only variant of the message list, served from the
+    removed_messages snapshots (the messages rows are deleted at removal).
+    Date filters and time sorting apply to `removed_at` (node-local removal
+    time), not `time`.
     """
     find_filters = query_params.model_dump(exclude_none=True)
     # Consumed by the caller or meaningless for removed queries.
@@ -490,26 +487,27 @@ def _list_removed_messages(
 
     session_factory = get_session_factory_from_request(request)
     with session_factory() as session:
-        rows = session.execute(
-            make_matching_removed_messages_query(
-                include_confirmations=True, **find_filters
-            )
-        ).all()
+        removed_messages = list(
+            session.execute(
+                make_matching_removed_messages_query(**find_filters)
+            ).scalars()
+        )
 
         # If the result set is smaller than the page size, we already know
-        # the total count without running a separate COUNT query.
-        if query_params.pagination and len(rows) < query_params.pagination:
-            total_msgs = (query_params.page - 1) * query_params.pagination + len(rows)
+        # the total count without running a separate COUNT query. Known
+        # trade-off (shared with the live-message listing): a page past the
+        # end of the result set overestimates the total.
+        if query_params.pagination and len(removed_messages) < query_params.pagination:
+            total_msgs = (query_params.page - 1) * query_params.pagination + len(
+                removed_messages
+            )
         else:
             total_msgs = count_matching_removed_messages(
                 session=session, **find_filters
             )
 
         response = format_response_dict(
-            messages=[
-                removed_message_to_dict(message, removed_message)
-                for message, removed_message in rows
-            ],
+            messages=[removed_message_to_dict(rm) for rm in removed_messages],
             pagination=query_params.pagination,
             page=query_params.page,
             total_messages=total_msgs,
@@ -576,19 +574,23 @@ async def view_messages_list(request: web.Request) -> web.Response:
         description: >-
           Accepted message statuses (comma-separated). 'forgotten' and
           'removed' are terminal statuses that must be the only status
-          requested (otherwise 400): 'forgotten' switches the query to the
-          forgotten_messages table, 'removed' joins messages with their
-          removal record. Supported filters are then msgTypes, addresses,
-          owners, chains, channels, hashes, paymentTypes and
-          startDate/endDate; date filters and time sorting apply to the
-          termination time (forgotten_at / removed_at), not to the message
-          time. Legacy rows without a termination time are excluded by date
-          filters and sorted last otherwise. Removed items carry
-          status/removed_at, and their 'size' field is the file-size snapshot
-          taken at removal (not the message content size). Unsupported
-          narrowing filters (refs, contentTypes, contentHashes, contentKeys,
-          tags, startBlock/endBlock) and cursor pagination are rejected
-          with 400.
+          requested (otherwise 400): both switch the query to the
+          corresponding snapshot table (forgotten_messages /
+          removed_messages — the messages row is deleted at termination)
+          and return message skeletons without content. Supported filters
+          are then msgTypes, addresses, owners, chains, channels, hashes,
+          paymentTypes and startDate/endDate; date filters and time sorting
+          apply to the termination time (forgotten_at / removed_at), not to
+          the message time. forgotten_at is the sender-supplied FORGET time
+          — the same declared-time semantics as the default time sort and
+          cursors of the live list; removed_at is the node-local removal
+          time (not deterministic across nodes). Legacy rows without a
+          termination time are excluded by date filters and sorted last
+          otherwise. The 'size' field of both skeletons is the file-size
+          snapshot preserved for billing (not the message content size).
+          Unsupported narrowing filters (refs, contentTypes, contentHashes,
+          contentKeys, tags, startBlock/endBlock) and cursor pagination are
+          rejected with 400.
       - name: addresses
         in: query
         schema:
@@ -1041,22 +1043,19 @@ def _get_message_with_status(
         )
 
     if status == MessageStatus.REMOVED:
-        message_db = get_message_by_item_hash(
-            session=session, item_hash=ItemHash(item_hash)
-        )
-        if not message_db:
-            raise web.HTTPNotFound()
-
+        # The messages row is deleted at removal (mirroring forgotten
+        # messages): the snapshot is the only record left.
         removed_message_db = get_removed_message(session=session, item_hash=item_hash)
+        if not removed_message_db:
+            raise web.HTTPGone(body=f"This message has been removed: {item_hash}")
 
-        message = format_message(message_db)
         return RemovedMessageStatus(
             item_hash=item_hash,
             reception_time=reception_time,
-            message=message,
+            message=RemovedMessage.model_validate(removed_message_db),
             reason=RemovedMessageReason.BALANCE_INSUFFICIENT,
-            removed_at=(removed_message_db.removed_at if removed_message_db else None),
-            size=removed_message_db.size if removed_message_db else None,
+            removed_at=removed_message_db.removed_at,
+            size=removed_message_db.size,
         )
 
     raise NotImplementedError(f"Unknown message status: {status}")

--- a/src/aleph/web/controllers/messages.py
+++ b/src/aleph/web/controllers/messages.py
@@ -13,16 +13,22 @@ from sqlalchemy.orm import defer
 
 import aleph.toolkit.json as aleph_json
 from aleph.db.accessors.messages import (
+    count_matching_forgotten_messages,
     count_matching_hashes,
+    count_matching_removed_messages,
     get_forgotten_message,
     get_matching_hashes,
     get_message_by_item_hash,
     get_message_status,
     get_rejected_message,
+    get_removed_message,
+    make_matching_forgotten_messages_query,
     make_matching_messages_query,
+    make_matching_removed_messages_query,
 )
 from aleph.db.accessors.pending_messages import get_pending_messages
 from aleph.db.models import MessageDb, MessageStatusDb
+from aleph.db.models.messages import ForgottenMessageDb, RemovedMessageDb
 from aleph.schemas.api.messages import (
     AlephMessage,
     ForgottenMessage,
@@ -368,6 +374,150 @@ def format_response_dict(
     }
 
 
+def forgotten_message_to_dict(message: ForgottenMessageDb) -> Dict[str, Any]:
+    # The ForgottenMessage schema owns the serialization rules (epoch-float
+    # time fields), so both the single-message endpoint and this list share
+    # one serializer.
+    message_dict = ForgottenMessage.model_validate(message).model_dump()
+    message_dict["status"] = MessageStatus.FORGOTTEN
+    message_dict["forgotten_by"] = message.forgotten_by
+    return message_dict
+
+
+def _validate_terminal_status_query_params(
+    query_params: MessageQueryParams, status_value: str
+) -> None:
+    """
+    Shared validation for forgotten/removed-only queries: cursor pagination
+    and filters over data these queries cannot narrow are rejected instead of
+    being silently ignored.
+    """
+    if query_params.cursor is not None:
+        raise web.HTTPBadRequest(
+            text=f"Cursor pagination is not supported for {status_value} "
+            "message queries"
+        )
+    unsupported_filters = {
+        "refs": query_params.refs,
+        "contentTypes": query_params.content_types,
+        "contentHashes": query_params.content_hashes,
+        "contentKeys": query_params.content_keys,
+        "tags": query_params.tags,
+        "startBlock": query_params.start_block,
+        "endBlock": query_params.end_block,
+    }
+    offending = [name for name, value in unsupported_filters.items() if value]
+    if offending:
+        raise web.HTTPBadRequest(
+            text=f"Filters not supported for {status_value} message queries: "
+            + ", ".join(offending)
+        )
+
+
+def _list_forgotten_messages(
+    request: web.Request, query_params: MessageQueryParams
+) -> web.Response:
+    """
+    Forgotten-only variant of the message list, served from the
+    forgotten_messages table. Date filters and time sorting apply to
+    `forgotten_at` (deletion time), not `time`.
+    """
+    find_filters = query_params.model_dump(exclude_none=True)
+    # Consumed by the caller or meaningless for forgotten queries.
+    for key in ("content_format", "exclude_content", "cursor", "message_statuses"):
+        find_filters.pop(key, None)
+
+    session_factory = get_session_factory_from_request(request)
+    with session_factory() as session:
+        forgotten_messages = list(
+            session.execute(
+                make_matching_forgotten_messages_query(**find_filters)
+            ).scalars()
+        )
+
+        # If the result set is smaller than the page size, we already know
+        # the total count without running a separate COUNT query.
+        if (
+            query_params.pagination
+            and len(forgotten_messages) < query_params.pagination
+        ):
+            total_msgs = (query_params.page - 1) * query_params.pagination + len(
+                forgotten_messages
+            )
+        else:
+            total_msgs = count_matching_forgotten_messages(
+                session=session, **find_filters
+            )
+
+        response = format_response_dict(
+            messages=[forgotten_message_to_dict(fm) for fm in forgotten_messages],
+            pagination=query_params.pagination,
+            page=query_params.page,
+            total_messages=total_msgs,
+        )
+
+    return web.json_response(text=aleph_json.dumps(response).decode("utf-8"))
+
+
+def removed_message_to_dict(
+    message: MessageDb, removed_message: Optional[RemovedMessageDb]
+) -> Dict[str, Any]:
+    message_dict = message_to_dict(message)
+    message_dict["status"] = MessageStatus.REMOVED
+    # File-size snapshot taken at removal time (shadows the message content
+    # size of live items; documented in the swagger docstring).
+    message_dict["size"] = removed_message.size if removed_message else None
+    message_dict["removed_at"] = (
+        removed_message.removed_at.timestamp()
+        if removed_message is not None and removed_message.removed_at is not None
+        else None
+    )
+    return message_dict
+
+
+def _list_removed_messages(
+    request: web.Request, query_params: MessageQueryParams
+) -> web.Response:
+    """
+    Removed-only variant of the message list: messages joined with their
+    removal record. Date filters and time sorting apply to `removed_at`
+    (removal time), not `time`.
+    """
+    find_filters = query_params.model_dump(exclude_none=True)
+    # Consumed by the caller or meaningless for removed queries.
+    for key in ("content_format", "exclude_content", "cursor", "message_statuses"):
+        find_filters.pop(key, None)
+
+    session_factory = get_session_factory_from_request(request)
+    with session_factory() as session:
+        rows = session.execute(
+            make_matching_removed_messages_query(
+                include_confirmations=True, **find_filters
+            )
+        ).all()
+
+        # If the result set is smaller than the page size, we already know
+        # the total count without running a separate COUNT query.
+        if query_params.pagination and len(rows) < query_params.pagination:
+            total_msgs = (query_params.page - 1) * query_params.pagination + len(rows)
+        else:
+            total_msgs = count_matching_removed_messages(
+                session=session, **find_filters
+            )
+
+        response = format_response_dict(
+            messages=[
+                removed_message_to_dict(message, removed_message)
+                for message, removed_message in rows
+            ],
+            pagination=query_params.pagination,
+            page=query_params.page,
+            total_messages=total_msgs,
+        )
+
+    return web.json_response(text=aleph_json.dumps(response).decode("utf-8"))
+
+
 def format_response(
     messages: Iterable[MessageDb],
     pagination: int,
@@ -423,6 +573,22 @@ async def view_messages_list(request: web.Request) -> web.Response:
         in: query
         schema:
           type: string
+        description: >-
+          Accepted message statuses (comma-separated). 'forgotten' and
+          'removed' are terminal statuses that must be the only status
+          requested (otherwise 400): 'forgotten' switches the query to the
+          forgotten_messages table, 'removed' joins messages with their
+          removal record. Supported filters are then msgTypes, addresses,
+          owners, chains, channels, hashes, paymentTypes and
+          startDate/endDate; date filters and time sorting apply to the
+          termination time (forgotten_at / removed_at), not to the message
+          time. Legacy rows without a termination time are excluded by date
+          filters and sorted last otherwise. Removed items carry
+          status/removed_at, and their 'size' field is the file-size snapshot
+          taken at removal (not the message content size). Unsupported
+          narrowing filters (refs, contentTypes, contentHashes, contentKeys,
+          tags, startBlock/endBlock) and cursor pagination are rejected
+          with 400.
       - name: addresses
         in: query
         schema:
@@ -536,6 +702,26 @@ async def view_messages_list(request: web.Request) -> web.Response:
     # parameters with the URL one
     if (url_page := get_path_page(request)) is not None:
         query_params.page = url_page
+
+    # Forgotten/removed-only queries run against dedicated tables (or joins)
+    # and sort on the termination time. Mixing them with other statuses
+    # would require a UNION across heterogeneous shapes, so it is rejected.
+    message_statuses = set(query_params.message_statuses or [])
+    terminal_statuses = message_statuses & {
+        MessageStatus.FORGOTTEN,
+        MessageStatus.REMOVED,
+    }
+    if terminal_statuses:
+        if len(message_statuses) > 1:
+            raise web.HTTPBadRequest(
+                text="msgStatuses=forgotten/removed cannot be combined with "
+                "other statuses"
+            )
+        status = next(iter(terminal_statuses))
+        _validate_terminal_status_query_params(query_params, status.value)
+        if status == MessageStatus.FORGOTTEN:
+            return _list_forgotten_messages(request, query_params)
+        return _list_removed_messages(request, query_params)
 
     find_filters = query_params.model_dump(exclude_none=True)
 
@@ -861,12 +1047,16 @@ def _get_message_with_status(
         if not message_db:
             raise web.HTTPNotFound()
 
+        removed_message_db = get_removed_message(session=session, item_hash=item_hash)
+
         message = format_message(message_db)
         return RemovedMessageStatus(
             item_hash=item_hash,
             reception_time=reception_time,
             message=message,
             reason=RemovedMessageReason.BALANCE_INSUFFICIENT,
+            removed_at=(removed_message_db.removed_at if removed_message_db else None),
+            size=removed_message_db.size if removed_message_db else None,
         )
 
     raise NotImplementedError(f"Unknown message status: {status}")

--- a/src/aleph/web/controllers/prices.py
+++ b/src/aleph/web/controllers/prices.py
@@ -25,7 +25,6 @@ from aleph.db.accessors.cost import (
     get_resources_with_costs,
     make_costs_upsert_query,
 )
-from aleph.db.accessors.files import get_file
 from aleph.db.accessors.messages import (
     get_forgotten_message,
     get_message_by_item_hash,
@@ -203,6 +202,10 @@ def _price_store_from_billing_metadata(
         # MIN_STORE_COST_MIB floor and the pricing aggregate apply exactly as
         # for live STORE messages. estimated_size_mib = size / MiB matches the
         # live calculation Decimal(file.size / MiB) bit for bit.
+        # content.item_hash carries the *message* hash, not the stored file
+        # hash a real STORE content would carry: it is only used to label
+        # cost rows, never for file lookups, because estimated_size_mib
+        # short-circuits calculate_storage_size.
         content = CostEstimationStoreContent(
             address=owner,
             time=time,
@@ -280,37 +283,36 @@ def _price_removed_store_message(
     session: DbSession, item_hash: ItemHash, include_size: bool
 ) -> web.Response:
     """
-    Price a removed STORE message live. The messages row survives removal,
-    so owner and payment type come from it; the size comes from the
-    removed_messages snapshot, falling back to a live files lookup (messages
-    removed before the snapshot existed and whose file was not collected
-    yet). Raises 410 Gone when the size is unresolvable or the message is
-    not a STORE.
+    Price a removed STORE message live from the billing metadata preserved
+    in removed_messages (the messages row is deleted at removal, mirroring
+    forgotten messages). Raises 410 Gone when the metadata is missing
+    (legacy rows, size never snapshotted) or the message is not a STORE.
     """
     gone = web.HTTPGone(body=f"This message has been removed: {item_hash}")
 
-    message = get_message_by_item_hash(session=session, item_hash=item_hash)
-    if message is None or message.type != MessageType.store or message.owner is None:
-        raise gone
-
     removed_message = get_removed_message(session=session, item_hash=item_hash)
-    size = removed_message.size if removed_message else None
-    if size is None and message.content_item_hash:
-        file = get_file(session, message.content_item_hash)
-        size = file.size if file else None
-    if size is None:
+    if (
+        removed_message is None
+        or removed_message.type != MessageType.store
+        or removed_message.owner is None
+        or removed_message.size is None
+        or removed_message.time is None
+    ):
         raise gone
 
-    payment_type_value = message.payment_type or PaymentType.hold.value
+    # Snapshots store the effective payment type (coalesced at removal);
+    # legacy rows may still carry NULL, which means hold everywhere in
+    # pyaleph.
+    payment_type_value = removed_message.payment_type or PaymentType.hold.value
 
     return _price_store_from_billing_metadata(
         session=session,
         item_hash=item_hash,
         include_size=include_size,
-        owner=message.owner,
+        owner=removed_message.owner,
         payment_type_value=payment_type_value,
-        size=size,
-        time=message.time.timestamp(),
+        size=removed_message.size,
+        time=removed_message.time.timestamp(),
         gone=gone,
     )
 

--- a/src/aleph/web/controllers/prices.py
+++ b/src/aleph/web/controllers/prices.py
@@ -1,11 +1,12 @@
 import logging
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Iterable, Optional, Sequence, Tuple
 
 from aiohttp import web
 from aiohttp.web_exceptions import HTTPException
-from aleph_message.models import ExecutableContent, ItemHash, MessageType
+from aleph_message.models import ExecutableContent, ItemHash, ItemType, MessageType
+from aleph_message.models.execution.base import Payment, PaymentType
 from dataclasses_json import DataClassJsonMixin
 from pydantic import BaseModel, Field, ValidationError
 from sqlalchemy import select
@@ -24,8 +25,15 @@ from aleph.db.accessors.cost import (
     get_resources_with_costs,
     make_costs_upsert_query,
 )
-from aleph.db.accessors.messages import get_message_by_item_hash, get_message_status
+from aleph.db.accessors.files import get_file
+from aleph.db.accessors.messages import (
+    get_forgotten_message,
+    get_message_by_item_hash,
+    get_message_status,
+    get_removed_message,
+)
 from aleph.db.models import MessageDb
+from aleph.db.models.account_costs import AccountCostsDb
 from aleph.schemas.api.costs import (
     CostComponentDetail,
     CostsFiltersResponse,
@@ -38,6 +46,7 @@ from aleph.schemas.api.costs import (
 )
 from aleph.schemas.cost_estimation_messages import (
     CostEstimationInstanceContent,
+    CostEstimationStoreContent,
     validate_cost_estimation_message_content,
     validate_cost_estimation_message_dict,
 )
@@ -141,9 +150,179 @@ async def get_executable_message(session: DbSession, item_hash: ItemHash) -> Mes
     return message
 
 
+def _make_cost_detail(
+    cost: AccountCostsDb, size_mib: Optional[float]
+) -> EstimatedCostDetailResponse:
+    return EstimatedCostDetailResponse(
+        type=(cost.type.value if hasattr(cost.type, "value") else str(cost.type)),
+        name=cost.name,
+        cost_hold=str(cost.cost_hold),
+        cost_stream=str(cost.cost_stream),
+        cost_credit=str(cost.cost_credit),
+        size_mib=size_mib,
+    )
+
+
+def _build_costs_response(
+    payment_type: PaymentType,
+    required_tokens: Decimal,
+    charged_address: str,
+    costs_with_sizes: Iterable[Tuple[AccountCostsDb, Optional[float]]],
+) -> web.Response:
+    model = {
+        "required_tokens": float(required_tokens),
+        "payment_type": payment_type,
+        "cost": format_cost_str(required_tokens),
+        "detail": [
+            _make_cost_detail(cost, size_mib) for cost, size_mib in costs_with_sizes
+        ],
+        "charged_address": charged_address,
+    }
+
+    response = EstimatedCostsResponse.model_validate(model)
+
+    return web.json_response(text=aleph_json.dumps(response).decode("utf-8"))
+
+
+def _price_store_from_billing_metadata(
+    session: DbSession,
+    item_hash: ItemHash,
+    include_size: bool,
+    owner: str,
+    payment_type_value: str,
+    size: int,
+    time: float,
+    gone: web.HTTPGone,
+) -> web.Response:
+    """
+    Price a terminated (forgotten/removed) STORE message live from its
+    preserved billing metadata.
+    """
+    try:
+        # Synthetic content routed through the estimation path so the
+        # MIN_STORE_COST_MIB floor and the pricing aggregate apply exactly as
+        # for live STORE messages. estimated_size_mib = size / MiB matches the
+        # live calculation Decimal(file.size / MiB) bit for bit.
+        content = CostEstimationStoreContent(
+            address=owner,
+            time=time,
+            item_type=ItemType.storage,
+            item_hash=item_hash,
+            payment=Payment(type=PaymentType(payment_type_value)),
+            estimated_size_mib=size / MiB,
+        )
+    except (ValidationError, ValueError):
+        raise gone
+
+    try:
+        payment_type = get_payment_type(content)
+        required_tokens, costs = get_total_and_detailed_costs(
+            session, content, item_hash
+        )
+    except RuntimeError as e:
+        raise web.HTTPNotFound(reason=str(e))
+
+    costs_with_sizes = [
+        (
+            cost,
+            (
+                get_cost_component_size_mib(session, cost, content)
+                if include_size
+                else None
+            ),
+        )
+        for cost in costs
+    ]
+
+    return _build_costs_response(
+        payment_type, required_tokens, content.address, costs_with_sizes
+    )
+
+
+def _price_forgotten_store_message(
+    session: DbSession, item_hash: ItemHash, include_size: bool
+) -> web.Response:
+    """
+    Price a forgotten STORE message live from the billing metadata preserved
+    in forgotten_messages (owner, size). Raises 410 Gone when the metadata is
+    missing (messages forgotten before it was captured) or the message is not
+    a STORE.
+    """
+    gone = web.HTTPGone(body=f"This message has been forgotten: {item_hash}")
+
+    forgotten_message = get_forgotten_message(session=session, item_hash=item_hash)
+    if (
+        forgotten_message is None
+        or forgotten_message.type != MessageType.store
+        or forgotten_message.owner is None
+        or forgotten_message.size is None
+    ):
+        raise gone
+
+    # Rows captured before payment_type was coalesced at forget time may
+    # store NULL: the absence of a payment field means hold everywhere in
+    # pyaleph, so apply the same default the live pricing path uses.
+    payment_type_value = forgotten_message.payment_type or PaymentType.hold.value
+
+    return _price_store_from_billing_metadata(
+        session=session,
+        item_hash=item_hash,
+        include_size=include_size,
+        owner=forgotten_message.owner,
+        payment_type_value=payment_type_value,
+        size=forgotten_message.size,
+        time=forgotten_message.time.timestamp(),
+        gone=gone,
+    )
+
+
+def _price_removed_store_message(
+    session: DbSession, item_hash: ItemHash, include_size: bool
+) -> web.Response:
+    """
+    Price a removed STORE message live. The messages row survives removal,
+    so owner and payment type come from it; the size comes from the
+    removed_messages snapshot, falling back to a live files lookup (messages
+    removed before the snapshot existed and whose file was not collected
+    yet). Raises 410 Gone when the size is unresolvable or the message is
+    not a STORE.
+    """
+    gone = web.HTTPGone(body=f"This message has been removed: {item_hash}")
+
+    message = get_message_by_item_hash(session=session, item_hash=item_hash)
+    if message is None or message.type != MessageType.store or message.owner is None:
+        raise gone
+
+    removed_message = get_removed_message(session=session, item_hash=item_hash)
+    size = removed_message.size if removed_message else None
+    if size is None and message.content_item_hash:
+        file = get_file(session, message.content_item_hash)
+        size = file.size if file else None
+    if size is None:
+        raise gone
+
+    payment_type_value = message.payment_type or PaymentType.hold.value
+
+    return _price_store_from_billing_metadata(
+        session=session,
+        item_hash=item_hash,
+        include_size=include_size,
+        owner=message.owner,
+        payment_type_value=payment_type_value,
+        size=size,
+        time=message.time.timestamp(),
+        gone=gone,
+    )
+
+
 async def message_price(request: web.Request):
     """
     Returns the price of an executable message.
+
+    Forgotten and removed STORE messages whose billing metadata was preserved
+    (forgotten_messages / removed_messages, with a live files fallback for
+    removed) are priced live from that metadata instead of returning 410
+    Gone.
 
     ---
     summary: Get message price
@@ -164,6 +343,8 @@ async def message_price(request: web.Request):
               $ref: '#/components/schemas/EstimatedCostsResponse'
       '404':
         description: Message not found
+      '410':
+        description: Message forgotten or removed, and not priceable
     """
 
     include_size = request.query.get("include_size", "false").lower() == "true"
@@ -171,6 +352,13 @@ async def message_price(request: web.Request):
     session_factory = get_session_factory_from_request(request)
     with session_factory() as session:
         item_hash = get_item_hash_from_request(request)
+
+        message_status_db = get_message_status(session=session, item_hash=item_hash)
+        if message_status_db and message_status_db.status == MessageStatus.FORGOTTEN:
+            return _price_forgotten_store_message(session, item_hash, include_size)
+        if message_status_db and message_status_db.status == MessageStatus.REMOVED:
+            return _price_removed_store_message(session, item_hash, include_size)
+
         message = await get_executable_message(session, item_hash)
         content: ExecutableContent = message.parsed_content
 
@@ -186,44 +374,25 @@ async def message_price(request: web.Request):
         # Optionally enrich detail with file sizes (single joined query).
         # Falls back to content-based sizes (PERSISTENT) when DB join yields nothing.
         if include_size:
-            costs_with_sizes = get_message_costs_with_file_sizes(session, item_hash)
+            costs_with_file_sizes = get_message_costs_with_file_sizes(
+                session, item_hash
+            )
         else:
-            costs_with_sizes = [(cost, None) for cost in costs]
+            costs_with_file_sizes = [(cost, None) for cost in costs]
 
-        detail_list = []
-        for cost, file_size_bytes in costs_with_sizes:
+        costs_with_sizes = []
+        for cost, file_size_bytes in costs_with_file_sizes:
             if file_size_bytes is not None:
                 size_mib: Optional[float] = float(file_size_bytes / MiB)
             elif include_size:
                 size_mib = get_cost_component_size_mib(session, cost, content)
             else:
                 size_mib = None
-            detail_list.append(
-                EstimatedCostDetailResponse(
-                    type=(
-                        cost.type.value
-                        if hasattr(cost.type, "value")
-                        else str(cost.type)
-                    ),
-                    name=cost.name,
-                    cost_hold=str(cost.cost_hold),
-                    cost_stream=str(cost.cost_stream),
-                    cost_credit=str(cost.cost_credit),
-                    size_mib=size_mib,
-                )
-            )
+            costs_with_sizes.append((cost, size_mib))
 
-    model = {
-        "required_tokens": float(required_tokens),
-        "payment_type": payment_type,
-        "cost": format_cost_str(required_tokens),
-        "detail": detail_list,
-        "charged_address": content.address,
-    }
-
-    response = EstimatedCostsResponse.model_validate(model)
-
-    return web.json_response(text=aleph_json.dumps(response).decode("utf-8"))
+    return _build_costs_response(
+        payment_type, required_tokens, content.address, costs_with_sizes
+    )
 
 
 class PubMessageRequest(BaseModel):
@@ -281,35 +450,14 @@ async def message_price_estimate(request: web.Request):
             raise web.HTTPNotFound(reason=str(e))
 
         # Enrich detail with size information
-        detail_list = []
-        for cost in costs:
-            size_mib = get_cost_component_size_mib(session, cost, content)
-            detail_list.append(
-                EstimatedCostDetailResponse(
-                    type=(
-                        cost.type.value
-                        if hasattr(cost.type, "value")
-                        else str(cost.type)
-                    ),
-                    name=cost.name,
-                    cost_hold=str(cost.cost_hold),
-                    cost_stream=str(cost.cost_stream),
-                    cost_credit=str(cost.cost_credit),
-                    size_mib=size_mib,
-                )
-            )
+        costs_with_sizes = [
+            (cost, get_cost_component_size_mib(session, cost, content))
+            for cost in costs
+        ]
 
-    model = {
-        "required_tokens": float(required_tokens),
-        "payment_type": payment_type,
-        "cost": format_cost_str(required_tokens),
-        "detail": detail_list,
-        "charged_address": content.address,
-    }
-
-    response = EstimatedCostsResponse.model_validate(model)
-
-    return web.json_response(text=aleph_json.dumps(response).decode("utf-8"))
+    return _build_costs_response(
+        payment_type, required_tokens, content.address, costs_with_sizes
+    )
 
 
 async def instance_cost_estimate(request: web.Request):
@@ -367,35 +515,14 @@ async def instance_cost_estimate(request: web.Request):
         except RuntimeError as e:
             raise web.HTTPNotFound(reason=str(e))
 
-        detail_list = []
-        for cost in costs:
-            size_mib = get_cost_component_size_mib(session, cost, content)
-            detail_list.append(
-                EstimatedCostDetailResponse(
-                    type=(
-                        cost.type.value
-                        if hasattr(cost.type, "value")
-                        else str(cost.type)
-                    ),
-                    name=cost.name,
-                    cost_hold=str(cost.cost_hold),
-                    cost_stream=str(cost.cost_stream),
-                    cost_credit=str(cost.cost_credit),
-                    size_mib=size_mib,
-                )
-            )
+        costs_with_sizes = [
+            (cost, get_cost_component_size_mib(session, cost, content))
+            for cost in costs
+        ]
 
-    model = {
-        "required_tokens": float(required_tokens),
-        "payment_type": payment_type,
-        "cost": format_cost_str(required_tokens),
-        "detail": detail_list,
-        "charged_address": content.address,
-    }
-
-    response = EstimatedCostsResponse.model_validate(model)
-
-    return web.json_response(text=aleph_json.dumps(response).decode("utf-8"))
+    return _build_costs_response(
+        payment_type, required_tokens, content.address, costs_with_sizes
+    )
 
 
 @require_auth_token

--- a/tests/api/test_credit_history.py
+++ b/tests/api/test_credit_history.py
@@ -496,3 +496,48 @@ async def test_credit_history_resource_filter_filters_entries(
         listing_uri, params={"resource": "target_vm", "direction": "incoming"}
     )
     assert response.status == 404
+
+
+@pytest.mark.asyncio
+async def test_credit_history_exposes_v2_expense_aggregates(
+    ccn_api_client, session_factory
+):
+    """v2 aggregated expense entries expose expense_count/expense_size_mib."""
+    with session_factory() as session:
+        update_credit_balances_expense(
+            session=session,
+            credits_list=[
+                {
+                    "address": "0xe2ev2expense",
+                    "amount": 750,
+                    "ref": "storage",
+                    "count": 3,
+                    "size": 512.25,
+                },
+                # v1-style entry, no aggregates
+                {
+                    "address": "0xe2ev2expense",
+                    "amount": 100,
+                    "ref": "v1_ref",
+                },
+            ],
+            message_hash="e2e_v2_expense",
+            message_timestamp=dt.datetime(2026, 4, 2, tzinfo=dt.timezone.utc),
+        )
+        session.commit()
+
+    response = await ccn_api_client.get(
+        "/api/v0/addresses/0xe2ev2expense/credit_history"
+    )
+    assert response.status == 200
+    data = await response.json()
+
+    entries = {entry["origin_ref"]: entry for entry in data["credit_history"]}
+
+    v2_entry = entries["storage"]
+    assert v2_entry["expense_count"] == 3
+    assert float(v2_entry["expense_size_mib"]) == 512.25
+
+    v1_entry = entries["v1_ref"]
+    assert v1_entry["expense_count"] is None
+    assert v1_entry["expense_size_mib"] is None

--- a/tests/api/test_forgotten_price.py
+++ b/tests/api/test_forgotten_price.py
@@ -1,0 +1,243 @@
+import datetime as dt
+
+import pytest
+from aleph_message.models import Chain, ItemHash, ItemType, MessageType
+from aleph_message.models.execution.base import Payment, PaymentType
+
+from aleph.db.models.messages import ForgottenMessageDb, MessageStatusDb
+from aleph.schemas.cost_estimation_messages import CostEstimationStoreContent
+from aleph.services.cost import get_total_and_detailed_costs
+from aleph.toolkit.constants import MIN_STORE_COST_MIB, MiB
+from aleph.toolkit.timestamp import timestamp_to_datetime
+from aleph.types.channel import Channel
+from aleph.types.db_session import DbSessionFactory
+from aleph.types.message_status import MessageStatus
+
+PRICE_URI = "/api/v0/price/{}"
+
+OWNER = "0xB6B5358493AF8159B17506C5cC85df69193444BC"
+SENDER = "0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106"
+
+FORGOTTEN_CREDIT_STORE_HASH = (
+    "5555555555555555555555555555555555555555555555555555555555555555"
+)
+FORGOTTEN_LEGACY_STORE_HASH = (
+    "6666666666666666666666666666666666666666666666666666666666666666"
+)
+FORGOTTEN_POST_HASH = "7777777777777777777777777777777777777777777777777777777777777777"
+FORGOTTEN_HOLD_STORE_HASH = (
+    "8888888888888888888888888888888888888888888888888888888888888888"
+)
+FORGOTTEN_NULL_PAYMENT_STORE_HASH = (
+    "9999999999999999999999999999999999999999999999999999999999999999"
+)
+
+SMALL_FILE_SIZE = 1024 * 1024  # 1 MiB, well below the MIN_STORE_COST_MIB floor
+
+
+def _add_forgotten_message(session, **kwargs) -> None:
+    defaults = dict(
+        chain=Chain.ETH,
+        sender=SENDER,
+        signature="sig",
+        item_type=ItemType.inline,
+        time=timestamp_to_datetime(1652786100),
+        channel=Channel("TEST"),
+        forgotten_by=["aaaa" * 16],
+    )
+    row = ForgottenMessageDb(**{**defaults, **kwargs})
+    session.add(row)
+    session.add(
+        MessageStatusDb(
+            item_hash=row.item_hash,
+            status=MessageStatus.FORGOTTEN,
+            reception_time=dt.datetime(2022, 1, 1, tzinfo=dt.timezone.utc),
+        )
+    )
+
+
+@pytest.fixture
+def fixture_forgotten_messages_for_pricing(session_factory: DbSessionFactory):
+    with session_factory() as session:
+        _add_forgotten_message(
+            session,
+            item_hash=FORGOTTEN_CREDIT_STORE_HASH,
+            type=MessageType.store,
+            owner=OWNER,
+            payment_type="credit",
+            size=SMALL_FILE_SIZE,
+            forgotten_at=timestamp_to_datetime(1652786500),
+        )
+        # Legacy row: no billing metadata
+        _add_forgotten_message(
+            session,
+            item_hash=FORGOTTEN_LEGACY_STORE_HASH,
+            type=MessageType.store,
+        )
+        # Forgotten non-STORE message with metadata-like fields
+        _add_forgotten_message(
+            session,
+            item_hash=FORGOTTEN_POST_HASH,
+            type=MessageType.post,
+            owner=OWNER,
+            forgotten_at=timestamp_to_datetime(1652786500),
+        )
+        # Hold-paid STORE captured with the explicit hold payment type
+        _add_forgotten_message(
+            session,
+            item_hash=FORGOTTEN_HOLD_STORE_HASH,
+            type=MessageType.store,
+            owner=OWNER,
+            payment_type="hold",
+            size=SMALL_FILE_SIZE,
+            forgotten_at=timestamp_to_datetime(1652786500),
+        )
+        # Row captured before payment_type was coalesced at forget time
+        _add_forgotten_message(
+            session,
+            item_hash=FORGOTTEN_NULL_PAYMENT_STORE_HASH,
+            type=MessageType.store,
+            owner=OWNER,
+            payment_type=None,
+            size=SMALL_FILE_SIZE,
+            forgotten_at=timestamp_to_datetime(1652786500),
+        )
+        session.commit()
+
+
+@pytest.mark.asyncio
+async def test_message_price_forgotten_store_with_metadata(
+    ccn_api_client,
+    session_factory: DbSessionFactory,
+    fixture_forgotten_messages_for_pricing,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """
+    A forgotten STORE with preserved metadata is priced live, and the
+    MIN_STORE_COST_MIB floor applies: a 1 MiB file is billed as
+    MIN_STORE_COST_MIB MiB.
+    """
+    response = await ccn_api_client.get(PRICE_URI.format(FORGOTTEN_CREDIT_STORE_HASH))
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    assert data["payment_type"] == "credit"
+    assert data["charged_address"] == OWNER
+    assert data["required_tokens"] > 0
+
+    # Expected price: the estimation path for a MIN_STORE_COST_MIB file
+    with session_factory() as session:
+        expected_cost, _ = get_total_and_detailed_costs(
+            session=session,
+            content=CostEstimationStoreContent(
+                address=OWNER,
+                time=1652786100.0,
+                item_type=ItemType.storage,
+                item_hash=ItemHash(FORGOTTEN_CREDIT_STORE_HASH),
+                payment=Payment(type=PaymentType.credit),
+                estimated_size_mib=MIN_STORE_COST_MIB,
+            ),
+            item_hash=FORGOTTEN_CREDIT_STORE_HASH,
+        )
+
+    assert data["required_tokens"] == float(expected_cost)
+    assert len(data["detail"]) == 1
+    assert data["detail"][0]["type"] == "STORAGE"
+
+
+@pytest.mark.asyncio
+async def test_message_price_forgotten_store_include_size(
+    ccn_api_client,
+    fixture_forgotten_messages_for_pricing,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """include_size returns the preserved (real) size, not the billed floor."""
+    response = await ccn_api_client.get(
+        PRICE_URI.format(FORGOTTEN_CREDIT_STORE_HASH) + "?include_size=true"
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    assert data["detail"][0]["size_mib"] == SMALL_FILE_SIZE / MiB
+
+
+@pytest.mark.asyncio
+async def test_message_price_forgotten_store_without_metadata(
+    ccn_api_client,
+    fixture_forgotten_messages_for_pricing,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """A forgotten STORE without preserved metadata keeps returning 410 Gone."""
+    response = await ccn_api_client.get(PRICE_URI.format(FORGOTTEN_LEGACY_STORE_HASH))
+    assert response.status == 410, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_message_price_forgotten_non_store(
+    ccn_api_client,
+    fixture_forgotten_messages_for_pricing,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """Forgotten non-STORE messages keep returning 410 Gone."""
+    response = await ccn_api_client.get(PRICE_URI.format(FORGOTTEN_POST_HASH))
+    assert response.status == 410, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_message_price_forgotten_hold_store(
+    ccn_api_client,
+    session_factory: DbSessionFactory,
+    fixture_forgotten_messages_for_pricing,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """A forgotten hold-paid STORE is priced as hold (no credit floor)."""
+    response = await ccn_api_client.get(PRICE_URI.format(FORGOTTEN_HOLD_STORE_HASH))
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    assert data["payment_type"] == "hold"
+    assert data["charged_address"] == OWNER
+
+    # Expected price: hold cost of the real (1 MiB) size, floor not applied
+    with session_factory() as session:
+        expected_cost, _ = get_total_and_detailed_costs(
+            session=session,
+            content=CostEstimationStoreContent(
+                address=OWNER,
+                time=1652786100.0,
+                item_type=ItemType.storage,
+                item_hash=ItemHash(FORGOTTEN_HOLD_STORE_HASH),
+                payment=Payment(type=PaymentType.hold),
+                estimated_size_mib=SMALL_FILE_SIZE / MiB,
+            ),
+            item_hash=FORGOTTEN_HOLD_STORE_HASH,
+        )
+
+    assert data["required_tokens"] == float(expected_cost)
+
+
+@pytest.mark.asyncio
+async def test_message_price_forgotten_store_null_payment_defaults_to_hold(
+    ccn_api_client,
+    fixture_forgotten_messages_for_pricing,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """
+    Rows captured before payment_type was coalesced at forget time have NULL
+    payment_type: they are priced as hold, matching the live pricing default.
+    """
+    response = await ccn_api_client.get(
+        PRICE_URI.format(FORGOTTEN_NULL_PAYMENT_STORE_HASH)
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    assert data["payment_type"] == "hold"
+    assert data["charged_address"] == OWNER
+    assert data["required_tokens"] > 0

--- a/tests/api/test_get_message.py
+++ b/tests/api/test_get_message.py
@@ -136,6 +136,10 @@ def fixture_messages_with_status(
             forgotten_by=[
                 "e3b24727335e34016247c0d37e2b0203bb8c2d76deddafc1700b4cf0e13845c5"
             ],
+            owner="0xB68B9D4f3771c246233823ed1D3Add451055F9Ef",
+            payment_type="credit",
+            size=1024 * 1024,
+            forgotten_at=timestamp_to_datetime(1645794100),
         )
     ]
 
@@ -277,6 +281,18 @@ async def test_get_forgotten_message_status(
         assert parsed_response.message.time == forgotten_message.time
 
         assert parsed_response.forgotten_by == forgotten_message.forgotten_by
+
+        # Billing metadata preserved at forget time
+        assert parsed_response.message.owner == forgotten_message.owner
+        assert parsed_response.message.payment_type == forgotten_message.payment_type
+        assert parsed_response.message.size == forgotten_message.size
+        assert parsed_response.message.forgotten_at == forgotten_message.forgotten_at
+        # time and forgotten_at are serialized as epoch floats
+        assert response_json["message"]["time"] == forgotten_message.time.timestamp()
+        assert (
+            response_json["message"]["forgotten_at"]
+            == forgotten_message.forgotten_at.timestamp()
+        )
 
         # Check that the content is not included in the response, somehow
         assert "item_content" not in response_json

--- a/tests/api/test_list_forgotten_messages.py
+++ b/tests/api/test_list_forgotten_messages.py
@@ -224,7 +224,9 @@ async def test_list_forgotten_messages_filters(
     data = await response.json()
     assert [msg["item_hash"] for msg in data["messages"]] == [STORE_CREDIT_HASH]
 
-    # paymentTypes (legacy rows with NULL payment_type never match)
+    # paymentTypes: absence of a payment field means hold (billing
+    # semantics), so NULL-payment rows (legacy included) match
+    # paymentTypes=hold — same coalescing as the removed query
     response = await ccn_api_client.get(
         MESSAGES_URI, params={"msgStatuses": "forgotten", "paymentTypes": "credit"}
     )
@@ -237,7 +239,27 @@ async def test_list_forgotten_messages_filters(
     )
     assert response.status == 200, await response.text()
     data = await response.json()
-    assert [msg["item_hash"] for msg in data["messages"]] == [STORE_HOLD_HASH]
+    assert {msg["item_hash"] for msg in data["messages"]} == {
+        STORE_HOLD_HASH,
+        POST_HASH,
+        LEGACY_STORE_HASH,
+    }
+
+    # combined with msgTypes=STORE: the implicit-hold legacy STORE matches
+    response = await ccn_api_client.get(
+        MESSAGES_URI,
+        params={
+            "msgStatuses": "forgotten",
+            "paymentTypes": "hold",
+            "msgTypes": "STORE",
+        },
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert {msg["item_hash"] for msg in data["messages"]} == {
+        STORE_HOLD_HASH,
+        LEGACY_STORE_HASH,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_list_forgotten_messages.py
+++ b/tests/api/test_list_forgotten_messages.py
@@ -1,0 +1,316 @@
+import pytest
+from aleph_message.models import Chain, ItemType, MessageType
+
+from aleph.db.models.messages import ForgottenMessageDb
+from aleph.toolkit.timestamp import timestamp_to_datetime
+from aleph.types.channel import Channel
+from aleph.types.db_session import DbSessionFactory
+
+MESSAGES_URI = "/api/v0/messages.json"
+
+OWNER_A = "0x8B8Ff2a2AC5d3b2Db4c1E7B1c1E7B1c1E7B1c1E7"
+OWNER_B = "0x02c2A8B8Ff2a2AC5d3b2Db4c1E7B1c1E7B1c1E7B"
+SENDER_A = "0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106"
+SENDER_B = "0xB68B9D4f3771c246233823ed1D3Add451055F9Ef"
+
+STORE_CREDIT_HASH = "1111111111111111111111111111111111111111111111111111111111111111"
+STORE_HOLD_HASH = "2222222222222222222222222222222222222222222222222222222222222222"
+POST_HASH = "3333333333333333333333333333333333333333333333333333333333333333"
+LEGACY_STORE_HASH = "4444444444444444444444444444444444444444444444444444444444444444"
+
+FORGOTTEN_AT_CREDIT = 1652786500.0
+FORGOTTEN_AT_HOLD = 1652787000.0
+FORGOTTEN_AT_POST = 1652787500.0
+
+
+@pytest.fixture
+def fixture_forgotten_messages(session_factory: DbSessionFactory):
+    rows = [
+        ForgottenMessageDb(
+            item_hash=STORE_CREDIT_HASH,
+            type=MessageType.store,
+            chain=Chain.ETH,
+            sender=SENDER_A,
+            signature="sig-1",
+            item_type=ItemType.inline,
+            time=timestamp_to_datetime(1652786100),
+            channel=Channel("TEST"),
+            forgotten_by=["aaaa" * 16],
+            owner=OWNER_A,
+            payment_type="credit",
+            size=4 * 1024 * 1024,
+            forgotten_at=timestamp_to_datetime(FORGOTTEN_AT_CREDIT),
+        ),
+        ForgottenMessageDb(
+            item_hash=STORE_HOLD_HASH,
+            type=MessageType.store,
+            chain=Chain.ETH,
+            sender=SENDER_B,
+            signature="sig-2",
+            item_type=ItemType.inline,
+            time=timestamp_to_datetime(1652786200),
+            channel=Channel("TEST"),
+            forgotten_by=["bbbb" * 16],
+            owner=OWNER_B,
+            payment_type="hold",
+            size=10 * 1024 * 1024,
+            forgotten_at=timestamp_to_datetime(FORGOTTEN_AT_HOLD),
+        ),
+        ForgottenMessageDb(
+            item_hash=POST_HASH,
+            type=MessageType.post,
+            chain=Chain.ETH,
+            sender=SENDER_A,
+            signature="sig-3",
+            item_type=ItemType.inline,
+            time=timestamp_to_datetime(1652786300),
+            channel=Channel("OTHER"),
+            forgotten_by=["cccc" * 16],
+            owner=OWNER_A,
+            payment_type=None,
+            size=None,
+            forgotten_at=timestamp_to_datetime(FORGOTTEN_AT_POST),
+        ),
+        # Legacy row: forgotten before the metadata columns existed
+        ForgottenMessageDb(
+            item_hash=LEGACY_STORE_HASH,
+            type=MessageType.store,
+            chain=Chain.ETH,
+            sender=SENDER_B,
+            signature="sig-4",
+            item_type=ItemType.inline,
+            time=timestamp_to_datetime(1652786400),
+            channel=Channel("TEST"),
+            forgotten_by=["dddd" * 16],
+        ),
+    ]
+
+    with session_factory() as session:
+        for row in rows:
+            session.add(row)
+        session.commit()
+
+    return rows
+
+
+@pytest.mark.asyncio
+async def test_list_forgotten_messages(fixture_forgotten_messages, ccn_api_client):
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "forgotten"}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    messages = data["messages"]
+    assert data["pagination_total"] == 4
+    # Sorted by forgotten_at DESC, legacy NULL rows last
+    assert [msg["item_hash"] for msg in messages] == [
+        POST_HASH,
+        STORE_HOLD_HASH,
+        STORE_CREDIT_HASH,
+        LEGACY_STORE_HASH,
+    ]
+
+    credit_store = messages[2]
+    assert credit_store["status"] == "forgotten"
+    assert credit_store["type"] == "STORE"
+    assert credit_store["chain"] == "ETH"
+    assert credit_store["sender"] == SENDER_A
+    assert credit_store["signature"] == "sig-1"
+    assert credit_store["item_type"] == "inline"
+    assert credit_store["time"] == 1652786100.0
+    assert credit_store["channel"] == "TEST"
+    assert credit_store["forgotten_by"] == ["aaaa" * 16]
+    assert credit_store["owner"] == OWNER_A
+    assert credit_store["payment_type"] == "credit"
+    assert credit_store["size"] == 4 * 1024 * 1024
+    assert credit_store["forgotten_at"] == FORGOTTEN_AT_CREDIT
+
+    legacy_store = messages[3]
+    assert legacy_store["owner"] is None
+    assert legacy_store["payment_type"] is None
+    assert legacy_store["size"] is None
+    assert legacy_store["forgotten_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_forgotten_messages_ascending(
+    fixture_forgotten_messages, ccn_api_client
+):
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "forgotten", "sortOrder": "1"}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    # Ascending forgotten_at, legacy NULL rows still last
+    assert [msg["item_hash"] for msg in data["messages"]] == [
+        STORE_CREDIT_HASH,
+        STORE_HOLD_HASH,
+        POST_HASH,
+        LEGACY_STORE_HASH,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_forgotten_messages_rejects_mixed_statuses(
+    fixture_forgotten_messages, ccn_api_client
+):
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "forgotten,processed"}
+    )
+    assert response.status == 400, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_list_forgotten_messages_rejects_cursor(
+    fixture_forgotten_messages, ccn_api_client
+):
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "forgotten", "cursor": "some-cursor"}
+    )
+    assert response.status == 400, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_list_forgotten_messages_filters(
+    fixture_forgotten_messages, ccn_api_client
+):
+    # msgTypes
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "forgotten", "msgTypes": "STORE"}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert {msg["item_hash"] for msg in data["messages"]} == {
+        STORE_CREDIT_HASH,
+        STORE_HOLD_HASH,
+        LEGACY_STORE_HASH,
+    }
+
+    # owners
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "forgotten", "owners": OWNER_B}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert [msg["item_hash"] for msg in data["messages"]] == [STORE_HOLD_HASH]
+
+    # addresses (sender)
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "forgotten", "addresses": SENDER_A}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert {msg["item_hash"] for msg in data["messages"]} == {
+        STORE_CREDIT_HASH,
+        POST_HASH,
+    }
+
+    # channels
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "forgotten", "channels": "OTHER"}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert [msg["item_hash"] for msg in data["messages"]] == [POST_HASH]
+
+    # hashes
+    response = await ccn_api_client.get(
+        MESSAGES_URI,
+        params={"msgStatuses": "forgotten", "hashes": STORE_CREDIT_HASH},
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert [msg["item_hash"] for msg in data["messages"]] == [STORE_CREDIT_HASH]
+
+    # paymentTypes (legacy rows with NULL payment_type never match)
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "forgotten", "paymentTypes": "credit"}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert [msg["item_hash"] for msg in data["messages"]] == [STORE_CREDIT_HASH]
+
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "forgotten", "paymentTypes": "hold"}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert [msg["item_hash"] for msg in data["messages"]] == [STORE_HOLD_HASH]
+
+
+@pytest.mark.asyncio
+async def test_list_forgotten_messages_rejects_unsupported_filters(
+    fixture_forgotten_messages, ccn_api_client
+):
+    """Filters on data not preserved in forgotten_messages return 400."""
+    unsupported_params = [
+        {"refs": "some-ref"},
+        {"contentTypes": "file"},
+        {"contentHashes": STORE_CREDIT_HASH},
+        {"contentKeys": STORE_CREDIT_HASH},
+        {"tags": "mainnet"},
+        {"startBlock": "100"},
+        {"endBlock": "200"},
+    ]
+    for params in unsupported_params:
+        response = await ccn_api_client.get(
+            MESSAGES_URI, params={"msgStatuses": "forgotten", **params}
+        )
+        assert response.status == 400, (params, await response.text())
+
+
+@pytest.mark.asyncio
+async def test_list_forgotten_messages_date_filters_use_forgotten_at(
+    fixture_forgotten_messages, ccn_api_client
+):
+    # Window covers the credit and hold stores only; the legacy NULL row is
+    # excluded by the date filter, the POST row falls after the window.
+    response = await ccn_api_client.get(
+        MESSAGES_URI,
+        params={
+            "msgStatuses": "forgotten",
+            "startDate": str(FORGOTTEN_AT_CREDIT),
+            "endDate": str(FORGOTTEN_AT_POST),
+        },
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert [msg["item_hash"] for msg in data["messages"]] == [
+        STORE_HOLD_HASH,
+        STORE_CREDIT_HASH,
+    ]
+
+    # The window does not match the original message times (1652786100-400):
+    # filtering on that range returns nothing, proving forgotten_at is used.
+    response = await ccn_api_client.get(
+        MESSAGES_URI,
+        params={
+            "msgStatuses": "forgotten",
+            "startDate": "1652786000",
+            "endDate": "1652786450",
+        },
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert data["messages"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_forgotten_messages_pagination(
+    fixture_forgotten_messages, ccn_api_client
+):
+    response = await ccn_api_client.get(
+        MESSAGES_URI,
+        params={"msgStatuses": "forgotten", "pagination": "2", "page": "2"},
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    assert data["pagination_total"] == 4
+    assert data["pagination_page"] == 2
+    assert [msg["item_hash"] for msg in data["messages"]] == [
+        STORE_CREDIT_HASH,
+        LEGACY_STORE_HASH,
+    ]

--- a/tests/api/test_list_removed_messages.py
+++ b/tests/api/test_list_removed_messages.py
@@ -1,0 +1,399 @@
+import datetime as dt
+
+import pytest
+from aleph_message.models import Chain, ItemType, MessageType
+
+from aleph.db.models.messages import MessageDb, MessageStatusDb, RemovedMessageDb
+from aleph.toolkit.timestamp import timestamp_to_datetime
+from aleph.types.channel import Channel
+from aleph.types.db_session import DbSessionFactory
+from aleph.types.message_status import MessageStatus
+
+MESSAGES_URI = "/api/v0/messages.json"
+MESSAGE_URI = "/api/v0/messages/{}"
+
+OWNER_A = "0x8B8Ff2a2AC5d3b2Db4c1E7B1c1E7B1c1E7B1c1E7"
+OWNER_B = "0x02c2A8B8Ff2a2AC5d3b2Db4c1E7B1c1E7B1c1E7B"
+SENDER_A = "0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106"
+SENDER_B = "0xB68B9D4f3771c246233823ed1D3Add451055F9Ef"
+
+STORE_CREDIT_HASH = "aaaa111111111111111111111111111111111111111111111111111111111111"
+STORE_HOLD_HASH = "bbbb111111111111111111111111111111111111111111111111111111111111"
+POST_HASH = "cccc111111111111111111111111111111111111111111111111111111111111"
+LEGACY_STORE_HASH = "dddd111111111111111111111111111111111111111111111111111111111111"
+
+REMOVED_AT_CREDIT = 1652786500.0
+REMOVED_AT_HOLD = 1652787000.0
+REMOVED_AT_POST = 1652787500.0
+
+
+def _make_removed_message(
+    item_hash: str,
+    message_type: MessageType,
+    sender: str,
+    owner: str,
+    channel: str,
+    time: float,
+    payment_type: str = "",
+) -> tuple:
+    content = {"address": owner, "time": time}
+    if message_type == MessageType.store:
+        content.update(
+            {
+                "item_hash": item_hash[::-1],
+                "item_type": ItemType.storage.value,
+            }
+        )
+        if payment_type:
+            content["payment"] = {"type": payment_type}
+    else:
+        content.update({"type": "test", "content": {"body": "test"}})
+
+    message = MessageDb(
+        item_hash=item_hash,
+        sender=sender,
+        chain=Chain.ETH,
+        type=message_type,
+        time=timestamp_to_datetime(time),
+        item_type=ItemType.inline,
+        signature=f"sig-{item_hash[:4]}",
+        size=1000,
+        channel=Channel(channel),
+        content=content,
+        status_value=MessageStatus.REMOVED,
+    )
+    status = MessageStatusDb(
+        item_hash=item_hash,
+        status=MessageStatus.REMOVED,
+        reception_time=dt.datetime(2022, 1, 1, tzinfo=dt.timezone.utc),
+    )
+    return message, status
+
+
+@pytest.fixture
+def fixture_removed_messages(session_factory: DbSessionFactory):
+    rows = [
+        *_make_removed_message(
+            STORE_CREDIT_HASH,
+            MessageType.store,
+            sender=SENDER_A,
+            owner=OWNER_A,
+            channel="TEST",
+            time=1652786100,
+            payment_type="credit",
+        ),
+        RemovedMessageDb(
+            item_hash=STORE_CREDIT_HASH,
+            size=4 * 1024 * 1024,
+            removed_at=timestamp_to_datetime(REMOVED_AT_CREDIT),
+        ),
+        *_make_removed_message(
+            STORE_HOLD_HASH,
+            MessageType.store,
+            sender=SENDER_B,
+            owner=OWNER_B,
+            channel="TEST",
+            time=1652786200,
+            payment_type="hold",
+        ),
+        RemovedMessageDb(
+            item_hash=STORE_HOLD_HASH,
+            size=10 * 1024 * 1024,
+            removed_at=timestamp_to_datetime(REMOVED_AT_HOLD),
+        ),
+        *_make_removed_message(
+            POST_HASH,
+            MessageType.post,
+            sender=SENDER_A,
+            owner=OWNER_A,
+            channel="OTHER",
+            time=1652786300,
+        ),
+        RemovedMessageDb(
+            item_hash=POST_HASH,
+            size=None,
+            removed_at=timestamp_to_datetime(REMOVED_AT_POST),
+        ),
+        # Legacy row: removed before the removal record existed
+        *_make_removed_message(
+            LEGACY_STORE_HASH,
+            MessageType.store,
+            sender=SENDER_B,
+            owner=OWNER_B,
+            channel="TEST",
+            time=1652786400,
+        ),
+    ]
+
+    with session_factory() as session:
+        for row in rows:
+            session.add(row)
+        session.commit()
+
+    return rows
+
+
+@pytest.mark.asyncio
+async def test_list_removed_messages(fixture_removed_messages, ccn_api_client):
+    response = await ccn_api_client.get(MESSAGES_URI, params={"msgStatuses": "removed"})
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    messages = data["messages"]
+    assert data["pagination_total"] == 4
+    # Sorted by removed_at DESC, legacy NULL rows last
+    assert [msg["item_hash"] for msg in messages] == [
+        POST_HASH,
+        STORE_HOLD_HASH,
+        STORE_CREDIT_HASH,
+        LEGACY_STORE_HASH,
+    ]
+
+    credit_store = messages[2]
+    assert credit_store["status"] == "removed"
+    assert credit_store["type"] == "STORE"
+    assert credit_store["chain"] == "ETH"
+    assert credit_store["sender"] == SENDER_A
+    assert credit_store["item_type"] == "inline"
+    assert credit_store["time"] == 1652786100.0
+    assert credit_store["content"]["address"] == OWNER_A
+    # size is the file-size snapshot taken at removal
+    assert credit_store["size"] == 4 * 1024 * 1024
+    assert credit_store["removed_at"] == REMOVED_AT_CREDIT
+
+    legacy_store = messages[3]
+    assert legacy_store["size"] is None
+    assert legacy_store["removed_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_removed_messages_ascending(
+    fixture_removed_messages, ccn_api_client
+):
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "removed", "sortOrder": "1"}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    # Ascending removed_at, legacy NULL rows still last
+    assert [msg["item_hash"] for msg in data["messages"]] == [
+        STORE_CREDIT_HASH,
+        STORE_HOLD_HASH,
+        POST_HASH,
+        LEGACY_STORE_HASH,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_removed_messages_rejects_mixed_statuses(
+    fixture_removed_messages, ccn_api_client
+):
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "removed,processed"}
+    )
+    assert response.status == 400, await response.text()
+
+    # forgotten + removed cannot be combined either
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "removed,forgotten"}
+    )
+    assert response.status == 400, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_list_removed_messages_rejects_cursor(
+    fixture_removed_messages, ccn_api_client
+):
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "removed", "cursor": "some-cursor"}
+    )
+    assert response.status == 400, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_list_removed_messages_rejects_unsupported_filters(
+    fixture_removed_messages, ccn_api_client
+):
+    """Filters the removed query cannot narrow return 400."""
+    unsupported_params = [
+        {"refs": "some-ref"},
+        {"contentTypes": "file"},
+        {"contentHashes": STORE_CREDIT_HASH},
+        {"contentKeys": STORE_CREDIT_HASH},
+        {"tags": "mainnet"},
+        {"startBlock": "100"},
+        {"endBlock": "200"},
+    ]
+    for params in unsupported_params:
+        response = await ccn_api_client.get(
+            MESSAGES_URI, params={"msgStatuses": "removed", **params}
+        )
+        assert response.status == 400, (params, await response.text())
+
+
+@pytest.mark.asyncio
+async def test_list_removed_messages_filters(fixture_removed_messages, ccn_api_client):
+    # msgTypes
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "removed", "msgTypes": "STORE"}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert {msg["item_hash"] for msg in data["messages"]} == {
+        STORE_CREDIT_HASH,
+        STORE_HOLD_HASH,
+        LEGACY_STORE_HASH,
+    }
+
+    # owners
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "removed", "owners": OWNER_B}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert {msg["item_hash"] for msg in data["messages"]} == {
+        STORE_HOLD_HASH,
+        LEGACY_STORE_HASH,
+    }
+
+    # addresses (sender)
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "removed", "addresses": SENDER_A}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert {msg["item_hash"] for msg in data["messages"]} == {
+        STORE_CREDIT_HASH,
+        POST_HASH,
+    }
+
+    # channels
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "removed", "channels": "OTHER"}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert [msg["item_hash"] for msg in data["messages"]] == [POST_HASH]
+
+    # hashes
+    response = await ccn_api_client.get(
+        MESSAGES_URI,
+        params={"msgStatuses": "removed", "hashes": STORE_CREDIT_HASH},
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert [msg["item_hash"] for msg in data["messages"]] == [STORE_CREDIT_HASH]
+
+    # paymentTypes: absence of a payment field means hold (billing
+    # semantics), so NULL-payment rows match paymentTypes=hold
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "removed", "paymentTypes": "credit"}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert [msg["item_hash"] for msg in data["messages"]] == [STORE_CREDIT_HASH]
+
+    response = await ccn_api_client.get(
+        MESSAGES_URI, params={"msgStatuses": "removed", "paymentTypes": "hold"}
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert {msg["item_hash"] for msg in data["messages"]} == {
+        STORE_HOLD_HASH,
+        POST_HASH,
+        LEGACY_STORE_HASH,
+    }
+
+    # combined with msgTypes=STORE: the implicit-hold legacy STORE matches
+    response = await ccn_api_client.get(
+        MESSAGES_URI,
+        params={
+            "msgStatuses": "removed",
+            "paymentTypes": "hold",
+            "msgTypes": "STORE",
+        },
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert {msg["item_hash"] for msg in data["messages"]} == {
+        STORE_HOLD_HASH,
+        LEGACY_STORE_HASH,
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_removed_messages_date_filters_use_removed_at(
+    fixture_removed_messages, ccn_api_client
+):
+    # Window covers the credit and hold stores only; the legacy row without a
+    # removal record is excluded, the POST row falls after the window.
+    response = await ccn_api_client.get(
+        MESSAGES_URI,
+        params={
+            "msgStatuses": "removed",
+            "startDate": str(REMOVED_AT_CREDIT),
+            "endDate": str(REMOVED_AT_POST),
+        },
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert [msg["item_hash"] for msg in data["messages"]] == [
+        STORE_HOLD_HASH,
+        STORE_CREDIT_HASH,
+    ]
+
+    # The window matches the original message times (1652786100-400) but no
+    # removed_at values: nothing is returned, proving removed_at is used.
+    response = await ccn_api_client.get(
+        MESSAGES_URI,
+        params={
+            "msgStatuses": "removed",
+            "startDate": "1652786000",
+            "endDate": "1652786450",
+        },
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+    assert data["messages"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_removed_messages_pagination(
+    fixture_removed_messages, ccn_api_client
+):
+    response = await ccn_api_client.get(
+        MESSAGES_URI,
+        params={"msgStatuses": "removed", "pagination": "2", "page": "2"},
+    )
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    assert data["pagination_total"] == 4
+    assert data["pagination_page"] == 2
+    assert [msg["item_hash"] for msg in data["messages"]] == [
+        STORE_CREDIT_HASH,
+        LEGACY_STORE_HASH,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_removed_message_status(fixture_removed_messages, ccn_api_client):
+    """GET /messages/{hash} exposes the removal record on REMOVED messages."""
+    response = await ccn_api_client.get(MESSAGE_URI.format(STORE_CREDIT_HASH))
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    assert data["status"] == "removed"
+    assert data["removed_at"] == REMOVED_AT_CREDIT
+    assert data["size"] == 4 * 1024 * 1024
+    assert data["message"]["item_hash"] == STORE_CREDIT_HASH
+
+    # Legacy removal: record fields are null
+    response = await ccn_api_client.get(MESSAGE_URI.format(LEGACY_STORE_HASH))
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    assert data["status"] == "removed"
+    assert data["removed_at"] is None
+    assert data["size"] is None

--- a/tests/api/test_list_removed_messages.py
+++ b/tests/api/test_list_removed_messages.py
@@ -1,9 +1,10 @@
 import datetime as dt
+from typing import Optional
 
 import pytest
 from aleph_message.models import Chain, ItemType, MessageType
 
-from aleph.db.models.messages import MessageDb, MessageStatusDb, RemovedMessageDb
+from aleph.db.models.messages import MessageStatusDb, RemovedMessageDb
 from aleph.toolkit.timestamp import timestamp_to_datetime
 from aleph.types.channel import Channel
 from aleph.types.db_session import DbSessionFactory
@@ -21,59 +22,52 @@ STORE_CREDIT_HASH = "aaaa1111111111111111111111111111111111111111111111111111111
 STORE_HOLD_HASH = "bbbb111111111111111111111111111111111111111111111111111111111111"
 POST_HASH = "cccc111111111111111111111111111111111111111111111111111111111111"
 LEGACY_STORE_HASH = "dddd111111111111111111111111111111111111111111111111111111111111"
+REMOVING_STORE_HASH = "eeee111111111111111111111111111111111111111111111111111111111111"
 
 REMOVED_AT_CREDIT = 1652786500.0
 REMOVED_AT_HOLD = 1652787000.0
 REMOVED_AT_POST = 1652787500.0
 
 
-def _make_removed_message(
+def _removed_snapshot(
     item_hash: str,
     message_type: MessageType,
     sender: str,
     owner: str,
     channel: str,
     time: float,
-    payment_type: str = "",
+    payment_type: str,
+    size: Optional[int],
+    removed_at: Optional[float],
 ) -> tuple:
-    content = {"address": owner, "time": time}
-    if message_type == MessageType.store:
-        content.update(
-            {
-                "item_hash": item_hash[::-1],
-                "item_type": ItemType.storage.value,
-            }
-        )
-        if payment_type:
-            content["payment"] = {"type": payment_type}
-    else:
-        content.update({"type": "test", "content": {"body": "test"}})
-
-    message = MessageDb(
+    snapshot = RemovedMessageDb(
         item_hash=item_hash,
-        sender=sender,
-        chain=Chain.ETH,
         type=message_type,
-        time=timestamp_to_datetime(time),
-        item_type=ItemType.inline,
+        chain=Chain.ETH,
+        sender=sender,
         signature=f"sig-{item_hash[:4]}",
-        size=1000,
+        item_type=ItemType.inline,
+        time=timestamp_to_datetime(time),
         channel=Channel(channel),
-        content=content,
-        status_value=MessageStatus.REMOVED,
+        owner=owner,
+        payment_type=payment_type,
+        size=size,
+        removed_at=(
+            timestamp_to_datetime(removed_at) if removed_at is not None else None
+        ),
     )
     status = MessageStatusDb(
         item_hash=item_hash,
         status=MessageStatus.REMOVED,
         reception_time=dt.datetime(2022, 1, 1, tzinfo=dt.timezone.utc),
     )
-    return message, status
+    return snapshot, status
 
 
 @pytest.fixture
 def fixture_removed_messages(session_factory: DbSessionFactory):
     rows = [
-        *_make_removed_message(
+        *_removed_snapshot(
             STORE_CREDIT_HASH,
             MessageType.store,
             sender=SENDER_A,
@@ -81,13 +75,10 @@ def fixture_removed_messages(session_factory: DbSessionFactory):
             channel="TEST",
             time=1652786100,
             payment_type="credit",
-        ),
-        RemovedMessageDb(
-            item_hash=STORE_CREDIT_HASH,
             size=4 * 1024 * 1024,
-            removed_at=timestamp_to_datetime(REMOVED_AT_CREDIT),
+            removed_at=REMOVED_AT_CREDIT,
         ),
-        *_make_removed_message(
+        *_removed_snapshot(
             STORE_HOLD_HASH,
             MessageType.store,
             sender=SENDER_B,
@@ -95,33 +86,48 @@ def fixture_removed_messages(session_factory: DbSessionFactory):
             channel="TEST",
             time=1652786200,
             payment_type="hold",
-        ),
-        RemovedMessageDb(
-            item_hash=STORE_HOLD_HASH,
             size=10 * 1024 * 1024,
-            removed_at=timestamp_to_datetime(REMOVED_AT_HOLD),
+            removed_at=REMOVED_AT_HOLD,
         ),
-        *_make_removed_message(
+        *_removed_snapshot(
             POST_HASH,
             MessageType.post,
             sender=SENDER_A,
             owner=OWNER_A,
             channel="OTHER",
             time=1652786300,
-        ),
-        RemovedMessageDb(
-            item_hash=POST_HASH,
+            payment_type="hold",
             size=None,
-            removed_at=timestamp_to_datetime(REMOVED_AT_POST),
+            removed_at=REMOVED_AT_POST,
         ),
-        # Legacy row: removed before the removal record existed
-        *_make_removed_message(
-            LEGACY_STORE_HASH,
-            MessageType.store,
+        # Legacy row: moved by migration 0063 with an unknown removal time
+        # and NULL payment_type (pre-coalescing removal)
+        RemovedMessageDb(
+            item_hash=LEGACY_STORE_HASH,
+            type=MessageType.store,
+            chain=Chain.ETH,
             sender=SENDER_B,
+            signature="sig-dddd",
+            item_type=ItemType.inline,
+            time=timestamp_to_datetime(1652786400),
+            channel=Channel("TEST"),
             owner=OWNER_B,
-            channel="TEST",
-            time=1652786400,
+        ),
+        MessageStatusDb(
+            item_hash=LEGACY_STORE_HASH,
+            status=MessageStatus.REMOVED,
+            reception_time=dt.datetime(2022, 1, 1, tzinfo=dt.timezone.utc),
+        ),
+        # Phase-1 record of a message still REMOVING (size-only snapshot):
+        # must never appear in the removed listing.
+        RemovedMessageDb(
+            item_hash=REMOVING_STORE_HASH,
+            size=1024,
+        ),
+        MessageStatusDb(
+            item_hash=REMOVING_STORE_HASH,
+            status=MessageStatus.REMOVING,
+            reception_time=dt.datetime(2022, 1, 1, tzinfo=dt.timezone.utc),
         ),
     ]
 
@@ -140,6 +146,7 @@ async def test_list_removed_messages(fixture_removed_messages, ccn_api_client):
     data = await response.json()
 
     messages = data["messages"]
+    # The still-REMOVING phase-1 record is excluded
     assert data["pagination_total"] == 4
     # Sorted by removed_at DESC, legacy NULL rows last
     assert [msg["item_hash"] for msg in messages] == [
@@ -154,14 +161,21 @@ async def test_list_removed_messages(fixture_removed_messages, ccn_api_client):
     assert credit_store["type"] == "STORE"
     assert credit_store["chain"] == "ETH"
     assert credit_store["sender"] == SENDER_A
+    assert credit_store["signature"] == "sig-aaaa"
     assert credit_store["item_type"] == "inline"
     assert credit_store["time"] == 1652786100.0
-    assert credit_store["content"]["address"] == OWNER_A
-    # size is the file-size snapshot taken at removal
+    assert credit_store["channel"] == "TEST"
+    assert credit_store["owner"] == OWNER_A
+    assert credit_store["payment_type"] == "credit"
+    # size is the file-size snapshot taken while the message was alive
     assert credit_store["size"] == 4 * 1024 * 1024
     assert credit_store["removed_at"] == REMOVED_AT_CREDIT
+    # Skeletons carry no content (the messages row is deleted at removal)
+    assert "content" not in credit_store
+    assert "item_content" not in credit_store
 
     legacy_store = messages[3]
+    assert legacy_store["payment_type"] is None
     assert legacy_store["size"] is None
     assert legacy_store["removed_at"] is None
 
@@ -215,7 +229,7 @@ async def test_list_removed_messages_rejects_cursor(
 async def test_list_removed_messages_rejects_unsupported_filters(
     fixture_removed_messages, ccn_api_client
 ):
-    """Filters the removed query cannot narrow return 400."""
+    """Filters on data not preserved in removed_messages return 400."""
     unsupported_params = [
         {"refs": "some-ref"},
         {"contentTypes": "file"},
@@ -286,7 +300,7 @@ async def test_list_removed_messages_filters(fixture_removed_messages, ccn_api_c
     assert [msg["item_hash"] for msg in data["messages"]] == [STORE_CREDIT_HASH]
 
     # paymentTypes: absence of a payment field means hold (billing
-    # semantics), so NULL-payment rows match paymentTypes=hold
+    # semantics), so the legacy NULL-payment row matches paymentTypes=hold
     response = await ccn_api_client.get(
         MESSAGES_URI, params={"msgStatuses": "removed", "paymentTypes": "credit"}
     )
@@ -327,7 +341,7 @@ async def test_list_removed_messages_date_filters_use_removed_at(
     fixture_removed_messages, ccn_api_client
 ):
     # Window covers the credit and hold stores only; the legacy row without a
-    # removal record is excluded, the POST row falls after the window.
+    # removal time is excluded, the POST row falls after the window.
     response = await ccn_api_client.get(
         MESSAGES_URI,
         params={
@@ -379,7 +393,7 @@ async def test_list_removed_messages_pagination(
 
 @pytest.mark.asyncio
 async def test_get_removed_message_status(fixture_removed_messages, ccn_api_client):
-    """GET /messages/{hash} exposes the removal record on REMOVED messages."""
+    """GET /messages/{hash} rebuilds REMOVED messages from their snapshot."""
     response = await ccn_api_client.get(MESSAGE_URI.format(STORE_CREDIT_HASH))
     assert response.status == 200, await response.text()
     data = await response.json()
@@ -388,6 +402,11 @@ async def test_get_removed_message_status(fixture_removed_messages, ccn_api_clie
     assert data["removed_at"] == REMOVED_AT_CREDIT
     assert data["size"] == 4 * 1024 * 1024
     assert data["message"]["item_hash"] == STORE_CREDIT_HASH
+    assert data["message"]["owner"] == OWNER_A
+    assert data["message"]["payment_type"] == "credit"
+    assert data["message"]["time"] == 1652786100.0
+    # The messages row is gone: skeletons carry no content
+    assert "content" not in data["message"]
 
     # Legacy removal: record fields are null
     response = await ccn_api_client.get(MESSAGE_URI.format(LEGACY_STORE_HASH))

--- a/tests/api/test_removed_price.py
+++ b/tests/api/test_removed_price.py
@@ -1,0 +1,211 @@
+import datetime as dt
+
+import pytest
+from aleph_message.models import Chain, ItemHash, ItemType, MessageType
+from aleph_message.models.execution.base import Payment, PaymentType
+
+from aleph.db.models.files import StoredFileDb
+from aleph.db.models.messages import MessageDb, MessageStatusDb, RemovedMessageDb
+from aleph.schemas.cost_estimation_messages import CostEstimationStoreContent
+from aleph.services.cost import get_total_and_detailed_costs
+from aleph.toolkit.constants import MIN_STORE_COST_MIB
+from aleph.toolkit.timestamp import timestamp_to_datetime
+from aleph.types.db_session import DbSessionFactory
+from aleph.types.files import FileType
+from aleph.types.message_status import MessageStatus
+
+PRICE_URI = "/api/v0/price/{}"
+
+OWNER = "0xB6B5358493AF8159B17506C5cC85df69193444BC"
+
+REMOVED_SNAPSHOT_STORE_HASH = (
+    "aaaa000000000000000000000000000000000000000000000000000000000000"
+)
+REMOVED_FALLBACK_STORE_HASH = (
+    "bbbb000000000000000000000000000000000000000000000000000000000000"
+)
+REMOVED_NO_SIZE_STORE_HASH = (
+    "cccc000000000000000000000000000000000000000000000000000000000000"
+)
+REMOVED_POST_HASH = "dddd000000000000000000000000000000000000000000000000000000000000"
+
+FALLBACK_FILE_HASH = "eeee000000000000000000000000000000000000000000000000000000000000"
+
+SMALL_FILE_SIZE = 1024 * 1024  # 1 MiB, well below the MIN_STORE_COST_MIB floor
+
+
+def _add_removed_message(
+    session,
+    item_hash: str,
+    message_type: MessageType,
+    file_hash: str,
+) -> None:
+    time = timestamp_to_datetime(1652786100)
+    content = {
+        "address": OWNER,
+        "time": 1652786100.0,
+    }
+    if message_type == MessageType.store:
+        content.update(
+            {
+                "item_hash": file_hash,
+                "item_type": ItemType.storage.value,
+                "payment": {"type": "credit"},
+            }
+        )
+    else:
+        content.update({"type": "test", "content": {"body": "test"}})
+
+    session.add(
+        MessageDb(
+            item_hash=item_hash,
+            sender=OWNER,
+            chain=Chain.ETH,
+            type=message_type,
+            time=time,
+            item_type=ItemType.inline,
+            signature="sig",
+            size=1000,
+            content=content,
+            status_value=MessageStatus.REMOVED,
+        )
+    )
+    session.add(
+        MessageStatusDb(
+            item_hash=item_hash,
+            status=MessageStatus.REMOVED,
+            reception_time=dt.datetime(2022, 1, 1, tzinfo=dt.timezone.utc),
+        )
+    )
+
+
+@pytest.fixture
+def fixture_removed_messages_for_pricing(session_factory: DbSessionFactory):
+    with session_factory() as session:
+        # STORE with a removed_messages size snapshot
+        _add_removed_message(
+            session,
+            REMOVED_SNAPSHOT_STORE_HASH,
+            MessageType.store,
+            file_hash="1111" * 16,
+        )
+        session.add(
+            RemovedMessageDb(
+                item_hash=REMOVED_SNAPSHOT_STORE_HASH,
+                size=SMALL_FILE_SIZE,
+                removed_at=timestamp_to_datetime(1652786500),
+            )
+        )
+
+        # STORE without snapshot, but the files row still exists (fallback)
+        _add_removed_message(
+            session,
+            REMOVED_FALLBACK_STORE_HASH,
+            MessageType.store,
+            file_hash=FALLBACK_FILE_HASH,
+        )
+        session.add(
+            StoredFileDb(
+                hash=FALLBACK_FILE_HASH, size=SMALL_FILE_SIZE, type=FileType.FILE
+            )
+        )
+
+        # STORE without snapshot and without files row: size unresolvable
+        _add_removed_message(
+            session,
+            REMOVED_NO_SIZE_STORE_HASH,
+            MessageType.store,
+            file_hash="2222" * 16,
+        )
+
+        # Non-STORE removed message
+        _add_removed_message(session, REMOVED_POST_HASH, MessageType.post, file_hash="")
+
+        session.commit()
+
+
+def _expected_floor_cost(session_factory: DbSessionFactory, item_hash: str) -> float:
+    with session_factory() as session:
+        expected_cost, _ = get_total_and_detailed_costs(
+            session=session,
+            content=CostEstimationStoreContent(
+                address=OWNER,
+                time=1652786100.0,
+                item_type=ItemType.storage,
+                item_hash=ItemHash(item_hash),
+                payment=Payment(type=PaymentType.credit),
+                estimated_size_mib=MIN_STORE_COST_MIB,
+            ),
+            item_hash=item_hash,
+        )
+    return float(expected_cost)
+
+
+@pytest.mark.asyncio
+async def test_message_price_removed_store_with_snapshot(
+    ccn_api_client,
+    session_factory: DbSessionFactory,
+    fixture_removed_messages_for_pricing,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """
+    A removed STORE with a size snapshot is priced live, with the
+    MIN_STORE_COST_MIB floor applied.
+    """
+    response = await ccn_api_client.get(PRICE_URI.format(REMOVED_SNAPSHOT_STORE_HASH))
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    assert data["payment_type"] == "credit"
+    assert data["charged_address"] == OWNER
+    assert data["required_tokens"] == _expected_floor_cost(
+        session_factory, REMOVED_SNAPSHOT_STORE_HASH
+    )
+
+
+@pytest.mark.asyncio
+async def test_message_price_removed_store_files_fallback(
+    ccn_api_client,
+    session_factory: DbSessionFactory,
+    fixture_removed_messages_for_pricing,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """
+    A removed STORE without a snapshot is priced from the still-existing
+    files row.
+    """
+    response = await ccn_api_client.get(PRICE_URI.format(REMOVED_FALLBACK_STORE_HASH))
+    assert response.status == 200, await response.text()
+    data = await response.json()
+
+    assert data["payment_type"] == "credit"
+    assert data["charged_address"] == OWNER
+    assert data["required_tokens"] == _expected_floor_cost(
+        session_factory, REMOVED_FALLBACK_STORE_HASH
+    )
+
+
+@pytest.mark.asyncio
+async def test_message_price_removed_store_without_size(
+    ccn_api_client,
+    fixture_removed_messages_for_pricing,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """A removed STORE whose size cannot be resolved keeps returning 410."""
+    response = await ccn_api_client.get(PRICE_URI.format(REMOVED_NO_SIZE_STORE_HASH))
+    assert response.status == 410, await response.text()
+
+
+@pytest.mark.asyncio
+async def test_message_price_removed_non_store(
+    ccn_api_client,
+    fixture_removed_messages_for_pricing,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """Removed non-STORE messages keep returning 410 Gone."""
+    response = await ccn_api_client.get(PRICE_URI.format(REMOVED_POST_HASH))
+    assert response.status == 410, await response.text()

--- a/tests/api/test_removed_price.py
+++ b/tests/api/test_removed_price.py
@@ -1,17 +1,16 @@
 import datetime as dt
+from typing import Optional
 
 import pytest
 from aleph_message.models import Chain, ItemHash, ItemType, MessageType
 from aleph_message.models.execution.base import Payment, PaymentType
 
-from aleph.db.models.files import StoredFileDb
-from aleph.db.models.messages import MessageDb, MessageStatusDb, RemovedMessageDb
+from aleph.db.models.messages import MessageStatusDb, RemovedMessageDb
 from aleph.schemas.cost_estimation_messages import CostEstimationStoreContent
 from aleph.services.cost import get_total_and_detailed_costs
 from aleph.toolkit.constants import MIN_STORE_COST_MIB
 from aleph.toolkit.timestamp import timestamp_to_datetime
 from aleph.types.db_session import DbSessionFactory
-from aleph.types.files import FileType
 from aleph.types.message_status import MessageStatus
 
 PRICE_URI = "/api/v0/price/{}"
@@ -21,7 +20,7 @@ OWNER = "0xB6B5358493AF8159B17506C5cC85df69193444BC"
 REMOVED_SNAPSHOT_STORE_HASH = (
     "aaaa000000000000000000000000000000000000000000000000000000000000"
 )
-REMOVED_FALLBACK_STORE_HASH = (
+REMOVED_NULL_PAYMENT_STORE_HASH = (
     "bbbb000000000000000000000000000000000000000000000000000000000000"
 )
 REMOVED_NO_SIZE_STORE_HASH = (
@@ -29,45 +28,29 @@ REMOVED_NO_SIZE_STORE_HASH = (
 )
 REMOVED_POST_HASH = "dddd000000000000000000000000000000000000000000000000000000000000"
 
-FALLBACK_FILE_HASH = "eeee000000000000000000000000000000000000000000000000000000000000"
-
 SMALL_FILE_SIZE = 1024 * 1024  # 1 MiB, well below the MIN_STORE_COST_MIB floor
 
 
-def _add_removed_message(
+def _add_removed_snapshot(
     session,
     item_hash: str,
     message_type: MessageType,
-    file_hash: str,
+    payment_type: Optional[str],
+    size: Optional[int],
 ) -> None:
-    time = timestamp_to_datetime(1652786100)
-    content = {
-        "address": OWNER,
-        "time": 1652786100.0,
-    }
-    if message_type == MessageType.store:
-        content.update(
-            {
-                "item_hash": file_hash,
-                "item_type": ItemType.storage.value,
-                "payment": {"type": "credit"},
-            }
-        )
-    else:
-        content.update({"type": "test", "content": {"body": "test"}})
-
     session.add(
-        MessageDb(
+        RemovedMessageDb(
             item_hash=item_hash,
-            sender=OWNER,
-            chain=Chain.ETH,
             type=message_type,
-            time=time,
-            item_type=ItemType.inline,
+            chain=Chain.ETH,
+            sender=OWNER,
             signature="sig",
-            size=1000,
-            content=content,
-            status_value=MessageStatus.REMOVED,
+            item_type=ItemType.inline,
+            time=timestamp_to_datetime(1652786100),
+            owner=OWNER,
+            payment_type=payment_type,
+            size=size,
+            removed_at=timestamp_to_datetime(1652786500),
         )
     )
     session.add(
@@ -82,44 +65,41 @@ def _add_removed_message(
 @pytest.fixture
 def fixture_removed_messages_for_pricing(session_factory: DbSessionFactory):
     with session_factory() as session:
-        # STORE with a removed_messages size snapshot
-        _add_removed_message(
+        # STORE snapshot with full billing metadata
+        _add_removed_snapshot(
             session,
             REMOVED_SNAPSHOT_STORE_HASH,
             MessageType.store,
-            file_hash="1111" * 16,
-        )
-        session.add(
-            RemovedMessageDb(
-                item_hash=REMOVED_SNAPSHOT_STORE_HASH,
-                size=SMALL_FILE_SIZE,
-                removed_at=timestamp_to_datetime(1652786500),
-            )
+            payment_type="credit",
+            size=SMALL_FILE_SIZE,
         )
 
-        # STORE without snapshot, but the files row still exists (fallback)
-        _add_removed_message(
+        # Legacy row moved before payment_type coalescing: NULL means hold
+        _add_removed_snapshot(
             session,
-            REMOVED_FALLBACK_STORE_HASH,
+            REMOVED_NULL_PAYMENT_STORE_HASH,
             MessageType.store,
-            file_hash=FALLBACK_FILE_HASH,
-        )
-        session.add(
-            StoredFileDb(
-                hash=FALLBACK_FILE_HASH, size=SMALL_FILE_SIZE, type=FileType.FILE
-            )
+            payment_type=None,
+            size=SMALL_FILE_SIZE,
         )
 
-        # STORE without snapshot and without files row: size unresolvable
-        _add_removed_message(
+        # STORE whose size was never snapshotted: unresolvable
+        _add_removed_snapshot(
             session,
             REMOVED_NO_SIZE_STORE_HASH,
             MessageType.store,
-            file_hash="2222" * 16,
+            payment_type="credit",
+            size=None,
         )
 
         # Non-STORE removed message
-        _add_removed_message(session, REMOVED_POST_HASH, MessageType.post, file_hash="")
+        _add_removed_snapshot(
+            session,
+            REMOVED_POST_HASH,
+            MessageType.post,
+            payment_type="hold",
+            size=None,
+        )
 
         session.commit()
 
@@ -150,8 +130,8 @@ async def test_message_price_removed_store_with_snapshot(
     fixture_settings_aggregate_in_db,
 ):
     """
-    A removed STORE with a size snapshot is priced live, with the
-    MIN_STORE_COST_MIB floor applied.
+    A removed STORE snapshot is priced live, with the MIN_STORE_COST_MIB
+    floor applied.
     """
     response = await ccn_api_client.get(PRICE_URI.format(REMOVED_SNAPSHOT_STORE_HASH))
     assert response.status == 200, await response.text()
@@ -165,26 +145,25 @@ async def test_message_price_removed_store_with_snapshot(
 
 
 @pytest.mark.asyncio
-async def test_message_price_removed_store_files_fallback(
+async def test_message_price_removed_store_null_payment_defaults_to_hold(
     ccn_api_client,
-    session_factory: DbSessionFactory,
     fixture_removed_messages_for_pricing,
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
 ):
     """
-    A removed STORE without a snapshot is priced from the still-existing
-    files row.
+    Legacy snapshots with NULL payment_type are priced as hold, matching the
+    live pricing default (absence of a payment field means hold).
     """
-    response = await ccn_api_client.get(PRICE_URI.format(REMOVED_FALLBACK_STORE_HASH))
+    response = await ccn_api_client.get(
+        PRICE_URI.format(REMOVED_NULL_PAYMENT_STORE_HASH)
+    )
     assert response.status == 200, await response.text()
     data = await response.json()
 
-    assert data["payment_type"] == "credit"
+    assert data["payment_type"] == "hold"
     assert data["charged_address"] == OWNER
-    assert data["required_tokens"] == _expected_floor_cost(
-        session_factory, REMOVED_FALLBACK_STORE_HASH
-    )
+    assert data["required_tokens"] > 0
 
 
 @pytest.mark.asyncio
@@ -194,7 +173,7 @@ async def test_message_price_removed_store_without_size(
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
 ):
-    """A removed STORE whose size cannot be resolved keeps returning 410."""
+    """A removed STORE whose size was never snapshotted returns 410."""
     response = await ccn_api_client.get(PRICE_URI.format(REMOVED_NO_SIZE_STORE_HASH))
     assert response.status == 410, await response.text()
 

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -124,6 +124,49 @@ def test_update_credit_balances_expense(session_factory: DbSessionFactory):
         assert expense_record.credit_index == 0
         assert expense_record.expiration_date is None
         assert expense_record.message_timestamp == message_timestamp
+        # v1 entries leave the v2 aggregate columns NULL
+        assert expense_record.expense_count is None
+        assert expense_record.expense_size_mib is None
+
+
+def test_update_credit_balances_expense_v2_aggregated(
+    session_factory: DbSessionFactory,
+):
+    """v2 aggregated expense entries persist count and size."""
+    credits_list = [
+        {
+            "address": "0x456",
+            "amount": 500,
+            "ref": "storage",
+            "count": 12,
+            "size": Decimal("2048.5"),
+            "time": 43200.0,  # total billed seconds; not persisted
+        }
+    ]
+
+    message_timestamp = dt.datetime(2026, 3, 2, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        update_credit_balances_expense(
+            session=session,
+            credits_list=credits_list,
+            message_hash="expense_msg_v2_123",
+            message_timestamp=message_timestamp,
+        )
+        session.commit()
+
+        expense_record = (
+            session.query(AlephCreditHistoryDb)
+            .filter_by(address="0x456", credit_ref="expense_msg_v2_123")
+            .first()
+        )
+
+        assert expense_record is not None
+        assert expense_record.amount == -500  # no multiplier after the cutoff
+        assert expense_record.origin_ref == "storage"
+        assert expense_record.payment_method == "credit_expense"
+        assert expense_record.expense_count == 12
+        assert expense_record.expense_size_mib == Decimal("2048.5")
 
 
 def test_update_credit_balances_expense_with_new_fields(

--- a/tests/db/test_messages.py
+++ b/tests/db/test_messages.py
@@ -28,6 +28,7 @@ from aleph.db.models import (
     StoredFileDb,
     message_confirmations,
 )
+from aleph.db.models.messages import RemovedMessageDb
 from aleph.toolkit.timestamp import timestamp_to_datetime
 from aleph.types.chain_sync import ChainSyncProtocol
 from aleph.types.channel import Channel
@@ -735,3 +736,107 @@ async def test_migration_0061_column_additions_are_rerunnable(
             )
         )
         session.commit()
+
+
+@pytest.mark.asyncio
+async def test_migration_0063_moves_removed_messages(
+    session_factory: DbSessionFactory,
+):
+    """
+    Check the semantics of the 0063 migration data move: existing REMOVED
+    messages are copied into removed_messages (size best-effort from a
+    still-existing files row, removed_at unknown -> NULL) and their messages
+    rows are deleted.
+    """
+    removed_hash = "beefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef"
+    file_hash = "feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed"
+    file_size = 7 * 1024 * 1024
+
+    with session_factory() as session:
+        session.add(
+            MessageDb(
+                item_hash=removed_hash,
+                sender="0x51A58800b26AA1451aaA803d1746687cB88E0500",
+                chain=Chain.ETH,
+                type=MessageType.store,
+                time=dt.datetime(2022, 1, 1, tzinfo=dt.timezone.utc),
+                item_type=ItemType.inline,
+                signature="sig",
+                size=1000,
+                content={
+                    "address": "0x51A58800b26AA1451aaA803d1746687cB88E0500",
+                    "time": 1640995200.0,
+                    "item_hash": file_hash,
+                    "item_type": "storage",
+                },
+                status_value=MessageStatus.REMOVED,
+            )
+        )
+        session.add(
+            MessageStatusDb(
+                item_hash=removed_hash,
+                status=MessageStatus.REMOVED,
+                reception_time=dt.datetime(2022, 1, 2, tzinfo=dt.timezone.utc),
+            )
+        )
+        session.add(StoredFileDb(hash=file_hash, size=file_size, type=FileType.FILE))
+        session.commit()
+
+        # Same statements as migration 0063
+        session.execute(
+            text(
+                """
+                INSERT INTO removed_messages (
+                    item_hash, type, chain, sender, signature, item_type, time,
+                    channel, owner, payment_type, size, removed_at
+                )
+                SELECT
+                    m.item_hash, m.type, m.chain, m.sender, m.signature,
+                    m.item_type, m.time, m.channel, m.owner,
+                    COALESCE(m.payment_type, 'hold'),
+                    f.size,
+                    NULL
+                FROM messages m
+                JOIN message_status ms ON ms.item_hash = m.item_hash
+                LEFT JOIN files f ON f.hash = m.content_item_hash
+                WHERE ms.status = 'removed'
+                ON CONFLICT (item_hash) DO UPDATE SET
+                    type = EXCLUDED.type,
+                    chain = EXCLUDED.chain,
+                    sender = EXCLUDED.sender,
+                    signature = EXCLUDED.signature,
+                    item_type = EXCLUDED.item_type,
+                    time = EXCLUDED.time,
+                    channel = EXCLUDED.channel,
+                    owner = EXCLUDED.owner,
+                    payment_type = EXCLUDED.payment_type,
+                    size = COALESCE(removed_messages.size, EXCLUDED.size)
+                """
+            )
+        )
+        session.execute(
+            text(
+                """
+                DELETE FROM messages m
+                USING message_status ms
+                WHERE ms.item_hash = m.item_hash
+                  AND ms.status = 'removed'
+                """
+            )
+        )
+        session.commit()
+
+        snapshot = session.get(RemovedMessageDb, removed_hash)
+        assert snapshot is not None
+        assert snapshot.type == MessageType.store
+        assert snapshot.sender == "0x51A58800b26AA1451aaA803d1746687cB88E0500"
+        # content.address is denormalized into messages.owner at insert time
+        assert snapshot.owner == "0x51A58800b26AA1451aaA803d1746687cB88E0500"
+        # No payment field: absence means hold
+        assert snapshot.payment_type == "hold"
+        # Size backfilled from the still-existing files row
+        assert snapshot.size == file_size
+        # Removal time unknown for legacy rows
+        assert snapshot.removed_at is None
+
+        assert session.get(MessageDb, removed_hash) is None

--- a/tests/db/test_messages.py
+++ b/tests/db/test_messages.py
@@ -1,5 +1,6 @@
 import datetime as dt
 from copy import copy
+from typing import Any, Dict
 
 import pytest
 import pytz
@@ -19,11 +20,19 @@ from aleph.db.accessors.messages import (
     make_message_upsert_query,
     message_exists,
 )
-from aleph.db.models import ChainTxDb, MessageDb, MessageStatusDb, message_confirmations
+from aleph.db.models import (
+    ChainTxDb,
+    ForgottenMessageDb,
+    MessageDb,
+    MessageStatusDb,
+    StoredFileDb,
+    message_confirmations,
+)
 from aleph.toolkit.timestamp import timestamp_to_datetime
 from aleph.types.chain_sync import ChainSyncProtocol
 from aleph.types.channel import Channel
 from aleph.types.db_session import DbSessionFactory
+from aleph.types.files import FileType
 from aleph.types.message_status import MessageStatus
 
 
@@ -419,12 +428,14 @@ async def test_forget_message(
     forget_message_hash = (
         "d06251c954d4c75476c749e80b8f2a4962d20282b28b3e237e30b0a76157df2d"
     )
+    forgotten_at = dt.datetime(2023, 5, 1, tzinfo=dt.timezone.utc)
 
     with session_factory() as session:
         forget_message(
             session=session,
             item_hash=fixture_message.item_hash,
             forget_message_hash=forget_message_hash,
+            forgotten_at=forgotten_at,
         )
         session.commit()
 
@@ -455,6 +466,14 @@ async def test_forget_message(
         assert forgotten_message.time == fixture_message.time
         assert forgotten_message.channel == fixture_message.channel
         assert forgotten_message.forgotten_by == [forget_message_hash]
+
+        # Billing metadata preserved at forget time
+        assert forgotten_message.owner == fixture_message.owner
+        # No payment field on the message: absence means hold
+        assert forgotten_message.payment_type == "hold"
+        # No file linked to this (aggregate) message
+        assert forgotten_message.size is None
+        assert forgotten_message.forgotten_at == forgotten_at
 
         # Now, add a hash to forgotten_by
         new_forget_message_hash = (
@@ -526,6 +545,7 @@ async def test_forget_message_with_confirmations(
             session=session,
             item_hash=fixture_message.item_hash,
             forget_message_hash=forget_message_hash,
+            forgotten_at=dt.datetime(2023, 5, 1, tzinfo=dt.timezone.utc),
         )
         session.commit()
 
@@ -591,3 +611,127 @@ async def test_payment_type_persisted_after_upsert(
         )
         assert fetched is not None
         assert fetched.payment_type == "credit"
+
+
+@pytest.mark.asyncio
+async def test_forget_store_credit_message_preserves_billing_metadata(
+    session_factory: DbSessionFactory,
+):
+    """Forgetting a credit-paid STORE preserves owner/payment_type/size/forgotten_at."""
+    message = make_validated_message_from_dict(STORE_CREDIT_MESSAGE)
+    store_content: Dict[str, Any] = STORE_CREDIT_MESSAGE["content"]  # type: ignore[assignment]
+    file_hash = store_content["item_hash"]
+    file_size = 5 * 1024 * 1024
+
+    with session_factory() as session:
+        session.execute(make_message_upsert_query(message))
+        session.add(
+            MessageStatusDb(
+                item_hash=message.item_hash,
+                status=MessageStatus.PROCESSED,
+                reception_time=message.time,
+            )
+        )
+        session.add(StoredFileDb(hash=file_hash, size=file_size, type=FileType.FILE))
+        session.commit()
+
+    forget_message_hash = (
+        "0223e74dbae53b45da6a443fa18fd2a25f88677c82ed2de93f17ab24f78f58cf"
+    )
+    forgotten_at = dt.datetime(2026, 2, 20, 12, 0, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        forget_message(
+            session=session,
+            item_hash=message.item_hash,
+            forget_message_hash=forget_message_hash,
+            forgotten_at=forgotten_at,
+        )
+        session.commit()
+
+        forgotten_message = get_forgotten_message(
+            session=session, item_hash=ItemHash(message.item_hash)
+        )
+        assert forgotten_message
+        assert forgotten_message.owner == store_content["address"]
+        assert forgotten_message.payment_type == "credit"
+        assert forgotten_message.size == file_size
+        assert forgotten_message.forgotten_at == forgotten_at
+
+
+@pytest.mark.asyncio
+async def test_migration_backfill_forgotten_at(
+    session_factory: DbSessionFactory, fixture_message: MessageDb
+):
+    """
+    Check the semantics of the 0061 migration backfill: forgotten_at is set
+    from the time of the first forgetting FORGET message still present in
+    the messages table.
+    """
+    forget_message_hash = fixture_message.item_hash
+    forgotten_hash = "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe"
+
+    with session_factory() as session:
+        # The FORGET message (any message with a known hash/time works here)
+        session.add(fixture_message)
+        # A legacy forgotten_messages row without forgotten_at
+        session.add(
+            ForgottenMessageDb(
+                item_hash=forgotten_hash,
+                type=MessageType.store,
+                chain=Chain.ETH,
+                sender="0x51A58800b26AA1451aaA803d1746687cB88E0500",
+                signature="sig",
+                item_type=ItemType.inline,
+                time=dt.datetime(2022, 1, 1, tzinfo=dt.timezone.utc),
+                channel=Channel("TEST"),
+                forgotten_by=[forget_message_hash],
+            )
+        )
+        session.commit()
+
+        # Same statement as migration 0061
+        session.execute(
+            text(
+                """
+                UPDATE forgotten_messages fm
+                SET forgotten_at = m.time
+                FROM messages m
+                WHERE m.item_hash = fm.forgotten_by[1]
+                  AND fm.forgotten_at IS NULL
+                """
+            )
+        )
+        session.commit()
+
+        forgotten_message = get_forgotten_message(
+            session=session, item_hash=forgotten_hash
+        )
+        assert forgotten_message
+        assert forgotten_message.forgotten_at == fixture_message.time
+
+
+@pytest.mark.asyncio
+async def test_migration_0061_column_additions_are_rerunnable(
+    session_factory: DbSessionFactory,
+):
+    """
+    Check the rerunnability of the 0061 migration column additions: the
+    CONCURRENT index step commits the ALTER TABLE statements before alembic
+    stamps the revision, so a rerun after an index failure re-executes them
+    against a table that already has the columns and must not error.
+    """
+    with session_factory() as session:
+        # Same statement as migration 0061, run against a schema where the
+        # columns already exist (the test schema is created from the models).
+        session.execute(
+            text(
+                """
+                ALTER TABLE forgotten_messages ADD COLUMN IF NOT EXISTS owner VARCHAR;
+                ALTER TABLE forgotten_messages ADD COLUMN IF NOT EXISTS payment_type VARCHAR;
+                ALTER TABLE forgotten_messages ADD COLUMN IF NOT EXISTS size BIGINT;
+                ALTER TABLE forgotten_messages ADD COLUMN IF NOT EXISTS forgotten_at TIMESTAMPTZ;
+                """
+            )
+        )
+        session.commit()

--- a/tests/jobs/test_balance_job.py
+++ b/tests/jobs/test_balance_job.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 import pytest
 import pytest_asyncio
-from aleph_message.models import Chain, ItemType, MessageType, PaymentType
+from aleph_message.models import Chain, ItemHash, ItemType, MessageType, PaymentType
 
 from aleph.db.accessors.messages import get_message_status
 from aleph.db.models.account_costs import AccountCostsDb
@@ -16,7 +16,7 @@ from aleph.db.models.files import (
     MessageFilePinDb,
     StoredFileDb,
 )
-from aleph.db.models.messages import MessageDb, MessageStatusDb
+from aleph.db.models.messages import MessageDb, MessageStatusDb, RemovedMessageDb
 from aleph.jobs.cron.balance_job import BalanceCronJob
 from aleph.toolkit.constants import (
     DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE,
@@ -282,11 +282,16 @@ async def fixture_message_for_recovery(session_factory, now, fixture_base_data):
         message, STORE_AND_PROGRAM_COST_CUTOFF_HEIGHT + 2000, now
     )
 
+    # Size snapshot taken when the message entered REMOVING
+    removed_message = RemovedMessageDb(item_hash=message_hash, size=30 * MiB)
+
     with session_factory() as session:
         session.add_all([message])
         session.commit()
 
-        session.add_all([wallet, file, file_pin, message_status, message_cost])
+        session.add_all(
+            [wallet, file, file_pin, message_status, message_cost, removed_message]
+        )
         session.commit()
 
     return {
@@ -332,6 +337,15 @@ async def test_balance_job_marks_messages_for_removal(
         assert (
             24.5 <= time_diff.total_seconds() / 3600 <= 25.5
         )  # Between 24.5 and 25.5 hours
+
+        # The file size must be snapshotted in removed_messages (two-phase
+        # removal record); removed_at stays NULL until the GC flips the status
+        removed_message = session.get(
+            RemovedMessageDb, fixture_message_for_removal["message_hash"]
+        )
+        assert removed_message is not None
+        assert removed_message.size == 30 * MiB
+        assert removed_message.removed_at is None
 
 
 @pytest.mark.asyncio
@@ -392,3 +406,51 @@ async def test_balance_job_recovers_messages_with_sufficient_balance(
         )
 
         assert len(grace_period_pins) == 0
+
+        # The removal record must be discarded on recovery
+        removed_message = session.get(
+            RemovedMessageDb, fixture_message_for_recovery["message_hash"]
+        )
+        assert removed_message is None
+
+
+@pytest.mark.asyncio
+async def test_balance_job_recover_keeps_removed_message(
+    session_factory, balance_job, now
+):
+    """
+    A recovery attempt racing with the garbage collector must not resurrect
+    a finalized removal: the REMOVING->PROCESSED flip does not happen (the
+    message is already REMOVED), so the denormalized status and the removal
+    record must survive.
+    """
+    message_hash = "feed5678" * 8
+    file_hash = "8765" * 16
+
+    message, file, _, _ = create_store_message(
+        message_hash, "0xtestaddress9", file_hash, now
+    )
+    message.status_value = MessageStatus.REMOVED
+    message_status = MessageStatusDb(
+        item_hash=message_hash,
+        status=MessageStatus.REMOVED,
+        reception_time=now,
+    )
+    removed_message = RemovedMessageDb(
+        item_hash=message_hash, size=30 * MiB, removed_at=now
+    )
+
+    with session_factory() as session:
+        session.add_all([message, file, message_status, removed_message])
+        session.commit()
+
+        await balance_job.recover_messages(session, [ItemHash(message_hash)])
+        session.commit()
+
+        fetched_message = session.get(MessageDb, message_hash)
+        assert fetched_message is not None
+        assert fetched_message.status_value == MessageStatus.REMOVED
+
+        fetched_removed_message = session.get(RemovedMessageDb, message_hash)
+        assert fetched_removed_message is not None
+        assert fetched_removed_message.removed_at == now

--- a/tests/jobs/test_balance_job.py
+++ b/tests/jobs/test_balance_job.py
@@ -421,16 +421,13 @@ async def test_balance_job_recover_keeps_removed_message(
     """
     A recovery attempt racing with the garbage collector must not resurrect
     a finalized removal: the REMOVING->PROCESSED flip does not happen (the
-    message is already REMOVED), so the denormalized status and the removal
-    record must survive.
+    message is already REMOVED and its messages row deleted), so the
+    removal record must survive and no messages row must reappear.
     """
     message_hash = "feed5678" * 8
-    file_hash = "8765" * 16
 
-    message, file, _, _ = create_store_message(
-        message_hash, "0xtestaddress9", file_hash, now
-    )
-    message.status_value = MessageStatus.REMOVED
+    # Finalized removal: message_status REMOVED, snapshot present, no
+    # messages row (deleted by the garbage collector).
     message_status = MessageStatusDb(
         item_hash=message_hash,
         status=MessageStatus.REMOVED,
@@ -441,15 +438,17 @@ async def test_balance_job_recover_keeps_removed_message(
     )
 
     with session_factory() as session:
-        session.add_all([message, file, message_status, removed_message])
+        session.add_all([message_status, removed_message])
         session.commit()
 
         await balance_job.recover_messages(session, [ItemHash(message_hash)])
         session.commit()
 
-        fetched_message = session.get(MessageDb, message_hash)
-        assert fetched_message is not None
-        assert fetched_message.status_value == MessageStatus.REMOVED
+        fetched_status = get_message_status(session=session, item_hash=message_hash)
+        assert fetched_status is not None
+        assert fetched_status.status == MessageStatus.REMOVED
+
+        assert session.get(MessageDb, message_hash) is None
 
         fetched_removed_message = session.get(RemovedMessageDb, message_hash)
         assert fetched_removed_message is not None

--- a/tests/jobs/test_check_removing_messages.py
+++ b/tests/jobs/test_check_removing_messages.py
@@ -218,14 +218,24 @@ async def test_check_and_update_removing_messages(
         assert legacy_status is not None
         assert legacy_status.status == MessageStatus.REMOVED
 
-        # The removal record of the removable message keeps its size snapshot
-        # and gets removed_at stamped
+        # The removal record of the removable message keeps its size
+        # snapshot, gets the billing metadata copied and removed_at stamped,
+        # and the messages row is deleted (forgotten-style)
         removed_message = get_removed_message(
             session=session, item_hash=fixture_removing_messages["removable_message"]
         )
         assert removed_message is not None
         assert removed_message.size == 1000
         assert removed_message.removed_at is not None
+        assert removed_message.type == MessageType.store
+        assert removed_message.sender == "0xsender1"
+        assert removed_message.time is not None
+        # No explicit payment field on the message: absence means hold
+        assert removed_message.payment_type == "hold"
+        assert (
+            session.get(MessageDb, fixture_removing_messages["removable_message"])
+            is None
+        )
 
         # The legacy message gets a removal record without size
         legacy_removed_message = get_removed_message(
@@ -234,16 +244,24 @@ async def test_check_and_update_removing_messages(
         assert legacy_removed_message is not None
         assert legacy_removed_message.size is None
         assert legacy_removed_message.removed_at is not None
+        assert legacy_removed_message.sender == "0xsender3"
+        assert (
+            session.get(MessageDb, fixture_removing_messages["legacy_message"]) is None
+        )
 
-        # The pinned message stays REMOVING: no removal time stamped
+        # The pinned message stays REMOVING: no removal record, row alive
         pinned_removed_message = get_removed_message(
             session=session, item_hash=fixture_removing_messages["pinned_message"]
         )
         assert pinned_removed_message is None
+        assert (
+            session.get(MessageDb, fixture_removing_messages["pinned_message"])
+            is not None
+        )
 
         # The concurrently recovered message must not reappear as removed:
-        # the guarded flip did not happen, so no phantom removal record and
-        # message_status stays PROCESSED
+        # the guarded flip did not happen, so no phantom removal record,
+        # message_status stays PROCESSED and the messages row survives
         recovered_status = get_message_status(
             session=session, item_hash=fixture_removing_messages["recovered_message"]
         )
@@ -254,3 +272,52 @@ async def test_check_and_update_removing_messages(
             session=session, item_hash=fixture_removing_messages["recovered_message"]
         )
         assert recovered_removed_message is None
+        assert (
+            session.get(MessageDb, fixture_removing_messages["recovered_message"])
+            is not None
+        )
+
+
+@pytest.mark.asyncio
+async def test_check_removing_messages_rolls_back_flip_on_stamp_failure(
+    session_factory: DbSessionFactory,
+    gc: GarbageCollector,
+    fixture_removing_messages,
+    monkeypatch,
+):
+    """
+    A failure between the REMOVING->REMOVED flip and the snapshot/deletion
+    must roll back the whole per-message savepoint: a REMOVED message
+    without removal record would be invisible to date-windowed queries.
+    """
+
+    def failing_remove_message(**_kwargs):
+        raise RuntimeError("snapshot failed")
+
+    monkeypatch.setattr(
+        "aleph.services.storage.garbage_collector.remove_message",
+        failing_remove_message,
+    )
+
+    # Must not raise: per-message errors are logged and skipped
+    await gc._check_and_update_removing_messages()
+
+    with session_factory() as session:
+        # The status flip was rolled back together with the failed snapshot
+        removable_status = get_message_status(
+            session=session, item_hash=fixture_removing_messages["removable_message"]
+        )
+        assert removable_status is not None
+        assert removable_status.status == MessageStatus.REMOVING
+
+        # The messages row is untouched
+        message = session.get(MessageDb, fixture_removing_messages["removable_message"])
+        assert message is not None
+        assert message.status_value == MessageStatus.REMOVING
+
+        # No removed_at was stamped on the phase-1 snapshot record
+        removed_message = get_removed_message(
+            session=session, item_hash=fixture_removing_messages["removable_message"]
+        )
+        assert removed_message is not None
+        assert removed_message.removed_at is None

--- a/tests/jobs/test_check_removing_messages.py
+++ b/tests/jobs/test_check_removing_messages.py
@@ -2,9 +2,9 @@ import pytest
 import pytest_asyncio
 from aleph_message.models import Chain, ItemType, MessageType
 
-from aleph.db.accessors.messages import get_message_status
+from aleph.db.accessors.messages import get_message_status, get_removed_message
 from aleph.db.models.files import FilePinType, MessageFilePinDb, StoredFileDb
-from aleph.db.models.messages import MessageDb, MessageStatusDb
+from aleph.db.models.messages import MessageDb, MessageStatusDb, RemovedMessageDb
 from aleph.services.storage.garbage_collector import GarbageCollector
 from aleph.storage import StorageService
 from aleph.toolkit.timestamp import utc_now
@@ -108,16 +108,75 @@ async def fixture_removing_messages(session_factory: DbSessionFactory):
         reception_time=now,
     )
 
+    # Size snapshot taken when the removable message entered REMOVING
+    store_removed_message = RemovedMessageDb(item_hash=store_message_hash, size=1000)
+
+    # Removable message that entered REMOVING before the size snapshot
+    # existed: no removed_messages row.
+    legacy_message_hash = "ijkl" * 16
+    legacy_message = MessageDb(
+        item_hash=legacy_message_hash,
+        sender="0xsender3",
+        chain=Chain.ETH,
+        type=MessageType.store,
+        time=now,
+        item_type=ItemType.ipfs,
+        signature="sig3",
+        size=1000,
+        content={
+            "type": "TEST",
+            "item_hash": "9abc" * 16,
+            "item_type": ItemType.ipfs.value,
+        },
+        status_value=MessageStatus.REMOVING,
+    )
+    legacy_message_status = MessageStatusDb(
+        item_hash=legacy_message_hash,
+        status=MessageStatus.REMOVING,
+        reception_time=now,
+    )
+
+    # Message concurrently recovered: the GC still lists it (denormalized
+    # status_value lags at REMOVING) but message_status is already PROCESSED,
+    # so the guarded flip must not happen.
+    recovered_message_hash = "mnop" * 16
+    recovered_message = MessageDb(
+        item_hash=recovered_message_hash,
+        sender="0xsender4",
+        chain=Chain.ETH,
+        type=MessageType.store,
+        time=now,
+        item_type=ItemType.ipfs,
+        signature="sig4",
+        size=1000,
+        content={
+            "type": "TEST",
+            "item_hash": "def0" * 16,
+            "item_type": ItemType.ipfs.value,
+        },
+        status_value=MessageStatus.REMOVING,
+    )
+    recovered_message_status = MessageStatusDb(
+        item_hash=recovered_message_hash,
+        status=MessageStatus.PROCESSED,
+        reception_time=now,
+    )
+
     with session_factory() as session:
         session.add_all(
             [
                 store_message,
                 store_file,
                 store_message_status,
+                store_removed_message,
                 pinned_message,
                 pinned_file,
                 pinned_file_pin,
                 pinned_message_status,
+                legacy_message,
+                legacy_message_status,
+                recovered_message,
+                recovered_message_status,
             ]
         )
         session.commit()
@@ -125,6 +184,8 @@ async def fixture_removing_messages(session_factory: DbSessionFactory):
         yield {
             "removable_message": store_message_hash,
             "pinned_message": pinned_message_hash,
+            "legacy_message": legacy_message_hash,
+            "recovered_message": recovered_message_hash,
         }
 
 
@@ -149,3 +210,47 @@ async def test_check_and_update_removing_messages(
         )
         assert pinned_status is not None
         assert pinned_status.status == MessageStatus.REMOVING
+
+        # The legacy message (no size snapshot) should also flip to REMOVED
+        legacy_status = get_message_status(
+            session=session, item_hash=fixture_removing_messages["legacy_message"]
+        )
+        assert legacy_status is not None
+        assert legacy_status.status == MessageStatus.REMOVED
+
+        # The removal record of the removable message keeps its size snapshot
+        # and gets removed_at stamped
+        removed_message = get_removed_message(
+            session=session, item_hash=fixture_removing_messages["removable_message"]
+        )
+        assert removed_message is not None
+        assert removed_message.size == 1000
+        assert removed_message.removed_at is not None
+
+        # The legacy message gets a removal record without size
+        legacy_removed_message = get_removed_message(
+            session=session, item_hash=fixture_removing_messages["legacy_message"]
+        )
+        assert legacy_removed_message is not None
+        assert legacy_removed_message.size is None
+        assert legacy_removed_message.removed_at is not None
+
+        # The pinned message stays REMOVING: no removal time stamped
+        pinned_removed_message = get_removed_message(
+            session=session, item_hash=fixture_removing_messages["pinned_message"]
+        )
+        assert pinned_removed_message is None
+
+        # The concurrently recovered message must not reappear as removed:
+        # the guarded flip did not happen, so no phantom removal record and
+        # message_status stays PROCESSED
+        recovered_status = get_message_status(
+            session=session, item_hash=fixture_removing_messages["recovered_message"]
+        )
+        assert recovered_status is not None
+        assert recovered_status.status == MessageStatus.PROCESSED
+
+        recovered_removed_message = get_removed_message(
+            session=session, item_hash=fixture_removing_messages["recovered_message"]
+        )
+        assert recovered_removed_message is None

--- a/tests/jobs/test_credit_balance_job.py
+++ b/tests/jobs/test_credit_balance_job.py
@@ -1,7 +1,7 @@
 import pytest
 from aleph_message.models import Chain, ItemHash, ItemType, MessageType
 
-from aleph.db.accessors.messages import get_removed_message
+from aleph.db.accessors.messages import get_message_status, get_removed_message
 from aleph.db.models.files import (
     FilePinType,
     GracePeriodFilePinDb,
@@ -130,6 +130,21 @@ async def test_credit_balance_job_delete_skips_snapshot_without_flip(
         assert removed_message is None
 
 
+def _add_finalized_removal(session, removed_at) -> None:
+    """Finalized removal: status REMOVED, snapshot present, messages row
+    deleted by the garbage collector."""
+    session.add(
+        MessageStatusDb(
+            item_hash=MESSAGE_HASH,
+            status=MessageStatus.REMOVED,
+            reception_time=utc_now(),
+        )
+    )
+    session.add(
+        RemovedMessageDb(item_hash=MESSAGE_HASH, size=FILE_SIZE, removed_at=removed_at)
+    )
+
+
 @pytest.mark.asyncio
 async def test_credit_balance_job_recover_keeps_record_after_gc_stamp(
     session_factory: DbSessionFactory, credit_balance_job: CreditBalanceCronJob
@@ -137,17 +152,13 @@ async def test_credit_balance_job_recover_keeps_record_after_gc_stamp(
     """
     A recovery attempt racing with the garbage collector must not destroy a
     finalized removal record: the REMOVING->PROCESSED flip does not happen
-    (the message is already REMOVED), so the record survives.
+    (the message is already REMOVED), so the record survives and no
+    messages row reappears.
     """
     removed_at = utc_now()
 
     with session_factory() as session:
-        _add_store_message(session, MessageStatus.REMOVED)
-        session.add(
-            RemovedMessageDb(
-                item_hash=MESSAGE_HASH, size=FILE_SIZE, removed_at=removed_at
-            )
-        )
+        _add_finalized_removal(session, removed_at)
         session.commit()
 
         await credit_balance_job.recover_messages(session, [ItemHash(MESSAGE_HASH)])
@@ -158,12 +169,12 @@ async def test_credit_balance_job_recover_keeps_record_after_gc_stamp(
         assert removed_message.size == FILE_SIZE
         assert removed_message.removed_at == removed_at
 
-        # The denormalized status must not be clobbered either: the message
-        # would otherwise disappear from removed-message listings and show
-        # up as processed.
-        message = session.get(MessageDb, MESSAGE_HASH)
-        assert message is not None
-        assert message.status_value == MessageStatus.REMOVED
+        # The message must not reappear as processed: the guarded flip did
+        # not happen and no messages row exists for a finalized removal.
+        status = get_message_status(session=session, item_hash=ItemHash(MESSAGE_HASH))
+        assert status is not None
+        assert status.status == MessageStatus.REMOVED
+        assert session.get(MessageDb, MESSAGE_HASH) is None
 
 
 @pytest.mark.asyncio
@@ -172,26 +183,21 @@ async def test_credit_balance_job_delete_keeps_removed_status(
 ):
     """
     A removal attempt on an already-REMOVED message must not flip its
-    denormalized status back to REMOVING nor write a removal record over
-    the finalized one.
+    status back to REMOVING nor write a removal record over the finalized
+    one.
     """
     removed_at = utc_now()
 
     with session_factory() as session:
-        _add_store_message(session, MessageStatus.REMOVED)
-        session.add(
-            RemovedMessageDb(
-                item_hash=MESSAGE_HASH, size=FILE_SIZE, removed_at=removed_at
-            )
-        )
+        _add_finalized_removal(session, removed_at)
         session.commit()
 
         await credit_balance_job.delete_messages(session, [ItemHash(MESSAGE_HASH)])
         session.commit()
 
-        message = session.get(MessageDb, MESSAGE_HASH)
-        assert message is not None
-        assert message.status_value == MessageStatus.REMOVED
+        status = get_message_status(session=session, item_hash=ItemHash(MESSAGE_HASH))
+        assert status is not None
+        assert status.status == MessageStatus.REMOVED
 
         removed_message = get_removed_message(session=session, item_hash=MESSAGE_HASH)
         assert removed_message is not None

--- a/tests/jobs/test_credit_balance_job.py
+++ b/tests/jobs/test_credit_balance_job.py
@@ -1,0 +1,198 @@
+import pytest
+from aleph_message.models import Chain, ItemHash, ItemType, MessageType
+
+from aleph.db.accessors.messages import get_removed_message
+from aleph.db.models.files import (
+    FilePinType,
+    GracePeriodFilePinDb,
+    MessageFilePinDb,
+    StoredFileDb,
+)
+from aleph.db.models.messages import MessageDb, MessageStatusDb, RemovedMessageDb
+from aleph.jobs.cron.credit_balance_job import CreditBalanceCronJob
+from aleph.toolkit.constants import DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE, MiB
+from aleph.toolkit.timestamp import utc_now
+from aleph.types.db_session import DbSessionFactory
+from aleph.types.files import FileType
+from aleph.types.message_status import MessageStatus
+
+MESSAGE_HASH = "dcba4321" * 8
+FILE_HASH = "4321" * 16
+FILE_SIZE = 30 * MiB
+SENDER = "0xB68B9D4f3771c246233823ed1D3Add451055F9Ef"
+
+
+@pytest.fixture
+def credit_balance_job(session_factory: DbSessionFactory) -> CreditBalanceCronJob:
+    return CreditBalanceCronJob(
+        session_factory=session_factory,
+        max_unauthenticated_upload_file_size=DEFAULT_MAX_UNAUTHENTICATED_UPLOAD_FILE_SIZE,
+    )
+
+
+def _add_store_message(session, status: MessageStatus) -> None:
+    now = utc_now()
+    message = MessageDb(
+        item_hash=MESSAGE_HASH,
+        sender=SENDER,
+        chain=Chain.ETH,
+        type=MessageType.store,
+        time=now,
+        item_type=ItemType.ipfs,
+        signature="sig",
+        size=1000,
+        content={
+            "address": SENDER,
+            "time": now.timestamp(),
+            "item_hash": FILE_HASH,
+            "item_type": ItemType.ipfs.value,
+            "payment": {"type": "credit"},
+        },
+        status_value=status,
+    )
+    file = StoredFileDb(hash=FILE_HASH, size=FILE_SIZE, type=FileType.FILE)
+    if status == MessageStatus.PROCESSED:
+        pin: object = MessageFilePinDb(
+            item_hash=MESSAGE_HASH,
+            file_hash=FILE_HASH,
+            type=FilePinType.MESSAGE,
+            owner=SENDER,
+            created=now,
+        )
+    else:
+        pin = GracePeriodFilePinDb(
+            item_hash=MESSAGE_HASH,
+            file_hash=FILE_HASH,
+            type=FilePinType.GRACE_PERIOD,
+            owner=SENDER,
+            created=now,
+            delete_by=now,
+        )
+    message_status = MessageStatusDb(
+        item_hash=MESSAGE_HASH,
+        status=status,
+        reception_time=now,
+    )
+    session.add_all([message, file, pin, message_status])
+
+
+@pytest.mark.asyncio
+async def test_credit_balance_job_delete_snapshots_removed_message(
+    session_factory: DbSessionFactory, credit_balance_job: CreditBalanceCronJob
+):
+    """Marking a credit STORE for removal snapshots its file size."""
+    with session_factory() as session:
+        _add_store_message(session, MessageStatus.PROCESSED)
+        session.commit()
+
+        await credit_balance_job.delete_messages(session, [ItemHash(MESSAGE_HASH)])
+        session.commit()
+
+        removed_message = get_removed_message(session=session, item_hash=MESSAGE_HASH)
+        assert removed_message is not None
+        assert removed_message.size == FILE_SIZE
+        assert removed_message.removed_at is None
+
+
+@pytest.mark.asyncio
+async def test_credit_balance_job_recover_discards_removed_message(
+    session_factory: DbSessionFactory, credit_balance_job: CreditBalanceCronJob
+):
+    """Recovering a REMOVING message discards its removal record."""
+    with session_factory() as session:
+        _add_store_message(session, MessageStatus.REMOVING)
+        session.add(RemovedMessageDb(item_hash=MESSAGE_HASH, size=FILE_SIZE))
+        session.commit()
+
+        await credit_balance_job.recover_messages(session, [ItemHash(MESSAGE_HASH)])
+        session.commit()
+
+        removed_message = get_removed_message(session=session, item_hash=MESSAGE_HASH)
+        assert removed_message is None
+
+
+@pytest.mark.asyncio
+async def test_credit_balance_job_delete_skips_snapshot_without_flip(
+    session_factory: DbSessionFactory, credit_balance_job: CreditBalanceCronJob
+):
+    """
+    No removal record is written when the PROCESSED->REMOVING flip does not
+    happen (message already on another transition).
+    """
+    with session_factory() as session:
+        _add_store_message(session, MessageStatus.REMOVING)
+        session.commit()
+
+        await credit_balance_job.delete_messages(session, [ItemHash(MESSAGE_HASH)])
+        session.commit()
+
+        removed_message = get_removed_message(session=session, item_hash=MESSAGE_HASH)
+        assert removed_message is None
+
+
+@pytest.mark.asyncio
+async def test_credit_balance_job_recover_keeps_record_after_gc_stamp(
+    session_factory: DbSessionFactory, credit_balance_job: CreditBalanceCronJob
+):
+    """
+    A recovery attempt racing with the garbage collector must not destroy a
+    finalized removal record: the REMOVING->PROCESSED flip does not happen
+    (the message is already REMOVED), so the record survives.
+    """
+    removed_at = utc_now()
+
+    with session_factory() as session:
+        _add_store_message(session, MessageStatus.REMOVED)
+        session.add(
+            RemovedMessageDb(
+                item_hash=MESSAGE_HASH, size=FILE_SIZE, removed_at=removed_at
+            )
+        )
+        session.commit()
+
+        await credit_balance_job.recover_messages(session, [ItemHash(MESSAGE_HASH)])
+        session.commit()
+
+        removed_message = get_removed_message(session=session, item_hash=MESSAGE_HASH)
+        assert removed_message is not None
+        assert removed_message.size == FILE_SIZE
+        assert removed_message.removed_at == removed_at
+
+        # The denormalized status must not be clobbered either: the message
+        # would otherwise disappear from removed-message listings and show
+        # up as processed.
+        message = session.get(MessageDb, MESSAGE_HASH)
+        assert message is not None
+        assert message.status_value == MessageStatus.REMOVED
+
+
+@pytest.mark.asyncio
+async def test_credit_balance_job_delete_keeps_removed_status(
+    session_factory: DbSessionFactory, credit_balance_job: CreditBalanceCronJob
+):
+    """
+    A removal attempt on an already-REMOVED message must not flip its
+    denormalized status back to REMOVING nor write a removal record over
+    the finalized one.
+    """
+    removed_at = utc_now()
+
+    with session_factory() as session:
+        _add_store_message(session, MessageStatus.REMOVED)
+        session.add(
+            RemovedMessageDb(
+                item_hash=MESSAGE_HASH, size=FILE_SIZE, removed_at=removed_at
+            )
+        )
+        session.commit()
+
+        await credit_balance_job.delete_messages(session, [ItemHash(MESSAGE_HASH)])
+        session.commit()
+
+        message = session.get(MessageDb, MESSAGE_HASH)
+        assert message is not None
+        assert message.status_value == MessageStatus.REMOVED
+
+        removed_message = get_removed_message(session=session, item_hash=MESSAGE_HASH)
+        assert removed_message is not None
+        assert removed_message.removed_at == removed_at

--- a/tests/message_processing/test_process_forgets.py
+++ b/tests/message_processing/test_process_forgets.py
@@ -239,6 +239,18 @@ async def test_forget_store_message(
         assert len(file.pins) == 1
         assert isinstance(file.pins[0], GracePeriodFilePinDb)
 
+        # Check that the billing metadata was preserved in forgotten_messages
+        forgotten_message = get_forgotten_message(
+            session=session, item_hash=ItemHash(pending_message.item_hash)
+        )
+        assert forgotten_message
+        assert forgotten_message.owner == "0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106"
+        # The STORE content carries no payment field: absence means hold
+        assert forgotten_message.payment_type == "hold"
+        # Size of the stored file (b"Test")
+        assert forgotten_message.size == 4
+        assert forgotten_message.forgotten_at == pending_forget_message.time
+
 
 @pytest.mark.asyncio
 async def test_forget_forget_message(

--- a/tests/schemas/test_credit_transfer.py
+++ b/tests/schemas/test_credit_transfer.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 from pydantic import ValidationError
 
@@ -340,6 +342,54 @@ class TestCreditExpenseContent:
         with pytest.raises(ValidationError, match="not be empty"):
             CreditExpenseContent.model_validate(
                 {"expense": {"credits": [{"address": "", "amount": 10}]}}
+            )
+
+    def test_v2_aggregated_entry(self):
+        entry = CreditExpenseContent.model_validate(
+            {
+                "expense": {
+                    "credits": [
+                        {
+                            "address": "0xabc",
+                            "amount": 500,
+                            "ref": "storage",
+                            "count": 42,
+                            "size": 1024.5,
+                            "time": 3600.0,
+                        }
+                    ]
+                }
+            }
+        ).expense.credits[0]
+        assert entry.count == 42
+        assert entry.size == Decimal("1024.5")
+        assert entry.time == 3600.0
+
+    def test_v1_entry_leaves_v2_fields_none(self):
+        entry = CreditExpenseContent.model_validate(
+            {"expense": {"credits": [{"address": "0xabc", "amount": 500}]}}
+        ).expense.credits[0]
+        assert entry.count is None
+        assert entry.size is None
+
+    def test_negative_count_rejected(self):
+        with pytest.raises(ValidationError):
+            CreditExpenseContent.model_validate(
+                {
+                    "expense": {
+                        "credits": [{"address": "0xabc", "amount": 10, "count": -1}]
+                    }
+                }
+            )
+
+    def test_negative_size_rejected(self):
+        with pytest.raises(ValidationError):
+            CreditExpenseContent.model_validate(
+                {
+                    "expense": {
+                        "credits": [{"address": "0xabc", "amount": 10, "size": -0.5}]
+                    }
+                }
             )
 
     def test_float_time_accepted(self):

--- a/tests/services/test_cost_service.py
+++ b/tests/services/test_cost_service.py
@@ -28,7 +28,12 @@ from aleph.services.cost import (
     get_cost_component_size_mib,
     get_total_and_detailed_costs,
 )
-from aleph.toolkit.constants import HOUR, MIN_CREDIT_COST_PER_HOUR, MiB
+from aleph.toolkit.constants import (
+    HOUR,
+    MIN_CREDIT_COST_PER_HOUR,
+    MIN_STORE_COST_MIB,
+    MiB,
+)
 from aleph.types.cost import CostType
 from aleph.types.db_session import DbSessionFactory
 
@@ -1051,3 +1056,66 @@ def test_compute_cost_unknown_gpu_raises_error(
                 content=fixture_unknown_gpu_instance_message,
                 item_hash="gpu_unknown",
             )
+
+
+def _make_store_content(size_mib: float, payment_type: PaymentType):
+    return CostEstimationStoreContent.model_validate(
+        {
+            "address": "0xA07B1214bAe0D5ccAA25449C3149c0aC83658874",
+            "time": 1701099523.849,
+            "item_type": "storage",
+            "item_hash": (
+                "734a1287a2b7b5be060312ff5b05ad1bcf838950492e3428f2ac6437a1acad26"
+            ),
+            "payment": Payment(type=payment_type),
+            "estimated_size_mib": size_mib,
+        }
+    )
+
+
+def test_store_min_cost_floor_applies_to_credit(
+    session_factory: DbSessionFactory,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """Credit-paid STOREs below MIN_STORE_COST_MIB are billed as MIN_STORE_COST_MIB."""
+    assert MIN_STORE_COST_MIB == 100
+
+    with session_factory() as session:
+        small_cost, _ = get_total_and_detailed_costs(
+            session, _make_store_content(1, PaymentType.credit), "hash-small"
+        )
+        floor_cost, _ = get_total_and_detailed_costs(
+            session,
+            _make_store_content(MIN_STORE_COST_MIB, PaymentType.credit),
+            "hash-floor",
+        )
+        above_cost, _ = get_total_and_detailed_costs(
+            session,
+            _make_store_content(MIN_STORE_COST_MIB * 2, PaymentType.credit),
+            "hash-above",
+        )
+
+    assert small_cost > 0
+    assert small_cost == floor_cost
+    assert above_cost > floor_cost
+
+
+def test_store_min_cost_floor_does_not_apply_to_hold(
+    session_factory: DbSessionFactory,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """The MIN_STORE_COST_MIB floor only applies to credit payment."""
+    with session_factory() as session:
+        small_cost, _ = get_total_and_detailed_costs(
+            session, _make_store_content(1, PaymentType.hold), "hash-small"
+        )
+        floor_cost, _ = get_total_and_detailed_costs(
+            session,
+            _make_store_content(MIN_STORE_COST_MIB, PaymentType.hold),
+            "hash-floor",
+        )
+
+    assert small_cost > 0
+    assert small_cost < floor_cost

--- a/tests/services/test_cost_service.py
+++ b/tests/services/test_cost_service.py
@@ -1079,8 +1079,6 @@ def test_store_min_cost_floor_applies_to_credit(
     fixture_settings_aggregate_in_db,
 ):
     """Credit-paid STOREs below MIN_STORE_COST_MIB are billed as MIN_STORE_COST_MIB."""
-    assert MIN_STORE_COST_MIB == 100
-
     with session_factory() as session:
         small_cost, _ = get_total_and_detailed_costs(
             session, _make_store_content(1, PaymentType.credit), "hash-small"


### PR DESCRIPTION
### Changes

- **Forgotten metadata**: `forget_message()` now snapshots `owner`,
  `payment_type` (NULL coalesced to hold), file `size` and `forgotten_at`
  into `forgotten_messages`. Migration 0061 adds the columns, backfills
  `forgotten_at` from still-indexed FORGET messages, and builds the indexes
  concurrently (rerun-safe).
- **Removed metadata**: new `removed_messages` table with a two-phase
  lifecycle — size snapshotted when a message enters REMOVING (the file row
  still exists at that point; the GC deletes it before flipping the status),
  row deleted if the message recovers, `removed_at` stamped by the GC at
  REMOVING→REMOVED. All writes (including the denormalized status
  dual-writes) are gated on the guarded status-flip rowcount to survive
  GC↔recovery races. Migration 0063.
- **Terminal-status queries**: `messages.json?msgStatuses=forgotten|removed`
  (single status only) windows and sorts on `forgotten_at`/`removed_at`,
  supports `paymentTypes` (coalesced to hold for removed) and returns 400 for
  unsupported narrowing filters. Single-message endpoints expose the new
  fields as epoch floats.
- **Pricing**: `/api/v0/price/{hash}` computes live prices for forgotten and
  removed STOREs from the preserved metadata through the estimation path —
  same floor and pricing aggregate as live messages. Missing metadata
  (legacy rows) still returns 410.
- **v2 expenses**: `aleph_credit_expense` entries may carry `count`/`size`,
  persisted to `credit_history` as `expense_count`/`expense_size_mib`
  (migration 0062). v1 messages are unaffected (NULL columns).
- **Spam floor**: `MIN_STORE_COST_MIB` raised 25 → 100 MiB (credit-only).

### Behavior changes worth reviewing

- `/price/{hash}` on a forgotten/removed STORE now returns 200 with a
  computed cost instead of 410 (only when metadata exists).
- Forgotten/removed responses expose `owner` and `size` — required for
  billing, but it narrows what FORGET hides. Deliberate, flagged for review.
- Precomputed `account_costs` keep the old 25 MiB floor until a
  recalculation; estimates and forgotten/removed pricing use 100 MiB
  immediately (documented at the constant).

Migrations: 0061 → 0062 → 0063, all rerun-safe, concurrent index builds.