### PR TITLE
chore(deps): bump aleph-message vprogram pin to #158 tip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "aiohttp-swagger3>=0.10.0",
   "aioipfs~=0.7.1",
   "alembic==1.18.5",
-  "aleph-message @ git+https://github.com/aleph-im/aleph-message.git@08898ecd63c25c024873e98697e1f9d279c85ad0",
+  "aleph-message @ git+https://github.com/aleph-im/aleph-message.git@bc9c0f86958a746faeecbd6c6f96cc6f5b4538de",
   "aleph-nuls2==0.1.1",
   "aleph-p2p-client @ git+https://github.com/aleph-im/p2p-service-client-python@1e992aaacdb0071a34ffb130cbbba9123509e08b",
   "asyncpg==0.31.0",


### PR DESCRIPTION
Bumps the `aleph-message` git pin from `08898ec` to `bc9c0f8`, the current tip of `od/vprogram-schema` (aleph-message PR #158).

The pin was one commit behind the branch tip. This picks up the intervening commit, [`bc9c0f8`](https://github.com/aleph-im/aleph-message/commit/bc9c0f86958a746faeecbd6c6f96cc6f5b4538de) *feat(vprogram): reject amendment (allow_amend/replaces) as schema-invalid*, so pyaleph runs the latest V-PROGRAM schema semantics.

Still a git-commit pin by design; will move to a versioned release once #158 lands and aleph-message cuts one.