### PR TITLE
fix(vprogram): check store dependencies of V-PROGRAM messages at processing time

### DIFF
--- a/src/aleph/handlers/content/vprogram.py
+++ b/src/aleph/handlers/content/vprogram.py
@@ -3,6 +3,7 @@ from typing import List, Set
 
 from aleph_message.models import PaymentType, VerifiableProgramContent
 
+from aleph.db.accessors.files import find_file_pins
 from aleph.db.accessors.vms import delete_vm
 from aleph.db.models import MessageDb, VProgramDb, VProgramVerifiedVolumeDb
 from aleph.db.models.account_costs import AccountCostsDb
@@ -11,7 +12,11 @@ from aleph.services.cost import get_payment_type, get_total_and_detailed_costs
 from aleph.services.cost_validation import validate_balance_for_payment
 from aleph.toolkit.timestamp import timestamp_to_datetime
 from aleph.types.db_session import DbSession
-from aleph.types.message_status import InvalidMessageFormat, InvalidPaymentMethod
+from aleph.types.message_status import (
+    InvalidMessageFormat,
+    InvalidPaymentMethod,
+    VmVolumeNotFound,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -105,6 +110,25 @@ class VProgramMessageHandler(ContentHandler):
     forget handler's dependent-volumes check. Measurement validation and
     CRN dispatch are later phases.
     """
+
+    async def check_dependencies(self, session: DbSession, message: MessageDb) -> None:
+        content = _get_vprogram_content(message)
+
+        # All V-Program references are direct store item hashes (there is no
+        # use_latest / file tag mechanism for measured content), so checking
+        # the file pins is enough.
+        refs = {
+            str(content.runtime.ref),
+            str(content.workload.ref),
+            str(content.workload.hash_tree),
+        }
+        for volume in content.volumes:
+            refs.add(str(volume.ref))
+            refs.add(str(volume.hash_tree))
+
+        missing_refs = refs - set(find_file_pins(session=session, item_hashes=refs))
+        if missing_refs:
+            raise VmVolumeNotFound(sorted(missing_refs))
 
     async def check_balance(
         self, session: DbSession, message: MessageDb

--- a/tests/api/test_vprogram_api.py
+++ b/tests/api/test_vprogram_api.py
@@ -5,10 +5,17 @@ import pytest
 from aleph_message.models import Chain, ItemType, MessageType
 from messages.test_vprogram import VPROGRAM_CONTENT, VPROGRAM_ITEM_HASH
 
-from aleph.db.models import AlephCreditBalanceDb, MessageStatusDb, PendingMessageDb
+from aleph.db.accessors.files import insert_message_file_pin
+from aleph.db.models import (
+    AlephCreditBalanceDb,
+    MessageStatusDb,
+    PendingMessageDb,
+    StoredFileDb,
+)
 from aleph.schemas.message_content import ContentSource, MessageContent
 from aleph.toolkit.timestamp import timestamp_to_datetime
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import DbSession, DbSessionFactory
+from aleph.types.files import FileType
 from aleph.types.message_status import ErrorCode, MessageStatus
 from aleph.web.controllers.app_state_getters import APP_STATE_STORAGE_SERVICE
 
@@ -55,6 +62,38 @@ def fixture_vprogram_message(session_factory: DbSessionFactory) -> PendingMessag
         )
         session.commit()
     return pending_message
+
+
+def insert_vprogram_refs(session: DbSession) -> None:
+    """
+    Insert the file pins referenced by the V-Program message so that the
+    dependency check passes at processing time.
+    """
+
+    refs = {
+        VPROGRAM_CONTENT["runtime"]["ref"],
+        VPROGRAM_CONTENT["workload"]["ref"],
+        VPROGRAM_CONTENT["workload"]["hash_tree"],
+    }
+    for volume in VPROGRAM_CONTENT["volumes"]:
+        refs.add(volume["ref"])
+        refs.add(volume["hash_tree"])
+
+    created = dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+
+    for ref in refs:
+        # The file hash just has to be a valid hash: use the reversed ref.
+        file_hash = ref[::-1]
+        session.add(StoredFileDb(hash=file_hash, size=1024 * 1024, type=FileType.FILE))
+        session.flush()
+        insert_message_file_pin(
+            session=session,
+            file_hash=file_hash,
+            owner=SENDER,
+            item_hash=ref,
+            ref=None,
+            created=created,
+        )
 
 
 @pytest.fixture
@@ -119,6 +158,10 @@ async def test_vprogram_message_price(
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
 ):
+    with session_factory() as session:
+        insert_vprogram_refs(session)
+        session.commit()
+
     pipeline = message_processor.make_pipeline()
     _ = [message async for message in pipeline]
 
@@ -139,6 +182,10 @@ async def test_vprogram_in_messages_list(
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
 ):
+    with session_factory() as session:
+        insert_vprogram_refs(session)
+        session.commit()
+
     pipeline = message_processor.make_pipeline()
     _ = [message async for message in pipeline]
 
@@ -201,7 +248,12 @@ async def test_vprogram_rejected_display(
     fixture_settings_aggregate_in_db,
 ):
     # No credit balance: processing rejects the message, and the rejected
-    # message is still visible through the single-message endpoint.
+    # message is still visible through the single-message endpoint. The refs
+    # are seeded so that the credit check is the one that rejects.
+    with session_factory() as session:
+        insert_vprogram_refs(session)
+        session.commit()
+
     pipeline = message_processor.make_pipeline()
     _ = [message async for message in pipeline]
 

--- a/tests/message_processing/test_process_vprograms.py
+++ b/tests/message_processing/test_process_vprograms.py
@@ -1,15 +1,23 @@
 import copy
 import datetime as dt
 import json
+from typing import List
 
 import pytest
-from aleph_message.models import Chain, ItemHash, ItemType, MessageType
+from aleph_message.models import (
+    Chain,
+    ItemHash,
+    ItemType,
+    MessageType,
+    VerifiableProgramContent,
+)
 from message_test_helpers import process_pending_messages
 from messages.test_vprogram import VPROGRAM_CONTENT, VPROGRAM_ITEM_HASH
 from more_itertools import one
 from sqlalchemy import func, select
 
 from aleph.db.accessors.cost import get_message_costs
+from aleph.db.accessors.files import find_file_pins, insert_message_file_pin
 from aleph.db.accessors.messages import (
     get_message_by_item_hash,
     get_message_status,
@@ -20,17 +28,60 @@ from aleph.db.models import (
     AlephCreditBalanceDb,
     MessageStatusDb,
     PendingMessageDb,
+    StoredFileDb,
     VProgramVerifiedVolumeDb,
 )
 from aleph.jobs.process_pending_messages import PendingMessageProcessor
 from aleph.schemas.api.messages import format_message
 from aleph.toolkit.timestamp import timestamp_to_datetime
-from aleph.types.db_session import DbSessionFactory
+from aleph.types.db_session import DbSession, DbSessionFactory
+from aleph.types.files import FileType
 from aleph.types.message_processing_result import ProcessedMessage, RejectedMessage
 from aleph.types.message_status import ErrorCode, MessageStatus
 from aleph.types.vms import VmType
 
 SENDER = "0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba"
+
+
+def get_vprogram_store_refs(content: VerifiableProgramContent) -> List[str]:
+    refs = [
+        str(content.runtime.ref),
+        str(content.workload.ref),
+        str(content.workload.hash_tree),
+    ]
+    for volume in content.volumes:
+        refs.append(str(volume.ref))
+        refs.append(str(volume.hash_tree))
+    return refs
+
+
+def insert_vprogram_refs(session: DbSession, message: PendingMessageDb):
+    """
+    Insert the file pins referenced by the V-Program to make it processable.
+    Refs that are already pinned (e.g. by a real STORE message) are skipped.
+    """
+
+    assert message.item_content
+    content = VerifiableProgramContent.model_validate_json(message.item_content)
+    refs = set(get_vprogram_store_refs(content))
+    refs -= set(find_file_pins(session=session, item_hashes=refs))
+
+    created = dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+
+    for ref in refs:
+        # As in the program tests, the file hash just has to be a valid hash:
+        # use the reversed ref.
+        file_hash = ref[::-1]
+        session.add(StoredFileDb(hash=file_hash, size=1024 * 1024, type=FileType.FILE))
+        session.flush()
+        insert_message_file_pin(
+            session=session,
+            file_hash=file_hash,
+            owner=content.address,
+            item_hash=ref,
+            ref=None,
+            created=created,
+        )
 
 
 @pytest.fixture
@@ -89,6 +140,10 @@ async def test_process_vprogram(
     fixture_product_prices_aggregate_in_db,
     fixture_settings_aggregate_in_db,
 ):
+    with session_factory() as session:
+        insert_vprogram_refs(session, fixture_vprogram_message)
+        session.commit()
+
     pipeline = message_processor.make_pipeline()
     _ = [message async for message in pipeline]
 
@@ -160,6 +215,10 @@ async def test_process_vprogram_insufficient_credit(
     fixture_settings_aggregate_in_db,
 ):
     # No credit balance is seeded: processing must reject the message.
+    with session_factory() as session:
+        insert_vprogram_refs(session, fixture_vprogram_message)
+        session.commit()
+
     pipeline = message_processor.make_pipeline()
     _ = [message async for message in pipeline]
 
@@ -175,6 +234,50 @@ async def test_process_vprogram_insufficient_credit(
         )
         assert rejected is not None
         assert rejected.error_code == ErrorCode.CREDIT_INSUFFICIENT
+
+
+@pytest.mark.asyncio
+async def test_process_vprogram_missing_refs(
+    session_factory: DbSessionFactory,
+    message_processor: PendingMessageProcessor,
+    fixture_vprogram_message: PendingMessageDb,
+    user_credit_balance,
+    fixture_product_prices_aggregate_in_db,
+    fixture_settings_aggregate_in_db,
+):
+    """A V-PROGRAM whose store references (runtime manifest, workload image
+    and hash tree, verified volumes and their hash trees) are unknown to the
+    node must not be processed, mirroring programs with missing volumes."""
+
+    # No refs are seeded: all five store references are missing.
+    pipeline = message_processor.make_pipeline()
+    _ = [message async for message in pipeline]
+
+    with session_factory() as session:
+        assert (
+            get_vprogram(session=session, item_hash=fixture_vprogram_message.item_hash)
+            is None
+        )
+
+        status = get_message_status(
+            session=session, item_hash=ItemHash(fixture_vprogram_message.item_hash)
+        )
+        assert status is not None
+        assert status.status == MessageStatus.REJECTED
+
+        rejected = get_rejected_message(
+            session=session, item_hash=fixture_vprogram_message.item_hash
+        )
+        assert rejected is not None
+        assert rejected.error_code == ErrorCode.VM_VOLUME_NOT_FOUND
+
+        assert fixture_vprogram_message.item_content
+        content = VerifiableProgramContent.model_validate_json(
+            fixture_vprogram_message.item_content
+        )
+        assert isinstance(rejected.details, dict)
+        assert set(rejected.details["errors"]) == set(get_vprogram_store_refs(content))
+        assert rejected.traceback is None
 
 
 def _pending_message(
@@ -259,6 +362,11 @@ async def test_forget_store_used_by_vprogram_is_blocked(
             )
         )
         assert isinstance(store_result, ProcessedMessage)
+
+        # The workload ref is pinned by the STORE message processed above;
+        # seed the other references (runtime, hash trees, volume) so the
+        # dependency check passes.
+        insert_vprogram_refs(session, vprogram_message)
 
         vprogram_result = one(
             await process_pending_messages(


### PR DESCRIPTION
## Problem

V-PROGRAM messages had no dependency existence check: `VProgramMessageHandler` did not override `check_dependencies`, and `find_missing_volumes` only branches on `ProgramContent` / `InstanceContent`. A V-Program referencing store files unknown to the node was processed successfully and then parked invisibly at the scheduler, whose hard lookup was the only guard.

This is the pyaleph phase-2 work item recorded in the #1222 review notes (the forget-protection half already landed there via `get_vms_dependent_volumes`).

## Fix

Add `check_dependencies` to `VProgramMessageHandler`. It checks the file pins for the five store references of the content:

- `runtime.ref` (runtime manifest)
- `workload.ref` and `workload.hash_tree`
- each verified volume's `ref` and `hash_tree`

V-Program references are direct store item hashes (there is no `use_latest` / file tag mechanism for measured content), so the pin check is sufficient. Missing refs raise `VmVolumeNotFound`, giving the same retry-then-reject behavior as programs with missing volumes (`VM_VOLUME_NOT_FOUND`).

Out of scope: the balance-removal/GC path not consulting `get_vms_dependent_volumes` for any executable type is a separate, pre-existing gap.

## Tests

- New `test_process_vprogram_missing_refs`: a V-Program with no seeded refs is rejected with `VM_VOLUME_NOT_FOUND` and the error details list all five missing refs (written first, watched fail against main).
- Existing processing and API tests now seed the referenced file pins (mirroring `insert_volume_refs` in the program tests) so they still exercise their original paths (processing, cost persistence, credit rejection, forget blocking).
- `tests/message_processing/`, `tests/api/test_vprogram_api.py`, `tests/db/test_vprograms_db.py`, `tests/services/test_cost_service_vprogram.py`, `tests/test_repair.py`, `tests/jobs/test_check_removing_messages.py`: all passing.