### PR TITLE
fix(pricing): backfill missing credit price from default in pricing timeline

### DIFF
--- a/src/aleph/services/pricing_utils.py
+++ b/src/aleph/services/pricing_utils.py
@@ -20,6 +20,29 @@ from aleph.types.cost import ProductPricing
 from aleph.types.db_session import DbSession
 
 
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge ``override`` onto a copy of ``base``.
+
+    Nested dicts are merged key-by-key so a *partial* override inherits any
+    leaf it does not set from ``base`` instead of dropping it. Non-dict values
+    (and dict-vs-non-dict conflicts) are taken from ``override``.
+
+    Used to backfill the pricing model from ``DEFAULT_PRICE_AGGREGATE``: a
+    pricing aggregate update that replaced e.g. ``INSTANCE.price.compute_unit``
+    without a ``credit`` field — as happened on chain during the 2025-02 →
+    2025-10 window, before credit pricing existed — otherwise resolves to
+    ``cost_credit = 0`` for every item priced in that window.
+    """
+    result = dict(base)
+    for key, value in override.items():
+        existing = result.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            result[key] = _deep_merge(existing, value)
+        else:
+            result[key] = value
+    return result
+
+
 def build_pricing_model_from_aggregate(
     aggregate_content: Dict[Union[ProductPriceType, str], dict],
 ) -> Dict[ProductPriceType, ProductPricing]:
@@ -113,11 +136,28 @@ def get_pricing_timeline(
     for element in pricing_elements:
         elements_so_far.append(element)
 
-        # Merge all elements up to this point to get the cumulative state
+        # Merge all elements up to this point to get the cumulative state.
+        # The shallow aggregate-merge semantics (how on-chain elements combine
+        # with each other) are unchanged.
         merged_content = merge_aggregate_elements(elements_so_far)
 
+        # Backfill missing leaves from the default aggregate, but only for the
+        # product types actually present on chain — types never priced on
+        # chain stay absent, preserving the timeline's semantics. This rescues
+        # a partial update that replaced e.g. INSTANCE.price.compute_unit
+        # without a `credit` field (as happened during the 2025-02 → 2025-10
+        # window, before credit pricing existed on chain): the credit leaf
+        # falls back to the default instead of resolving to cost_credit=0.
+        # On-chain values always win where present.
+        full_content = {
+            price_type: _deep_merge(
+                DEFAULT_PRICE_AGGREGATE.get(price_type, {}), pricing_data
+            )
+            for price_type, pricing_data in merged_content.items()
+        }
+
         # Build pricing model from the merged content
-        pricing_model = build_pricing_model_from_aggregate(merged_content)
+        pricing_model = build_pricing_model_from_aggregate(full_content)
         timeline.append((element.creation_datetime, pricing_model))
 
     return timeline

--- a/tests/services/test_pricing_utils.py
+++ b/tests/services/test_pricing_utils.py
@@ -335,6 +335,52 @@ class TestGetPricingTimeline:
             assert program_pricing.price.storage.holding == Decimal("0.1")
             assert program_pricing.price.compute_unit.holding == Decimal("100")
 
+    def test_pricing_timeline_backfills_missing_credit_from_default(
+        self, session_factory
+    ):
+        """Regression: an INSTANCE compute_unit published WITHOUT a `credit`
+        field — the on-chain shape during the 2025-02 → 2025-10 gap window,
+        before credit pricing existed — must inherit the default credit price
+        (14250) instead of resolving to cost_credit=0. On-chain values that
+        ARE set still win."""
+        base_time = dt.datetime(2025, 3, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+        gap_element = AggregateElementDb(
+            item_hash="gap_window_instance",
+            key=PRICE_AGGREGATE_KEY,
+            owner=PRICE_AGGREGATE_OWNER,
+            content={
+                ProductPriceType.INSTANCE: {
+                    "price": {
+                        "storage": {"payg": "0.000000977", "holding": "0.05"},
+                        # compute_unit WITHOUT `credit` — the gap-window shape
+                        "compute_unit": {"payg": "0.055", "holding": "1000"},
+                    },
+                    "tiers": [{"id": "tier-3", "compute_units": 4}],
+                    "compute_unit": {
+                        "vcpus": 1,
+                        "disk_mib": 20480,
+                        "memory_mib": 2048,
+                    },
+                }
+            },
+            creation_datetime=base_time,
+        )
+
+        with session_factory() as session:
+            session.add(gap_element)
+            session.commit()
+
+            timeline = get_pricing_timeline(session)
+
+        _, model = timeline[-1]
+        instance = model[ProductPriceType.INSTANCE]
+
+        # credit backfilled from DEFAULT_PRICE_AGGREGATE, not zeroed
+        assert instance.price.compute_unit.credit == Decimal("14250")
+        # on-chain values still win for the leaves that WERE set
+        assert instance.price.compute_unit.holding == Decimal("1000")
+        assert instance.price.compute_unit.payg == Decimal("0.055")
+
 
 class TestPricingTimelineIntegration:
     """Integration tests for pricing timeline with real message types."""


### PR DESCRIPTION
A pricing aggregate update that replaced a nested price object without a `credit` field, the on-chain shape during the 2025-02 → 2025-10 window, before credit pricing existed, resolved to cost_credit=0 for every item priced in that window, because get_pricing_timeline built each model from the shallow-merged on-chain elements only, with no fallback to the default.

Deep-merge each on-chain product type onto DEFAULT_PRICE_AGGREGATE so unset leaves (e.g. INSTANCE.price.compute_unit.credit = 14250) fall back to the default instead of zeroing. On-chain values still win where present, and product types never priced on chain stay absent (timeline semantics unchanged). The shallow aggregate-merge semantics themselves are untouched.

Adds a regression test asserting a gap-window INSTANCE compute_unit with no credit inherits the default 14250 while its on-chain payg/holding win.