### PR TITLE
feat(vprogram): give V-Programs a vms representation and forget-protection

### DIFF
--- a/deployment/migrations/versions/0064_a7c3e9f2d5b1_vprogram_vms_rows.py
+++ b/deployment/migrations/versions/0064_a7c3e9f2d5b1_vprogram_vms_rows.py
@@ -1,0 +1,59 @@
+"""Add the vms representation of V-PROGRAM messages
+
+Revision ID: a7c3e9f2d5b1
+Revises: f4b8a2d7c1e9
+Create Date: 2026-07-10
+
+V-Programs get a row in the single-inheritance vms table (type='vprogram').
+The runtime manifest and workload are single refs, so they live in nullable
+columns on vms (like the program-specific columns); the positional verified
+volume list gets its own table, cascading on vms deletion like the other
+volume tables.
+
+These rows exist so that get_vms_dependent_volumes sees the STORE files a
+V-Program references (runtime manifest, workload image and hash tree,
+verified volumes and their hash trees) and the forget handler blocks
+forgetting them while the V-Program is alive.
+
+No data backfill: no V-PROGRAM message can have reached PROCESSED before
+this migration (the message type ships in the same release).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a7c3e9f2d5b1"
+down_revision = "f4b8a2d7c1e9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("vms", sa.Column("runtime_ref", sa.String(), nullable=True))
+    op.add_column("vms", sa.Column("runtime_comment", sa.String(), nullable=True))
+    op.add_column("vms", sa.Column("workload_ref", sa.String(), nullable=True))
+    op.add_column("vms", sa.Column("workload_hash_tree", sa.String(), nullable=True))
+    op.add_column("vms", sa.Column("workload_roothash", sa.String(), nullable=True))
+    op.create_table(
+        "vprogram_verified_volumes",
+        sa.Column("vm_hash", sa.String(), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("ref", sa.String(), nullable=False),
+        sa.Column("hash_tree", sa.String(), nullable=False),
+        sa.Column("roothash", sa.String(), nullable=False),
+        sa.Column("comment", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["vm_hash"], ["vms.item_hash"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("vm_hash", "position"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("vprogram_verified_volumes")
+    op.drop_column("vms", "workload_roothash")
+    op.drop_column("vms", "workload_hash_tree")
+    op.drop_column("vms", "workload_ref")
+    op.drop_column("vms", "runtime_comment")
+    op.drop_column("vms", "runtime_ref")

--- a/deployment/migrations/versions/0064_a7c3e9f2d5b1_vprogram_vms_rows.py
+++ b/deployment/migrations/versions/0064_a7c3e9f2d5b1_vprogram_vms_rows.py
@@ -4,7 +4,7 @@ Revision ID: a7c3e9f2d5b1
 Revises: f4b8a2d7c1e9
 Create Date: 2026-07-10
 
-V-Programs get a row in the single-inheritance vms table (type='vprogram').
+V-Programs get a row in the single-inheritance vms table (type='v-program').
 The runtime manifest and workload are single refs, so they live in nullable
 columns on vms (like the program-specific columns); the positional verified
 volume list gets its own table, cascading on vms deletion like the other

--- a/src/aleph/db/accessors/vms.py
+++ b/src/aleph/db/accessors/vms.py
@@ -14,6 +14,8 @@ from aleph.db.models.vms import (
     VmBaseDb,
     VmInstanceDb,
     VmVersionDb,
+    VProgramDb,
+    VProgramVerifiedVolumeDb,
 )
 from aleph.types.db_session import DbSession
 from aleph.types.vms import VmVersion
@@ -26,6 +28,11 @@ def get_instance(session: DbSession, item_hash: str) -> Optional[VmInstanceDb]:
 
 def get_program(session: DbSession, item_hash: str) -> Optional[ProgramDb]:
     select_stmt = select(ProgramDb).where(ProgramDb.item_hash == item_hash)
+    return session.execute(select_stmt).scalar_one_or_none()
+
+
+def get_vprogram(session: DbSession, item_hash: str) -> Optional[VProgramDb]:
+    select_stmt = select(VProgramDb).where(VProgramDb.item_hash == item_hash)
     return session.execute(select_stmt).scalar_one_or_none()
 
 
@@ -83,6 +90,11 @@ def get_vms_dependent_volumes(
             RootfsVolumeDb.instance_hash == VmBaseDb.item_hash,
             isouter=True,
         )
+        .join(
+            VProgramVerifiedVolumeDb,
+            VProgramVerifiedVolumeDb.vm_hash == VmBaseDb.item_hash,
+            isouter=True,
+        )
         .where(
             or_(
                 ImmutableVolumeDb.ref == volume_hash,
@@ -90,10 +102,22 @@ def get_vms_dependent_volumes(
                 DataVolumeDb.ref == volume_hash,
                 RuntimeDb.ref == volume_hash,
                 RootfsVolumeDb.parent_ref == volume_hash,
+                # V-Program refs: the runtime manifest and workload live in
+                # columns on the vms table (same table as VmBaseDb, so no
+                # join is needed); hash trees are store files too.
+                VProgramDb.runtime_ref == volume_hash,
+                VProgramDb.workload_ref == volume_hash,
+                VProgramDb.workload_hash_tree == volume_hash,
+                VProgramVerifiedVolumeDb.ref == volume_hash,
+                VProgramVerifiedVolumeDb.hash_tree == volume_hash,
             )
         )
+        # Several rows can match (e.g. two VMs sharing a runtime, or two
+        # volumes of one VM referencing the same file); any one of them is
+        # enough to block the forget.
+        .limit(1)
     )
-    return session.execute(statement).scalar_one_or_none()
+    return session.execute(statement).scalars().first()
 
 
 def upsert_vm_version(

--- a/src/aleph/db/models/vms.py
+++ b/src/aleph/db/models/vms.py
@@ -224,6 +224,57 @@ class ProgramDb(VmBaseDb):
     )
 
 
+class VProgramVerifiedVolumeDb(Base):
+    """A verity-bound read-only volume of a V-Program.
+
+    Volumes are positional: the measured cmdline carries the roothashes in
+    list order, so `position` preserves the message's volume order.
+    """
+
+    __tablename__ = "vprogram_verified_volumes"
+
+    vm_hash: Mapped[str] = mapped_column(
+        ForeignKey("vms.item_hash", ondelete="CASCADE"), primary_key=True
+    )
+    position: Mapped[int] = mapped_column(Integer, primary_key=True)
+    ref: Mapped[str] = mapped_column(String, nullable=False)
+    hash_tree: Mapped[str] = mapped_column(String, nullable=False)
+    roothash: Mapped[str] = mapped_column(String, nullable=False)
+    comment: Mapped[str] = mapped_column(String, nullable=False)
+
+    vprogram: Mapped["VProgramDb"] = relationship(
+        "VProgramDb", back_populates="verified_volumes"
+    )
+
+
+class VProgramDb(VmBaseDb):
+    """A verifiable program (V-PROGRAM).
+
+    The runtime manifest and the workload are single refs, so they live in
+    columns (like ProgramDb's scalar fields); the verified volume list gets
+    its own table. There is no use_latest anywhere: V-Programs pin exact
+    item hashes, and they are immutable (the schema rejects allow_amend and
+    replaces), so they also keep no vm_versions rows.
+    """
+
+    __mapper_args__ = {
+        "polymorphic_identity": VmType.VPROGRAM.value,
+    }
+
+    runtime_ref: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    runtime_comment: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    workload_ref: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    workload_hash_tree: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    workload_roothash: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+
+    verified_volumes: Mapped[List[VProgramVerifiedVolumeDb]] = relationship(
+        VProgramVerifiedVolumeDb,
+        back_populates="vprogram",
+        uselist=True,
+        order_by=VProgramVerifiedVolumeDb.position,
+    )
+
+
 class VmVersionDb(Base):
     __tablename__ = "vm_versions"
 

--- a/src/aleph/handlers/content/vprogram.py
+++ b/src/aleph/handlers/content/vprogram.py
@@ -3,11 +3,13 @@ from typing import List, Set
 
 from aleph_message.models import PaymentType, VerifiableProgramContent
 
-from aleph.db.models import MessageDb
+from aleph.db.accessors.vms import delete_vm
+from aleph.db.models import MessageDb, VProgramDb, VProgramVerifiedVolumeDb
 from aleph.db.models.account_costs import AccountCostsDb
 from aleph.handlers.content.content_handler import ContentHandler
 from aleph.services.cost import get_payment_type, get_total_and_detailed_costs
 from aleph.services.cost_validation import validate_balance_for_payment
+from aleph.toolkit.timestamp import timestamp_to_datetime
 from aleph.types.db_session import DbSession
 from aleph.types.message_status import InvalidMessageFormat, InvalidPaymentMethod
 
@@ -23,13 +25,85 @@ def _get_vprogram_content(message: MessageDb) -> VerifiableProgramContent:
     return content
 
 
+def vprogram_message_to_db(message: MessageDb) -> VProgramDb:
+    content = _get_vprogram_content(message)
+
+    cpu_architecture = None
+    cpu_vendor = None
+    node_owner = None
+    node_address_regex = None
+    node_hash = None
+
+    if content.requirements:
+        if cpu := content.requirements.cpu:
+            cpu_architecture = cpu.architecture
+            cpu_vendor = cpu.vendor
+
+        if node := content.requirements.node:
+            node_owner = node.owner
+            node_address_regex = node.address_regex
+            node_hash = node.node_hash
+
+    return VProgramDb(
+        item_hash=message.item_hash,
+        owner=content.address,
+        # The schema rejects allow_amend/replaces (V-Programs are immutable);
+        # map them anyway rather than hardcoding the invariant here.
+        allow_amend=content.allow_amend,
+        replaces=content.replaces,
+        metadata_=content.metadata,
+        # variables and authorized_keys are rejected by the schema
+        # (unmeasured host-to-guest channels).
+        variables=content.variables,
+        authorized_keys=None,
+        message_triggers=None,
+        environment_reproducible=False,
+        environment_internet=content.environment.internet,
+        environment_aleph_api=False,
+        environment_shared_cache=False,
+        # The verification block (SNP policy, launch measurements) stays in
+        # the message content: the SNP policy is 64-bit and does not fit the
+        # int4 column that holds the SEV policy of instances.
+        environment_trusted_execution_policy=None,
+        environment_trusted_execution_firmware=None,
+        resources_vcpus=content.resources.vcpus,
+        resources_memory=content.resources.memory,
+        resources_seconds=content.resources.seconds,
+        cpu_architecture=cpu_architecture,
+        cpu_vendor=cpu_vendor,
+        node_owner=node_owner,
+        node_address_regex=node_address_regex,
+        node_hash=node_hash,
+        payment_type=content.payment.type,
+        created=timestamp_to_datetime(content.time),
+        volumes=[],
+        runtime_ref=str(content.runtime.ref),
+        runtime_comment=content.runtime.comment,
+        workload_ref=str(content.workload.ref),
+        workload_hash_tree=str(content.workload.hash_tree),
+        workload_roothash=content.workload.roothash,
+        verified_volumes=[
+            VProgramVerifiedVolumeDb(
+                position=position,
+                ref=str(volume.ref),
+                hash_tree=str(volume.hash_tree),
+                roothash=volume.roothash,
+                comment=volume.comment,
+            )
+            for position, volume in enumerate(content.volumes)
+        ],
+    )
+
+
 class VProgramMessageHandler(ContentHandler):
     """Handles V-PROGRAM (verifiable program) messages.
 
-    Phase 1 scope: validate the credit balance, persist costs, store and
-    display the message. Measurement validation and CRN dispatch are later
-    phases, so process/forget maintain no side tables: the message row is
-    the source of truth.
+    Validates the credit balance, persists costs, and maintains the vms
+    representation: a VProgramDb row plus verified volume rows, so that
+    forgetting a STORE file referenced by a V-Program (runtime manifest,
+    workload image, hash trees, verified volumes) is blocked by the
+    forget handler's dependent-volumes check. Measurement validation and
+    CRN dispatch are later phases.
     """
 
     async def check_balance(
@@ -57,10 +131,17 @@ class VProgramMessageHandler(ContentHandler):
         return costs
 
     async def process(self, session: DbSession, messages: List[MessageDb]) -> None:
-        # No side tables in phase 1.
-        pass
+        for message in messages:
+            # No vm_versions row: V-Programs are immutable, there is no
+            # amend chain to track.
+            session.add(vprogram_message_to_db(message))
 
     async def forget_message(self, session: DbSession, message: MessageDb) -> Set[str]:
-        # No side tables and no update chain to clean up in phase 1. Costs
-        # are removed by the generic forget path.
+        LOGGER.debug("Deleting v-program %s...", message.item_hash)
+
+        # Verified volume rows follow via ON DELETE CASCADE. V-Programs are
+        # immutable, so there are no updates to forget and no version table
+        # to refresh. Costs are removed by the generic forget path.
+        delete_vm(session=session, vm_hash=message.item_hash)
+
         return set()

--- a/src/aleph/repair.py
+++ b/src/aleph/repair.py
@@ -53,8 +53,8 @@ def mark_processed_message_as_rejected(
     Mirrors ``mark_pending_message_as_rejected`` for messages that already
     cleared the pipeline under permissive rules but are no longer valid under
     current ones (ex: ExecutableContent.metadata used to accept lists, now
-    requires a dict). Cleans up type-specific state (VM rows for
-    program/instance), snapshots the row into ``rejected_messages``, flips
+    requires a dict). Cleans up type-specific state (vms rows for the
+    executable types), snapshots the row into ``rejected_messages``, flips
     ``message_status`` to REJECTED, and deletes the ``messages`` row. The
     trigger keeps ``message_counts`` consistent; FK cascades clean
     ``message_confirmations`` and ``account_costs``.
@@ -64,7 +64,14 @@ def mark_processed_message_as_rejected(
     """
     snapshot = _wire_message_dict(message)
 
-    if message.type in (MessageType.program, MessageType.instance):
+    # The vms rows have no FK to messages: without an explicit delete_vm, a
+    # rejected executable would leave an orphaned vms row that keeps blocking
+    # forgets of the files it references (get_vms_dependent_volumes).
+    if message.type in (
+        MessageType.program,
+        MessageType.instance,
+        MessageType.v_program,
+    ):
         delete_vm(session=session, vm_hash=message.item_hash)
         _ = list(delete_vm_updates(session=session, vm_hash=message.item_hash))
 

--- a/src/aleph/types/vms.py
+++ b/src/aleph/types/vms.py
@@ -7,7 +7,7 @@ VmVersion = NewType("VmVersion", str)
 class VmType(str, Enum):
     INSTANCE = "instance"
     PROGRAM = "program"
-    VPROGRAM = "vprogram"
+    VPROGRAM = "v-program"
 
 
 class CpuArchitecture(str, Enum):

--- a/src/aleph/types/vms.py
+++ b/src/aleph/types/vms.py
@@ -7,6 +7,7 @@ VmVersion = NewType("VmVersion", str)
 class VmType(str, Enum):
     INSTANCE = "instance"
     PROGRAM = "program"
+    VPROGRAM = "vprogram"
 
 
 class CpuArchitecture(str, Enum):

--- a/tests/db/test_vprograms_db.py
+++ b/tests/db/test_vprograms_db.py
@@ -1,0 +1,176 @@
+import datetime as dt
+
+import pytest
+import pytz
+from aleph_message.models.execution import MachineType
+from sqlalchemy import func, select
+
+from aleph.db.accessors.vms import (
+    delete_vm,
+    get_instance,
+    get_program,
+    get_vms_dependent_volumes,
+    get_vprogram,
+)
+from aleph.db.models import ProgramDb, RuntimeDb, VProgramDb, VProgramVerifiedVolumeDb
+from aleph.types.db_session import DbSessionFactory
+from aleph.types.vms import VmType
+
+VPROGRAM_HASH = "1a" * 32
+RUNTIME_REF = "2b" * 32
+WORKLOAD_REF = "3c" * 32
+WORKLOAD_HASH_TREE = "4d" * 32
+VOLUME_REF = "5e" * 32
+VOLUME_HASH_TREE = "6f" * 32
+
+
+@pytest.fixture
+def vprogram() -> VProgramDb:
+    return VProgramDb(
+        item_hash=VPROGRAM_HASH,
+        owner="0xabadbabe",
+        allow_amend=False,
+        metadata_=None,
+        variables=None,
+        message_triggers=None,
+        environment_reproducible=False,
+        environment_internet=True,
+        environment_aleph_api=False,
+        environment_shared_cache=False,
+        resources_vcpus=2,
+        resources_memory=2048,
+        resources_seconds=30,
+        cpu_architecture=None,
+        cpu_vendor=None,
+        node_owner=None,
+        node_address_regex=None,
+        replaces=None,
+        created=pytz.utc.localize(dt.datetime(2026, 7, 10)),
+        runtime_ref=RUNTIME_REF,
+        runtime_comment="snp runtime bundle",
+        workload_ref=WORKLOAD_REF,
+        workload_hash_tree=WORKLOAD_HASH_TREE,
+        workload_roothash="ab" * 32,
+        verified_volumes=[
+            VProgramVerifiedVolumeDb(
+                position=0,
+                ref=VOLUME_REF,
+                hash_tree=VOLUME_HASH_TREE,
+                roothash="cd" * 32,
+                comment="model weights",
+            )
+        ],
+    )
+
+
+def test_vprogram_accessors(session_factory: DbSessionFactory, vprogram: VProgramDb):
+    with session_factory() as session:
+        session.add(vprogram)
+        session.commit()
+
+    with session_factory() as session:
+        vprogram_db = get_vprogram(session=session, item_hash=VPROGRAM_HASH)
+        assert vprogram_db is not None
+        assert vprogram_db.type == VmType.VPROGRAM
+        assert vprogram_db.runtime_ref == RUNTIME_REF
+        assert vprogram_db.workload_ref == WORKLOAD_REF
+        assert len(vprogram_db.verified_volumes) == 1
+
+        # A V-Program is neither an instance nor a program.
+        assert get_instance(session=session, item_hash=VPROGRAM_HASH) is None
+        assert get_program(session=session, item_hash=VPROGRAM_HASH) is None
+
+
+@pytest.mark.parametrize(
+    "volume_hash",
+    [RUNTIME_REF, WORKLOAD_REF, WORKLOAD_HASH_TREE, VOLUME_REF, VOLUME_HASH_TREE],
+)
+def test_get_vms_dependent_volumes_sees_vprogram_refs(
+    session_factory: DbSessionFactory, vprogram: VProgramDb, volume_hash: str
+):
+    """Every store file referenced by a V-Program (runtime manifest, workload
+    image and hash tree, verified volumes and their hash trees) must block
+    forgets while the V-Program is alive."""
+    with session_factory() as session:
+        session.add(vprogram)
+        session.commit()
+
+    with session_factory() as session:
+        dependent_vm = get_vms_dependent_volumes(
+            session=session, volume_hash=volume_hash
+        )
+        assert dependent_vm is not None
+        assert dependent_vm.item_hash == VPROGRAM_HASH
+
+        assert get_vms_dependent_volumes(session=session, volume_hash="00" * 32) is None
+
+
+def test_get_vms_dependent_volumes_multiple_matches(
+    session_factory: DbSessionFactory, vprogram: VProgramDb
+):
+    """Several rows can reference the same file (here: a second verified
+    volume of the same V-Program, and a program runtime); the query must
+    return one of them instead of raising MultipleResultsFound."""
+    vprogram.verified_volumes.append(
+        VProgramVerifiedVolumeDb(
+            position=1,
+            ref=VOLUME_REF,
+            hash_tree="7a" * 32,
+            roothash="ef" * 32,
+            comment="same dataset, second mount",
+        )
+    )
+    program = ProgramDb(
+        item_hash="8b" * 32,
+        owner="0xabadbabe",
+        program_type=MachineType.vm_function,
+        allow_amend=False,
+        metadata_=None,
+        variables=None,
+        http_trigger=True,
+        message_triggers=None,
+        persistent=False,
+        environment_reproducible=False,
+        environment_internet=True,
+        environment_aleph_api=True,
+        environment_shared_cache=False,
+        resources_vcpus=1,
+        resources_memory=128,
+        resources_seconds=30,
+        cpu_architecture=None,
+        cpu_vendor=None,
+        node_owner=None,
+        node_address_regex=None,
+        replaces=None,
+        created=pytz.utc.localize(dt.datetime(2026, 7, 10)),
+        runtime=RuntimeDb(ref=VOLUME_REF, use_latest=False, comment="shared file"),
+    )
+    with session_factory() as session:
+        session.add(vprogram)
+        session.add(program)
+        session.commit()
+
+    with session_factory() as session:
+        dependent_vm = get_vms_dependent_volumes(
+            session=session, volume_hash=VOLUME_REF
+        )
+        assert dependent_vm is not None
+        assert dependent_vm.item_hash in (VPROGRAM_HASH, "8b" * 32)
+
+
+def test_delete_vprogram_cascades_verified_volumes(
+    session_factory: DbSessionFactory, vprogram: VProgramDb
+):
+    with session_factory() as session:
+        session.add(vprogram)
+        session.commit()
+
+    with session_factory() as session:
+        delete_vm(session=session, vm_hash=VPROGRAM_HASH)
+        session.commit()
+
+        assert get_vprogram(session=session, item_hash=VPROGRAM_HASH) is None
+        remaining_volumes = session.execute(
+            select(func.count()).select_from(VProgramVerifiedVolumeDb)
+        ).scalar_one()
+        assert remaining_volumes == 0

--- a/tests/message_processing/test_process_vprograms.py
+++ b/tests/message_processing/test_process_vprograms.py
@@ -1,9 +1,13 @@
+import copy
 import datetime as dt
 import json
 
 import pytest
 from aleph_message.models import Chain, ItemHash, ItemType, MessageType
+from message_test_helpers import process_pending_messages
 from messages.test_vprogram import VPROGRAM_CONTENT, VPROGRAM_ITEM_HASH
+from more_itertools import one
+from sqlalchemy import func, select
 
 from aleph.db.accessors.cost import get_message_costs
 from aleph.db.accessors.messages import (
@@ -11,13 +15,20 @@ from aleph.db.accessors.messages import (
     get_message_status,
     get_rejected_message,
 )
-from aleph.db.accessors.vms import get_instance
-from aleph.db.models import AlephCreditBalanceDb, MessageStatusDb, PendingMessageDb
+from aleph.db.accessors.vms import get_instance, get_program, get_vprogram
+from aleph.db.models import (
+    AlephCreditBalanceDb,
+    MessageStatusDb,
+    PendingMessageDb,
+    VProgramVerifiedVolumeDb,
+)
 from aleph.jobs.process_pending_messages import PendingMessageProcessor
 from aleph.schemas.api.messages import format_message
 from aleph.toolkit.timestamp import timestamp_to_datetime
 from aleph.types.db_session import DbSessionFactory
+from aleph.types.message_processing_result import ProcessedMessage, RejectedMessage
 from aleph.types.message_status import ErrorCode, MessageStatus
+from aleph.types.vms import VmType
 
 SENDER = "0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba"
 
@@ -97,9 +108,37 @@ async def test_process_vprogram(
         assert costs
         assert all(cost.owner == SENDER for cost in costs)
 
-        # Phase 1 keeps no vms side table rows.
+        # The vms representation was written, under its own polymorphic
+        # identity (neither an instance nor a program).
+        vprogram = get_vprogram(
+            session=session, item_hash=fixture_vprogram_message.item_hash
+        )
+        assert vprogram is not None
+        assert vprogram.type == VmType.VPROGRAM
+        assert vprogram.owner == SENDER
+        assert vprogram.payment_type == "credit"
+        assert vprogram.environment_internet is True
+        assert vprogram.runtime_ref == VPROGRAM_CONTENT["runtime"]["ref"]
+        assert vprogram.runtime_comment == VPROGRAM_CONTENT["runtime"]["comment"]
+        assert vprogram.workload_ref == VPROGRAM_CONTENT["workload"]["ref"]
+        assert vprogram.workload_hash_tree == VPROGRAM_CONTENT["workload"]["hash_tree"]
+        assert vprogram.workload_roothash == VPROGRAM_CONTENT["workload"]["roothash"]
+
+        volume_content = VPROGRAM_CONTENT["volumes"][0]
+        assert len(vprogram.verified_volumes) == 1
+        volume = vprogram.verified_volumes[0]
+        assert volume.position == 0
+        assert volume.ref == volume_content["ref"]
+        assert volume.hash_tree == volume_content["hash_tree"]
+        assert volume.roothash == volume_content["roothash"]
+        assert volume.comment == volume_content["comment"]
+
         assert (
             get_instance(session=session, item_hash=fixture_vprogram_message.item_hash)
+            is None
+        )
+        assert (
+            get_program(session=session, item_hash=fixture_vprogram_message.item_hash)
             is None
         )
 
@@ -136,3 +175,157 @@ async def test_process_vprogram_insufficient_credit(
         )
         assert rejected is not None
         assert rejected.error_code == ErrorCode.CREDIT_INSUFFICIENT
+
+
+def _pending_message(
+    item_hash: str,
+    message_type: MessageType,
+    content: dict,
+    time: float,
+) -> PendingMessageDb:
+    return PendingMessageDb(
+        item_hash=item_hash,
+        type=message_type,
+        chain=Chain.ETH,
+        sender=SENDER,
+        signature=None,
+        item_type=ItemType.inline,
+        item_content=json.dumps(content),
+        time=timestamp_to_datetime(time),
+        channel=None,
+        reception_time=timestamp_to_datetime(time + 1),
+        fetched=True,
+        check_message=False,
+        retries=0,
+        next_attempt=dt.datetime(2026, 1, 1),
+    )
+
+
+@pytest.mark.asyncio
+async def test_forget_store_used_by_vprogram_is_blocked(
+    session_factory: DbSessionFactory,
+    message_processor: PendingMessageProcessor,
+    user_credit_balance,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """Forgetting a STORE file referenced by a live V-Program (here: the
+    workload image) must be blocked; forgetting the V-Program itself must
+    delete its vms rows, after which the STORE becomes forgettable."""
+
+    file_hash = "f0" * 32
+    store_message_hash = "50" * 32
+    vprogram_message_hash = "51" * 32
+
+    store_message = _pending_message(
+        item_hash=store_message_hash,
+        message_type=MessageType.store,
+        content={
+            "address": SENDER,
+            "time": 1719502000.0,
+            "item_type": "storage",
+            "item_hash": file_hash,
+            "mime_type": "text/plain",
+        },
+        time=1719502000.0,
+    )
+
+    vprogram_content = copy.deepcopy(VPROGRAM_CONTENT)
+    vprogram_content["workload"]["ref"] = store_message_hash
+    vprogram_message = _pending_message(
+        item_hash=vprogram_message_hash,
+        message_type=MessageType.v_program,
+        content=vprogram_content,
+        time=1719502010.0,
+    )
+
+    def forget_message(item_hash: str, target: str, time: float) -> PendingMessageDb:
+        return _pending_message(
+            item_hash=item_hash,
+            message_type=MessageType.forget,
+            content={"address": SENDER, "time": time, "hashes": [target]},
+            time=time,
+        )
+
+    storage_engine = message_processor.message_handler.storage_service.storage_engine
+    await storage_engine.write(filename=file_hash, content=b"workload image")
+
+    with session_factory() as session:
+        store_result = one(
+            await process_pending_messages(
+                message_processor=message_processor,
+                pending_messages=[store_message],
+                session=session,
+            )
+        )
+        assert isinstance(store_result, ProcessedMessage)
+
+        vprogram_result = one(
+            await process_pending_messages(
+                message_processor=message_processor,
+                pending_messages=[vprogram_message],
+                session=session,
+            )
+        )
+        assert isinstance(vprogram_result, ProcessedMessage)
+        assert (
+            get_vprogram(session=session, item_hash=vprogram_message_hash) is not None
+        )
+
+        # Forgetting the STORE while the V-Program references it is blocked.
+        blocked_forget_result = one(
+            await process_pending_messages(
+                message_processor=message_processor,
+                pending_messages=[
+                    forget_message("52" * 32, store_message_hash, 1719502020.0)
+                ],
+                session=session,
+            )
+        )
+        assert isinstance(blocked_forget_result, RejectedMessage)
+        rejected = get_rejected_message(session=session, item_hash="52" * 32)
+        assert rejected is not None
+        assert rejected.error_code == ErrorCode.FORGET_NOT_ALLOWED
+
+        store_status = get_message_status(
+            session=session, item_hash=ItemHash(store_message_hash)
+        )
+        assert store_status is not None
+        assert store_status.status == MessageStatus.PROCESSED
+
+        # Forgetting the V-Program deletes its vms representation...
+        vprogram_forget_result = one(
+            await process_pending_messages(
+                message_processor=message_processor,
+                pending_messages=[
+                    forget_message("53" * 32, vprogram_message_hash, 1719502030.0)
+                ],
+                session=session,
+            )
+        )
+        assert isinstance(vprogram_forget_result, ProcessedMessage)
+        assert get_vprogram(session=session, item_hash=vprogram_message_hash) is None
+        remaining_volumes = session.execute(
+            select(func.count()).select_from(VProgramVerifiedVolumeDb)
+        ).scalar_one()
+        assert remaining_volumes == 0
+
+        # ... after which the STORE can be forgotten.
+        store_forget_result = one(
+            await process_pending_messages(
+                message_processor=message_processor,
+                pending_messages=[
+                    forget_message("54" * 32, store_message_hash, 1719502040.0)
+                ],
+                session=session,
+            )
+        )
+        assert isinstance(store_forget_result, ProcessedMessage)
+        # The pipeline commits in its own sessions: expire this session's
+        # identity map so the status re-read hits the database.
+        session.expire_all()
+        store_status = get_message_status(
+            session=session, item_hash=ItemHash(store_message_hash)
+        )
+        assert store_status is not None
+        assert store_status.status == MessageStatus.FORGOTTEN

--- a/tests/messages/test_vprogram.py
+++ b/tests/messages/test_vprogram.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any, Dict
 
 from aleph_message.models import MessageType, VerifiableProgramContent
 
@@ -6,7 +7,7 @@ from aleph.db.models.messages import CONTENT_TYPE_MAP, extract_tags
 from aleph.schemas.api.messages import VProgramMessage, format_message_dict
 from aleph.schemas.pending_messages import PendingVProgramMessage, parse_message
 
-VPROGRAM_CONTENT = {
+VPROGRAM_CONTENT: Dict[str, Any] = {
     "address": "0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
     "time": 1719502000.0,
     "allow_amend": False,

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -2,11 +2,20 @@ import datetime as dt
 
 import pytest
 from aleph_message.models import Chain, ItemHash, ItemType, MessageType
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from aleph.db.accessors.messages import get_message_status, get_rejected_message
-from aleph.db.models import MessageDb, MessageStatusDb
-from aleph.repair import _reject_invalid_program_metadata
+from aleph.db.accessors.vms import get_vms_dependent_volumes, get_vprogram
+from aleph.db.models import (
+    MessageDb,
+    MessageStatusDb,
+    VProgramDb,
+    VProgramVerifiedVolumeDb,
+)
+from aleph.repair import (
+    _reject_invalid_program_metadata,
+    mark_processed_message_as_rejected,
+)
 from aleph.toolkit.timestamp import timestamp_to_datetime
 from aleph.types.channel import Channel
 from aleph.types.db_session import DbSessionFactory
@@ -178,3 +187,85 @@ def test_reject_invalid_program_metadata_skips_valid_programs(
             is not None
         )
         assert get_rejected_message(session=session, item_hash=item_hash) is None
+
+
+def test_mark_processed_vprogram_as_rejected_deletes_vms_rows(
+    session_factory: DbSessionFactory,
+):
+    """Rejecting a processed V-PROGRAM must delete its vms representation:
+    the vms rows have no FK to messages, and an orphaned row would keep
+    blocking forgets of the files it references."""
+    vprogram_hash = "feed" + "0" * 60
+    workload_ref = "3c" * 32
+
+    message = MessageDb(
+        item_hash=vprogram_hash,
+        chain=Chain.ETH,
+        sender="0x0000000000000000000000000000000000000001",
+        signature="0xsig",
+        item_type=ItemType.inline,
+        type=MessageType.v_program,
+        content={"address": "0xabc", "time": 1700000000.0},
+        size=100,
+        time=timestamp_to_datetime(1700000000.0),
+        channel=Channel("TEST"),
+    )
+    vprogram_row = VProgramDb(
+        item_hash=vprogram_hash,
+        owner="0xabc",
+        allow_amend=False,
+        environment_reproducible=False,
+        environment_internet=True,
+        environment_aleph_api=False,
+        environment_shared_cache=False,
+        resources_vcpus=2,
+        resources_memory=2048,
+        resources_seconds=30,
+        created=timestamp_to_datetime(1700000000.0),
+        runtime_ref="2b" * 32,
+        runtime_comment="",
+        workload_ref=workload_ref,
+        workload_hash_tree="4d" * 32,
+        workload_roothash="ab" * 32,
+        verified_volumes=[
+            VProgramVerifiedVolumeDb(
+                position=0,
+                ref="5e" * 32,
+                hash_tree="6f" * 32,
+                roothash="cd" * 32,
+                comment="",
+            )
+        ],
+    )
+
+    with session_factory() as session:
+        _seed(session, message)
+        session.add(vprogram_row)
+        session.commit()
+
+    with session_factory() as session:
+        message_db = session.execute(
+            select(MessageDb).where(MessageDb.item_hash == vprogram_hash)
+        ).scalar_one()
+        mark_processed_message_as_rejected(
+            session=session,
+            message=message_db,
+            error_code=ErrorCode.INVALID_FORMAT,
+            reason="test rejection",
+        )
+        session.commit()
+
+    with session_factory() as session:
+        status = get_message_status(session=session, item_hash=ItemHash(vprogram_hash))
+        assert status is not None
+        assert status.status == MessageStatus.REJECTED
+
+        assert get_vprogram(session=session, item_hash=vprogram_hash) is None
+        remaining_volumes = session.execute(
+            select(func.count()).select_from(VProgramVerifiedVolumeDb)
+        ).scalar_one()
+        assert remaining_volumes == 0
+        # The referenced files are forgettable again.
+        assert (
+            get_vms_dependent_volumes(session=session, volume_hash=workload_ref) is None
+        )


### PR DESCRIPTION
Follow-up to #1220 (V-PROGRAM phase 1).

## Problem

Phase 1 (#1220) deliberately kept `VProgramMessageHandler.process` a no-op: no `vms` rows, no `VmType` member. That left a genuine footgun: `get_vms_dependent_volumes` — the only gate the FORGET handler uses to protect files referenced by executables — could not see V-Program references, so **forgetting a STORE file used by a live V-Program (workload image, runtime manifest, hash trees, verified volumes) was not blocked**, silently breaking the deployment.

## Changes

- **`VmType.VPROGRAM`** — pure Python change: the `vms.type` column is a varchar-backed `ChoiceType`, no DDL needed for the enum member.
- **`VProgramDb(VmBaseDb)`** polymorphic subclass. Following the `ProgramDb` precedent (scalar per-type fields as columns on the single-inheritance table, lists as side tables):
  - runtime manifest + workload as nullable columns on `vms` (`runtime_ref`, `runtime_comment`, `workload_ref`, `workload_hash_tree`, `workload_roothash`);
  - the verified volume list in a new `vprogram_verified_volumes` table with a `position` column — order matters, it's the measured cmdline order (`verified_volumes=h1,h2,...`) — cascading on `vms` deletion like the other volume tables (migration 0064).
  - No `vm_versions` rows: V-Programs are immutable at the schema level (no `allow_amend`/`replaces`), there is no amend chain to track. Cross-type amends are already impossible (`check_dependencies` resolves `replaces` via `get_program`, which won't return a V-Program row).
  - The verification block (SNP policy, launch measurements) stays in the message content: the SNP policy is 64-bit and does not fit the int4 column holding the SEV policy of instances.
- **Handler**: `process` writes the row, `forget_message` deletes it (volumes follow via `ON DELETE CASCADE`).
- **Forget-protection**: `get_vms_dependent_volumes` now also scans `runtime_ref`, `workload_ref`, `workload_hash_tree` (columns on `vms`, no extra join) and `vprogram_verified_volumes.ref`/`.hash_tree`. Hash trees are STORE files too and are as load-bearing as the data images.
- **Bug fix in the same query**: switched `scalar_one_or_none()` to `first()`. Several rows can legitimately match one file hash — two VMs sharing a runtime ref (common: official runtimes), or two volumes of one VM referencing the same file — which previously raised `MultipleResultsFound` instead of blocking the forget. Regression-tested.

## Not in scope

- The async removal path (`removed_messages` GC, #1219) does not consult `get_vms_dependent_volumes` for any executable type; that insolvency-removal ordering question is pre-existing and shared with instances/programs.
- `check_dependencies`-time existence checks for referenced STOREs (the `find_missing_volumes` analog) — candidate follow-up.

## Tests

- `tests/db/test_vprograms_db.py` (new): accessors, all five ref/hash-tree columns block via `get_vms_dependent_volumes` (parametrized), `MultipleResultsFound` regression, cascade deletion.
- `tests/message_processing/test_process_vprograms.py`: processing now asserts the full vms row (identity, refs, positional volumes); new end-to-end lifecycle test — forget of the referenced STORE is **rejected** with `FORGET_NOT_ALLOWED`, forgetting the V-Program deletes its rows, after which the STORE forget succeeds.

Locally: the vprogram/forget/instance/program/db/removal suites pass and mypy is clean (317 files); migrations are exercised by the test harness (alembic upgrade to head). Full-suite run left to CI.
