### PR TITLE
feat(cli): add --repair/--no-repair switch to toggle boot repair

### DIFF
--- a/src/aleph/cli/args.py
+++ b/src/aleph/cli/args.py
@@ -30,6 +30,14 @@ def parse_args(args):
     )
     parser.add_argument("--no-jobs", action="store_true", dest="no_jobs", default=False)
     parser.add_argument(
+        "--repair",
+        dest="repair",
+        help="Run repair operations at startup (enabled by default). "
+        "Use --no-repair to skip them.",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         dest="loglevel",

--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -192,9 +192,12 @@ async def main(args: List[str]) -> None:
         )
         await stack.enter_async_context(chain_connector)
 
-        await repair_node(
-            storage_service=storage_service, session_factory=session_factory
-        )
+        if args.repair:
+            await repair_node(
+                storage_service=storage_service, session_factory=session_factory
+            )
+        else:
+            LOGGER.info("Repair operations disabled by CLI arguments")
 
         tasks: List[Coroutine] = []
 

--- a/tests/cli/test_args.py
+++ b/tests/cli/test_args.py
@@ -1,0 +1,17 @@
+from aleph.cli.args import parse_args
+
+
+def test_repair_enabled_by_default():
+    """Repair operations run at boot unless explicitly disabled."""
+    args = parse_args([])
+    assert args.repair is True
+
+
+def test_repair_flag_enables_repair():
+    args = parse_args(["--repair"])
+    assert args.repair is True
+
+
+def test_no_repair_flag_disables_repair():
+    args = parse_args(["--no-repair"])
+    assert args.repair is False


### PR DESCRIPTION
## Summary

Adds a `--repair` / `--no-repair` CLI switch controlling whether repair operations run at node startup. `--repair` is the default, so existing behaviour is unchanged; operators can pass `--no-repair` to skip repair on boot.

## Changes

- **`src/aleph/cli/args.py`** — new `--repair` argument using `argparse.BooleanOptionalAction`, which creates the paired `--repair` / `--no-repair` flags and defaults to `True`.
- **`src/aleph/commands.py`** — the `repair_node(...)` startup call is now gated behind `if args.repair:` (logging when disabled), mirroring the existing `--no-jobs` pattern.
- **`tests/cli/test_args.py`** — new tests covering the default (`True`), `--repair` (`True`), and `--no-repair` (`False`).

## Testing

- `hatch run testing:test tests/cli/test_args.py` — 3 passed (written test-first).
- `hatch run linting:fmt` / `linting:all` — ruff, black, isort, yamlfix pass. The mypy step fails on a pre-existing SQLAlchemy-stubs plugin conflict (aborts at plugin-load before any file is checked); reproduces identically on the untouched base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)