### PR TITLE
chore(ipfs): bump kubo to v0.43.0 for CVE fixes

### DIFF
--- a/deployment/docker-build/dev/docker-compose.yml
+++ b/deployment/docker-build/dev/docker-compose.yml
@@ -115,7 +115,7 @@ services:
 
   ipfs:
     restart: always
-    image: ipfs/kubo:v0.37.0
+    image: ipfs/kubo:v0.43.0
     ports:
       - "4001:4001"
       - "4001:4001/udp"

--- a/deployment/docker-build/dev/kubo.json
+++ b/deployment/docker-build/dev/kubo.json
@@ -2,7 +2,7 @@
   "AutoNAT": {
     "ServiceMode": "enabled"
   },
-  "Reprovider": {
+  "Provide": {
     "Strategy": "pinned"
   },
   "Routing": {

--- a/deployment/docker-build/docker-compose.yml
+++ b/deployment/docker-build/docker-compose.yml
@@ -44,7 +44,7 @@ services:
 
   ipfs:
     restart: always
-    image: ipfs/kubo:v0.37.0
+    image: ipfs/kubo:v0.43.0
     ports:
       - "4001:4001"
       - "4001:4001/udp"

--- a/deployment/docker-build/kubo.json
+++ b/deployment/docker-build/kubo.json
@@ -2,7 +2,7 @@
   "AutoNAT": {
     "ServiceMode": "enabled"
   },
-  "Reprovider": {
+  "Provide": {
     "Strategy": "pinned"
   },
   "Routing": {

--- a/deployment/docker-build/test/kubo.json
+++ b/deployment/docker-build/test/kubo.json
@@ -2,7 +2,7 @@
   "AutoNAT": {
     "ServiceMode": "enabled"
   },
-  "Reprovider": {
+  "Provide": {
     "Strategy": "pinned"
   },
   "Routing": {

--- a/deployment/samples/docker-compose/docker-compose.yml
+++ b/deployment/samples/docker-compose/docker-compose.yml
@@ -103,7 +103,7 @@ services:
 
   ipfs:
     restart: always
-    image: ipfs/kubo:v0.37.0
+    image: ipfs/kubo:v0.43.0
     ports:
       - "4001:4001"
       - "4001:4001/udp"

--- a/deployment/samples/docker-monitoring/docker-compose.yml
+++ b/deployment/samples/docker-monitoring/docker-compose.yml
@@ -105,7 +105,7 @@ services:
 
   ipfs:
     restart: always
-    image: ipfs/kubo:v0.37.0
+    image: ipfs/kubo:v0.43.0
     ports:
       - "4001:4001"
       - "4001:4001/udp"

--- a/deployment/scripts/001-update-ipfs-config.sh
+++ b/deployment/scripts/001-update-ipfs-config.sh
@@ -14,7 +14,7 @@ echo "Updating IPFS config file..."
 ipfs config AutoNAT.ServiceMode 'enabled'
 
 # Only announce recursively pinned CIDs
-ipfs config Reprovider.Strategy 'pinned'
+ipfs config Provide.Strategy 'pinned'
 
 # ONLY use the Amino DHT (no HTTP routers).
 ipfs config Routing.Type "dhtserver"


### PR DESCRIPTION
Bumps the Kubo (IPFS) image from `v0.37.0` to `v0.43.0` in all four docker-compose files.

## Why
v0.43.0 fixes security issues affecting CCNs:

- **CVE-2026-46679** — an unauthenticated peer can flood a node with pubsub topic subscriptions, disconnect, and leave the node holding that state; memory climbs until restart. Affects every pubsub-enabled node, which is all CCNs (pubsub is how messages propagate), so disabling pubsub is not an option.
- **CVE-2026-57497** — WebTransport memory leak on nodes listening on `/quic-v1/webtransport` (on by default).
- A routing-query race that could crash the daemon mid-response.

Also includes non-security fixes: `ipfs repo gc` no longer deadlocks MFS, bitswap no longer stalls on a just-reconnected peer, lower memory during DHT reprovides, and immediate relay retry.

## Files
- `deployment/docker-build/docker-compose.yml`
- `deployment/docker-build/dev/docker-compose.yml`
- `deployment/samples/docker-compose/docker-compose.yml`
- `deployment/samples/docker-monitoring/docker-compose.yml`

## Operator note (not in these files)
v0.43.0 refuses to start if `Ipns.RecordLifetime` < `Ipns.RepublishPeriod`. That config lives in each node's IPFS volume, not in compose, so operators should check before restarting:

```
ipfs config Ipns.RecordLifetime
ipfs config Ipns.RepublishPeriod
```

The first start after upgrading also runs a one-off background datastore scan (normal, does not block startup).

Release notes: https://github.com/ipfs/kubo/releases/tag/v0.43.0