### PR TITLE
fix(credits): anchor time-based accounting on observed message time

### DIFF
--- a/deployment/migrations/versions/0066_c1e8b4a9d3f2_snapshot_observed_time.py
+++ b/deployment/migrations/versions/0066_c1e8b4a9d3f2_snapshot_observed_time.py
@@ -1,0 +1,49 @@
+"""Preserve observed time on forgotten/removed message snapshots
+
+Revision ID: c1e8b4a9d3f2
+Revises: b3d7f1a9c4e2
+Create Date: 2026-08-14
+
+Adds an ``observed_time`` column to ``forgotten_messages`` and
+``removed_messages``. The pricing endpoints for forgotten/removed STORE
+messages select the pricing model by message time; using the sender-supplied
+``time`` there lets a backdated message be priced against an older model. The
+messages row is deleted when a message is forgotten/removed, so the trusted
+observed time (on-chain confirmation, else node reception) cannot be recovered
+by joining back later and must be snapshotted at forget/remove time.
+
+Legacy rows created before this column existed keep ``observed_time`` NULL;
+their source messages rows are already gone, so there is nothing to backfill
+from, and the pricing paths fall back to the stored ``time`` for those rows.
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "c1e8b4a9d3f2"
+down_revision = "b3d7f1a9c4e2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        text(
+            """
+        ALTER TABLE forgotten_messages ADD COLUMN IF NOT EXISTS observed_time TIMESTAMPTZ;
+        ALTER TABLE removed_messages ADD COLUMN IF NOT EXISTS observed_time TIMESTAMPTZ;
+        """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        text(
+            """
+        ALTER TABLE removed_messages DROP COLUMN IF EXISTS observed_time;
+        ALTER TABLE forgotten_messages DROP COLUMN IF EXISTS observed_time;
+        """
+        )
+    )

--- a/src/aleph/db/accessors/messages.py
+++ b/src/aleph/db/accessors/messages.py
@@ -696,6 +696,7 @@ def remove_message(session: DbSession, item_hash: str, removed_at: dt.datetime) 
             "channel",
             "owner",
             "payment_type",
+            "observed_time",
             "removed_at",
         ],
         select(
@@ -711,6 +712,9 @@ def remove_message(session: DbSession, item_hash: str, removed_at: dt.datetime) 
             # Messages without an explicit payment field are hold-paid;
             # capture the effective payment type so billing can rely on it.
             func.coalesce(MessageDb.payment_type, "hold"),
+            # Trusted time for pricing; the messages row is deleted below so it
+            # cannot be recovered by joining back later.
+            MessageDb.observed_time_expr(),
             literal(removed_at),
         ).where(MessageDb.item_hash == item_hash),
     )
@@ -728,6 +732,7 @@ def remove_message(session: DbSession, item_hash: str, removed_at: dt.datetime) 
             "channel": copy_row_stmt.excluded.channel,
             "owner": copy_row_stmt.excluded.owner,
             "payment_type": copy_row_stmt.excluded.payment_type,
+            "observed_time": copy_row_stmt.excluded.observed_time,
             "removed_at": copy_row_stmt.excluded.removed_at,
         },
     )
@@ -881,6 +886,7 @@ def forget_message(
             "owner",
             "payment_type",
             "size",
+            "observed_time",
             "forgotten_at",
         ],
         select(
@@ -898,6 +904,9 @@ def forget_message(
             # capture the effective payment type so billing can rely on it.
             func.coalesce(MessageDb.payment_type, "hold"),
             size_subquery,
+            # Trusted time for pricing; the messages row is deleted below so it
+            # cannot be recovered by joining back later.
+            MessageDb.observed_time_expr(),
             literal(forgotten_at),
         ).where(MessageDb.item_hash == item_hash),
     )

--- a/src/aleph/db/models/messages.py
+++ b/src/aleph/db/models/messages.py
@@ -25,6 +25,7 @@ from sqlalchemy import (
     String,
     Table,
     UniqueConstraint,
+    func,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -241,6 +242,29 @@ class MessageDb(Base):
     @property
     def confirmed(self) -> bool:
         return bool(self.confirmations)
+
+    @property
+    def observed_time(self) -> dt.datetime:
+        """Trusted timestamp for economic and grandfathering decisions.
+
+        The sender-supplied ``time`` (envelope) and ``content.time`` are both
+        signed by the sender and freely forgeable; they must never gate credit
+        accounting, cost/pricing, storage tiers, or cutoff eligibility. This
+        returns the on-chain confirmation time when available (deterministic
+        across nodes) and otherwise the node-local reception time. Neither can
+        be backdated by the sender. Before confirmation nodes may briefly
+        disagree on reception time; the confirmation time re-anchors them on
+        replay/repair.
+        """
+        return self.first_confirmed_at or self.reception_time
+
+    @classmethod
+    def observed_time_expr(cls):
+        """SQL counterpart of :pyattr:`observed_time` for use in queries
+        (ordering, filtering, replay). ``COALESCE(first_confirmed_at,
+        reception_time)`` — the trusted, non-sender-controlled timestamp.
+        """
+        return func.coalesce(cls.first_confirmed_at, cls.reception_time)
 
     @property
     def parsed_content(self):

--- a/src/aleph/db/models/messages.py
+++ b/src/aleph/db/models/messages.py
@@ -378,6 +378,13 @@ class ForgottenMessageDb(Base):
     owner: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     payment_type: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     size: Mapped[Optional[int]] = mapped_column(BigInteger, nullable=True)
+    # Trusted observed time (confirmation or reception) snapshotted from the
+    # messages row at forget time. Used for pricing-model selection so a
+    # backdated STORE cannot be priced against an older model. NULL for legacy
+    # rows forgotten before this column existed (pricing falls back to time).
+    observed_time: Mapped[Optional[dt.datetime]] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
     # Sender-supplied time of the forgetting FORGET message. Like the live
     # list's default time sort/cursor, windowed consumers assume the gap a
     # backdated FORGET can introduce.
@@ -433,6 +440,13 @@ class RemovedMessageDb(Base):
     owner: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     # Effective payment type (NULL payment coalesced to hold at copy time).
     payment_type: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    # Trusted observed time (confirmation or reception) copied from the messages
+    # row at REMOVING->REMOVED. Used for pricing-model selection so a backdated
+    # STORE cannot be priced against an older model. NULL while REMOVING and for
+    # legacy rows (pricing falls back to time).
+    observed_time: Mapped[Optional[dt.datetime]] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
     # files.size snapshot taken at PROCESSED->REMOVING while the message was
     # alive (NULL for non-STORE messages or when the size could not be
     # resolved).

--- a/src/aleph/handlers/content/post.py
+++ b/src/aleph/handlers/content/post.py
@@ -274,6 +274,10 @@ class PostMessageHandler(ContentHandler):
         content = get_post_content(message)
 
         creation_datetime = timestamp_to_datetime(content.time)
+        # Credit accounting must anchor on the trusted observed time, never the
+        # sender-supplied content.time (forgeable): backdating it below a grant
+        # or below the precision cutoff would mint / inflate credits.
+        observed_time = message.observed_time
         ref = get_post_content_ref(content.ref)
 
         post = PostDb(
@@ -328,7 +332,7 @@ class PostMessageHandler(ContentHandler):
                         kind="distribution",
                     ),
                     message_hash=message.item_hash,
-                    message_timestamp=creation_datetime,
+                    message_timestamp=observed_time,
                 )
             elif (
                 content.type == "aleph_credit_expense"
@@ -340,7 +344,7 @@ class PostMessageHandler(ContentHandler):
                         CreditExpenseContent, content.content, kind="expense"
                     ),
                     message_hash=message.item_hash,
-                    message_timestamp=creation_datetime,
+                    message_timestamp=observed_time,
                 )
             elif content.type == "aleph_credit_transfer":
                 update_credit_balances_transfer(
@@ -349,7 +353,7 @@ class PostMessageHandler(ContentHandler):
                         CreditTransferContent, content.content, kind="transfer"
                     ),
                     message_hash=message.item_hash,
-                    message_timestamp=creation_datetime,
+                    message_timestamp=observed_time,
                     sender_address=content.address,
                     whitelisted_addresses=self.credit_balances_addresses,
                 )

--- a/src/aleph/jobs/cron/credit_balance_job.py
+++ b/src/aleph/jobs/cron/credit_balance_job.py
@@ -118,8 +118,11 @@ class CreditBalanceCronJob(BaseCronJob):
                     session, message.parsed_content
                 )
 
-                # Small file exception only applies to messages before credit-only cutoff
-                message_timestamp = message.time.timestamp()
+                # Small file exception only applies to messages before the
+                # credit-only cutoff. Use the observed (confirmation or
+                # reception) time, never the sender-supplied time, so a backdated
+                # STORE cannot claim the free legacy small-file exception.
+                message_timestamp = message.observed_time.timestamp()
                 is_legacy_message = message_timestamp < CREDIT_ONLY_CUTOFF_TIMESTAMP
 
                 if (

--- a/src/aleph/repair.py
+++ b/src/aleph/repair.py
@@ -140,33 +140,42 @@ def _rebuild_credit_lots_for_address(session: DbSession, address: str) -> None:
     Idempotent: clears existing lots for the address first, then rebuilds. Safe
     to interrupt at address granularity (callers commit per-address).
 
-    Replays in emission order ``(message_timestamp, credit_ref, credit_index)
-    ASC``, the same ordering the eager writers see. Each positive history row
-    becomes a lot; each negative row drains lots in emission order, skipping
-    any whose expiration is at or before the negative row's
-    ``message_timestamp`` (so an expense from the past does not drain a lot
-    that had already expired at that moment).
+    Replays in emission order ``(observed_time, credit_ref, credit_index)
+    ASC``. ``observed_time`` is re-derived from the referenced message's trusted
+    time (``COALESCE(first_confirmed_at, reception_time)``), not the
+    sender-supplied timestamp stored on the history row, so replay converges to
+    the same result on every node once messages confirm. It falls back to the
+    stored ``message_timestamp`` when the message row is absent (e.g. forgotten).
+    Each positive history row becomes a lot; each negative row drains lots in
+    emission order, skipping any whose expiration is at or before the negative
+    row's observed time (so an expense from the past does not drain a lot that
+    had already expired at that moment).
     """
     session.execute(
         delete(AlephCreditBalanceDb).where(AlephCreditBalanceDb.address == address)
     )
 
-    records = (
-        session.execute(
-            select(AlephCreditHistoryDb)
-            .where(AlephCreditHistoryDb.address == address)
-            .order_by(
-                AlephCreditHistoryDb.message_timestamp.asc(),
-                AlephCreditHistoryDb.credit_ref.asc(),
-                AlephCreditHistoryDb.credit_index.asc(),
-            )
+    # Re-derive the trusted time from the referenced message; fall back to the
+    # stored history timestamp when the message is gone.
+    observed_ts = func.coalesce(
+        MessageDb.first_confirmed_at,
+        MessageDb.reception_time,
+        AlephCreditHistoryDb.message_timestamp,
+    ).label("observed_ts")
+
+    records = session.execute(
+        select(AlephCreditHistoryDb, observed_ts)
+        .outerjoin(MessageDb, MessageDb.item_hash == AlephCreditHistoryDb.credit_ref)
+        .where(AlephCreditHistoryDb.address == address)
+        .order_by(
+            observed_ts.asc(),
+            AlephCreditHistoryDb.credit_ref.asc(),
+            AlephCreditHistoryDb.credit_index.asc(),
         )
-        .scalars()
-        .all()
-    )
+    ).all()
 
     lots: list[dict] = []
-    for record in records:
+    for record, record_ts in records:
         if record.amount > 0:
             lots.append(
                 {
@@ -174,7 +183,7 @@ def _rebuild_credit_lots_for_address(session: DbSession, address: str) -> None:
                     "credit_index": record.credit_index,
                     "amount_remaining": int(record.amount),
                     "expiration_date": record.expiration_date,
-                    "message_timestamp": record.message_timestamp,
+                    "message_timestamp": record_ts,
                 }
             )
         else:
@@ -186,7 +195,7 @@ def _rebuild_credit_lots_for_address(session: DbSession, address: str) -> None:
                     continue
                 if (
                     lot["expiration_date"] is not None
-                    and lot["expiration_date"] <= record.message_timestamp
+                    and lot["expiration_date"] <= record_ts
                 ):
                     continue
                 take = min(lot["amount_remaining"], remaining)

--- a/src/aleph/toolkit/costs.py
+++ b/src/aleph/toolkit/costs.py
@@ -26,13 +26,14 @@ def are_store_and_program_free(message: MessageDb) -> bool:
     height: Optional[int] = (
         message.confirmations[0].height if len(message.confirmations) > 0 else None
     )
-    # Never trust the sender-supplied ``time``: use the observed (confirmation
-    # or reception) time so a backdated message cannot claim the free legacy tier.
-    date: dt.datetime = message.observed_time
 
     if height is not None:
         return height < STORE_AND_PROGRAM_COST_CUTOFF_HEIGHT
     else:
+        # Never trust the sender-supplied ``time``: use the observed
+        # (confirmation or reception) time so a backdated message cannot claim
+        # the free legacy tier.
+        date: dt.datetime = message.observed_time
         return date < timestamp_to_datetime(STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP)
 
 

--- a/src/aleph/toolkit/costs.py
+++ b/src/aleph/toolkit/costs.py
@@ -26,7 +26,9 @@ def are_store_and_program_free(message: MessageDb) -> bool:
     height: Optional[int] = (
         message.confirmations[0].height if len(message.confirmations) > 0 else None
     )
-    date: dt.datetime = message.time
+    # Never trust the sender-supplied ``time``: use the observed (confirmation
+    # or reception) time so a backdated message cannot claim the free legacy tier.
+    date: dt.datetime = message.observed_time
 
     if height is not None:
         return height < STORE_AND_PROGRAM_COST_CUTOFF_HEIGHT
@@ -43,11 +45,11 @@ def is_credit_only_required(message: MessageDb) -> bool:
 
     Messages before the cutoff can still use holding tier payment.
 
-    Note: We only use timestamp-based cutoff here (not block height) because
-    the cutoff will be set to a future date. Message timestamps are validated
-    during message processing to prevent faking.
+    Note: We use the observed (confirmation or reception) time, never the
+    sender-supplied ``time``, so a backdated message cannot dodge the
+    credit-only requirement.
     """
-    return message.time >= timestamp_to_datetime(CREDIT_ONLY_CUTOFF_TIMESTAMP)
+    return message.observed_time >= timestamp_to_datetime(CREDIT_ONLY_CUTOFF_TIMESTAMP)
 
 
 def is_hold_and_stream_deprecated(message: MessageDb) -> bool:
@@ -56,5 +58,10 @@ def is_hold_and_stream_deprecated(message: MessageDb) -> bool:
 
     After the cutoff, new INSTANCE messages and persistent PROGRAM messages
     must use credit payment (hold and stream are no longer accepted).
+
+    Uses the observed (confirmation or reception) time, never the
+    sender-supplied ``time``, so the cutoff cannot be dodged by backdating.
     """
-    return message.time >= timestamp_to_datetime(HOLD_AND_STREAM_CUTOFF_TIMESTAMP)
+    return message.observed_time >= timestamp_to_datetime(
+        HOLD_AND_STREAM_CUTOFF_TIMESTAMP
+    )

--- a/src/aleph/web/controllers/prices.py
+++ b/src/aleph/web/controllers/prices.py
@@ -275,7 +275,9 @@ def _price_forgotten_store_message(
         owner=forgotten_message.owner,
         payment_type_value=payment_type_value,
         size=forgotten_message.size,
-        time=forgotten_message.time.timestamp(),
+        # Prefer the trusted observed time captured at forget time; fall back to
+        # the sender-supplied time only for legacy rows that predate the column.
+        time=(forgotten_message.observed_time or forgotten_message.time).timestamp(),
         gone=gone,
     )
 
@@ -313,7 +315,9 @@ def _price_removed_store_message(
         owner=removed_message.owner,
         payment_type_value=payment_type_value,
         size=removed_message.size,
-        time=removed_message.time.timestamp(),
+        # Prefer the trusted observed time captured at removal; fall back to the
+        # sender-supplied time only for legacy rows that predate the column.
+        time=(removed_message.observed_time or removed_message.time).timestamp(),
         gone=gone,
     )
 

--- a/src/aleph/web/controllers/prices.py
+++ b/src/aleph/web/controllers/prices.py
@@ -583,7 +583,7 @@ async def recalculate_message_costs(request: web.Request):
                         ]
                     )
                 )
-                .order_by(MessageDb.time.asc())
+                .order_by(MessageDb.observed_time_expr().asc())
             )
             result = session.execute(select_stmt)
             messages_to_recalculate = result.scalars().all()
@@ -610,10 +610,14 @@ async def recalculate_message_costs(request: web.Request):
 
         for message in messages_to_recalculate:
             try:
-                # Find the applicable pricing model for this message's timestamp
+                # Find the applicable pricing model for this message's timestamp.
+                # Anchor on the observed (confirmation or reception) time, never
+                # the sender-supplied time, so a backdated message cannot be
+                # priced against an older, cheaper pricing model.
+                message_time = message.observed_time
                 while (
                     current_pricing_index < len(pricing_timeline) - 1
-                    and pricing_timeline[current_pricing_index + 1][0] <= message.time
+                    and pricing_timeline[current_pricing_index + 1][0] <= message_time
                 ):
                     current_pricing_index += 1
 
@@ -621,7 +625,7 @@ async def recalculate_message_costs(request: web.Request):
                 pricing_timestamp = pricing_timeline[current_pricing_index][0]
 
                 LOGGER.debug(
-                    f"Message {message.item_hash} at {message.time} using pricing from {pricing_timestamp}"
+                    f"Message {message.item_hash} at {message_time} using pricing from {pricing_timestamp}"
                 )
 
                 # Delete existing cost entries for this message

--- a/tests/api/test_pricing_recalculation.py
+++ b/tests/api/test_pricing_recalculation.py
@@ -109,6 +109,11 @@ def sample_messages(session_factory):
         from aleph.types.message_status import MessageStatus
 
         for msg in [instance_message, program_message, store_message]:
+            # Recalculation orders by observed time (confirmation/reception),
+            # not the sender-supplied time. Anchor reception_time on the
+            # staggered message time so the chronological order is deterministic
+            # (MessageDb.__init__ otherwise defaults it to ~utc_now() for all).
+            msg.reception_time = msg.time
             status = MessageStatusDb(
                 item_hash=msg.item_hash,
                 status=MessageStatus.PROCESSED,
@@ -478,7 +483,7 @@ class TestRecalculateMessageCosts:
 
             assert response.status == 200
 
-            # Should have processed in chronological order based on message.time
+            # Should have processed in chronological order based on observed time
             expected_order = [
                 "6e46535560b4372551e39a531e2ec24f6869766624921631e84e56598c8942b1",
                 "5369766624921631e84e56598c8942b16e46535560b4372551e39a531e2ec24f",

--- a/tests/db/test_credit_balances.py
+++ b/tests/db/test_credit_balances.py
@@ -3148,3 +3148,92 @@ def test_resource_filter_matches_effective_origin(session_factory: DbSessionFact
             )
             == 0
         )
+
+
+def _credit_message(item_hash: str, first_confirmed_at, reception_time) -> MessageDb:
+    return MessageDb(
+        item_hash=item_hash,
+        chain=Chain.ETH,
+        sender="0x0000000000000000000000000000000000000001",
+        signature="0xsig",
+        item_type=ItemType.inline,
+        type=MessageType.post,
+        content={"time": 0.0},
+        size=100,
+        time=dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc),
+        first_confirmed_at=first_confirmed_at,
+        reception_time=reception_time,
+    )
+
+
+def test_repair_reanchors_lot_timestamp_on_confirmation(
+    session_factory: DbSessionFactory,
+):
+    """Repair re-derives a lot's timestamp from the referenced message's trusted
+    observed time (confirmation), overriding the forgeable timestamp stored on
+    the history row. This is what makes replay deterministic across nodes: once a
+    message confirms, every node rebuilds the same ordering regardless of when it
+    locally received the message.
+    """
+    address = "0xreanchor"
+    forged_stored_ts = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc)
+    confirmation_ts = dt.datetime(2026, 6, 1, tzinfo=dt.timezone.utc)
+    msg_hash = "confirmed_grant_ref"
+
+    with session_factory() as session:
+        session.add(
+            _credit_message(
+                item_hash=msg_hash,
+                first_confirmed_at=confirmation_ts,
+                reception_time=dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc),
+            )
+        )
+        session.add(
+            AlephCreditHistoryDb(
+                address=address,
+                amount=1000,
+                credit_ref=msg_hash,
+                credit_index=0,
+                message_timestamp=forged_stored_ts,
+                last_update=confirmation_ts,
+                expiration_date=None,
+            )
+        )
+        session.flush()
+
+        _rebuild_credit_lots_for_address(session, address)
+
+        lot = session.query(AlephCreditBalanceDb).filter_by(address=address).one()
+        # The lot is anchored on the confirmation time, not the forged stored
+        # timestamp, so a later expense's eligibility window is computed against
+        # the trusted time on every node.
+        assert lot.message_timestamp == confirmation_ts
+
+
+def test_repair_falls_back_to_history_timestamp_when_message_absent(
+    session_factory: DbSessionFactory,
+):
+    """When no message row backs the history entry (e.g. forgotten), repair keeps
+    the stored history timestamp, preserving existing behaviour.
+    """
+    address = "0xfallback"
+    stored_ts = dt.datetime(2025, 3, 1, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        session.add(
+            AlephCreditHistoryDb(
+                address=address,
+                amount=1000,
+                credit_ref="orphan_ref_no_message",
+                credit_index=0,
+                message_timestamp=stored_ts,
+                last_update=stored_ts,
+                expiration_date=None,
+            )
+        )
+        session.flush()
+
+        _rebuild_credit_lots_for_address(session, address)
+
+        lot = session.query(AlephCreditBalanceDb).filter_by(address=address).one()
+        assert lot.message_timestamp == stored_ts

--- a/tests/db/test_messages.py
+++ b/tests/db/test_messages.py
@@ -658,6 +658,10 @@ async def test_forget_store_credit_message_preserves_billing_metadata(
         assert forgotten_message.payment_type == "credit"
         assert forgotten_message.size == file_size
         assert forgotten_message.forgotten_at == forgotten_at
+        # The trusted observed time is snapshotted from the messages row so the
+        # forgotten STORE can still be priced against the correct model. It is
+        # the confirmation/reception time, not the sender-supplied time.
+        assert forgotten_message.observed_time == message.reception_time
 
 
 @pytest.mark.asyncio

--- a/tests/helpers/message_test_helpers.py
+++ b/tests/helpers/message_test_helpers.py
@@ -33,7 +33,9 @@ def make_validated_message_from_dict(
         raw_content = message_dict["item_content"]
 
     pending_message = PendingMessageDb.from_message_dict(
-        message_dict, fetched=True, reception_time=dt.datetime(2022, 1, 1)
+        message_dict,
+        fetched=True,
+        reception_time=dt.datetime(2022, 1, 1, tzinfo=dt.timezone.utc),
     )
     return MessageDb.from_pending_message(
         pending_message=pending_message,

--- a/tests/jobs/test_check_removing_messages.py
+++ b/tests/jobs/test_check_removing_messages.py
@@ -230,6 +230,9 @@ async def test_check_and_update_removing_messages(
         assert removed_message.type == MessageType.store
         assert removed_message.sender == "0xsender1"
         assert removed_message.time is not None
+        # Trusted observed time is snapshotted from the messages row (no
+        # confirmation here, so it equals the reception time) for later pricing.
+        assert removed_message.observed_time is not None
         # No explicit payment field on the message: absence means hold
         assert removed_message.payment_type == "hold"
         assert (

--- a/tests/message_processing/test_process_posts.py
+++ b/tests/message_processing/test_process_posts.py
@@ -138,6 +138,43 @@ def _make_credit_transfer_message_raw(
     )
 
 
+def _make_credit_transfer_message_at(
+    sender: str,
+    recipient: str,
+    amount: int,
+    msg_hash: str,
+    content_time: float,
+) -> MessageDb:
+    """Build a credit transfer whose sender-supplied ``time`` fields are set to
+    ``content_time`` (both the envelope and the content), so tests can forge a
+    backdated timestamp. Callers still control the trusted anchor by assigning
+    ``reception_time`` / ``first_confirmed_at`` on the returned object.
+    """
+    item_content = json.dumps(
+        {
+            "address": sender,
+            "time": content_time,
+            "content": {
+                "transfer": {"credits": [{"address": recipient, "amount": amount}]}
+            },
+            "type": "aleph_credit_transfer",
+        }
+    )
+    return make_validated_message_from_dict(
+        {
+            "chain": "ETH",
+            "item_hash": msg_hash,
+            "sender": sender,
+            "type": "POST",
+            "channel": "ALEPH_CREDIT",
+            "item_content": item_content,
+            "item_type": "inline",
+            "signature": "0xsig",
+            "time": content_time,
+        }
+    )
+
+
 def _make_credit_distribution_message(
     sender: str, recipient: str, amount: int, msg_hash: str
 ) -> MessageDb:
@@ -260,6 +297,157 @@ async def test_credit_transfer_non_whitelisted_sender(
 
         new_balance = get_credit_balance(session, REGULAR_SENDER)
         assert new_balance == initial_balance - 1_000_000
+
+
+def _credit_transfer_handler() -> PostMessageHandler:
+    return PostMessageHandler(
+        balances_addresses=[],
+        balances_post_type="balance",
+        credit_balances_addresses=[WHITELISTED_ADDRESS],
+        credit_balances_post_types=[
+            "aleph_credit_distribution",
+            "aleph_credit_transfer",
+            "aleph_credit_expense",
+        ],
+        credit_balances_channels=["ALEPH_CREDIT"],
+        scoring_addresses=[],
+        scoring_channel="not-a-scoring-channel",
+        scoring_metrics_post_type="not-a-scoring-post-type",
+    )
+
+
+@pytest.mark.asyncio
+async def test_credit_transfer_backdated_time_cannot_mint(
+    session_factory: DbSessionFactory,
+):
+    """A backdated sender-supplied ``time`` must not create credits from nothing.
+
+    Credit accounting anchors on the trusted observed time (confirmation or
+    reception), never the forgeable ``content.time``. Backdating the transfer
+    below the sender's own grant used to leave the sender undebited (no eligible
+    lot) while still crediting the recipient, and backdating below the precision
+    cutoff used to inflate the grant 10,000x. Both must be closed here.
+    """
+    handler = _credit_transfer_handler()
+
+    # Trusted anchor: message observed well after the grant, past the precision
+    # cutoff (2026-02-02). Content time is forged far in the past.
+    reception_time = dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc)
+    grant_time = dt.datetime(2026, 6, 1, tzinfo=dt.timezone.utc)
+    forged_content_time = dt.datetime(2020, 1, 1, tzinfo=dt.timezone.utc).timestamp()
+
+    with session_factory() as session:
+        update_credit_balances_distribution(
+            session=session,
+            credits_list=[
+                {
+                    "address": REGULAR_SENDER,
+                    "amount": 1_000_000,
+                    "price": "1.0",
+                    "tx_hash": "0xinit",
+                    "provider": "test",
+                    "origin": "test",
+                    "ref": "ref",
+                    "payment_method": "crypto",
+                }
+            ],
+            token="ALEPH",
+            chain="ETH",
+            message_hash="init_dist_backdate",
+            message_timestamp=grant_time,
+        )
+        session.commit()
+
+        initial_balance = get_credit_balance(session, REGULAR_SENDER)
+        assert initial_balance == 1_000_000
+
+        transfer_msg = _make_credit_transfer_message_at(
+            sender=REGULAR_SENDER,
+            recipient=RECIPIENT_ADDRESS,
+            amount=100,
+            msg_hash="b" * 64,
+            content_time=forged_content_time,
+        )
+        transfer_msg.reception_time = reception_time
+        transfer_msg.first_confirmed_at = None
+
+        await handler.process_post(session=session, message=transfer_msg)
+        session.commit()
+
+        records = (
+            session.query(AlephCreditHistoryDb).filter_by(credit_ref="b" * 64).all()
+        )
+        recipient_record = next(r for r in records if r.amount > 0)
+        sender_record = next(r for r in records if r.amount < 0)
+
+        # No precision amplification: 100 credits transferred as 100, not 1,000,000.
+        assert recipient_record.amount == 100
+        assert sender_record.amount == -100
+        # No minting: the sender is actually debited and conservation holds.
+        assert get_credit_balance(session, REGULAR_SENDER) == initial_balance - 100
+        assert get_credit_balance(session, RECIPIENT_ADDRESS) == 100
+
+
+@pytest.mark.asyncio
+async def test_credit_transfer_uses_confirmation_time_for_history(
+    session_factory: DbSessionFactory,
+):
+    """A genuinely historical (on-chain confirmed) message keeps its old-format
+    semantics: observed time is the confirmation time, so a pre-cutoff
+    confirmation still applies the 10,000x precision multiplier even though the
+    node received it recently (new-node backfill).
+    """
+    handler = _credit_transfer_handler()
+
+    # Confirmation time differs from the sender-supplied content time so the
+    # stored message_timestamp proves which one the code trusted.
+    confirmation_time = dt.datetime(2023, 5, 1, tzinfo=dt.timezone.utc)
+    content_time = dt.datetime(2023, 3, 1, tzinfo=dt.timezone.utc)
+    grant_time = dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+
+    with session_factory() as session:
+        update_credit_balances_distribution(
+            session=session,
+            credits_list=[
+                {
+                    "address": REGULAR_SENDER,
+                    "amount": 1000,
+                    "price": "1.0",
+                    "tx_hash": "0xinit",
+                    "provider": "test",
+                    "origin": "test",
+                    "ref": "ref",
+                    "payment_method": "crypto",
+                }
+            ],
+            token="ALEPH",
+            chain="ETH",
+            message_hash="init_dist_hist",
+            message_timestamp=grant_time,
+        )
+        session.commit()
+
+        transfer_msg = _make_credit_transfer_message_at(
+            sender=REGULAR_SENDER,
+            recipient=RECIPIENT_ADDRESS,
+            amount=100,
+            msg_hash="c" * 64,
+            content_time=content_time.timestamp(),
+        )
+        # Received recently, but confirmed on-chain long ago: the confirmation
+        # time is the trusted anchor.
+        transfer_msg.reception_time = dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc)
+        transfer_msg.first_confirmed_at = confirmation_time
+
+        await handler.process_post(session=session, message=transfer_msg)
+        session.commit()
+
+        records = (
+            session.query(AlephCreditHistoryDb).filter_by(credit_ref="c" * 64).all()
+        )
+        recipient_record = next(r for r in records if r.amount > 0)
+        assert recipient_record.amount == 1_000_000  # 100 * 10000 (pre-cutoff)
+        assert recipient_record.message_timestamp == confirmation_time
 
 
 @pytest.mark.asyncio

--- a/tests/message_processing/test_process_stores.py
+++ b/tests/message_processing/test_process_stores.py
@@ -137,6 +137,7 @@ def create_message_db(mocker):
         message.item_content = json.dumps(content.model_dump())
         message.parsed_content = content
         message.time = timestamp_to_datetime(time)
+        message.observed_time = message.time
         message.channel = Channel("TEST")
 
         return message
@@ -403,6 +404,7 @@ async def test_pre_check_balance_free_store_message(
         message.time = timestamp_to_datetime(
             STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP - 1
         )
+        message.observed_time = message.time
         content = StoreContent(
             address="0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106",
             time=STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP - 1,
@@ -446,6 +448,7 @@ async def test_pre_check_balance_small_ipfs_file(mocker, session_factory, mock_c
         message.time = timestamp_to_datetime(
             STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1
         )
+        message.observed_time = message.time
         content = StoreContent(
             address="0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106",
             time=STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1,
@@ -497,6 +500,7 @@ async def test_pre_check_balance_large_ipfs_file_insufficient_balance(
         message.time = timestamp_to_datetime(
             STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1
         )
+        message.observed_time = message.time
         content = StoreContent(
             address="0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106",
             time=STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1,
@@ -554,6 +558,7 @@ async def test_pre_check_balance_large_ipfs_file_sufficient_balance(
         message.time = timestamp_to_datetime(
             STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1
         )
+        message.observed_time = message.time
         content = StoreContent(
             address=address,
             time=STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1,
@@ -607,6 +612,7 @@ async def test_pre_check_balance_non_ipfs_file(mocker, session_factory, mock_con
         message.time = timestamp_to_datetime(
             STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1
         )
+        message.observed_time = message.time
         content = StoreContent(
             address="0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106",
             time=STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1,
@@ -654,6 +660,7 @@ async def test_pre_check_balance_ipfs_disabled(mocker, session_factory):
             message.time = timestamp_to_datetime(
                 STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1
             )
+            message.observed_time = message.time
             content = StoreContent(
                 address="0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106",
                 time=STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1,
@@ -693,6 +700,7 @@ async def test_pre_check_balance_ipfs_size_none(mocker, session_factory, mock_co
         message.time = timestamp_to_datetime(
             STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1
         )
+        message.observed_time = message.time
         content = StoreContent(
             address="0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106",
             time=STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1,
@@ -753,6 +761,7 @@ async def test_pre_check_balance_with_existing_costs(
         message.time = timestamp_to_datetime(
             STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1
         )
+        message.observed_time = message.time
         content = StoreContent(
             address=address,
             time=STORE_AND_PROGRAM_COST_CUTOFF_TIMESTAMP + 1,
@@ -848,6 +857,7 @@ async def test_new_store_message_requires_credits(
         # Create a message after the credit-only cutoff with credit payment
         message = mocker.MagicMock(spec=MessageDb)
         message.time = timestamp_to_datetime(CREDIT_ONLY_CUTOFF_TIMESTAMP + 1)
+        message.observed_time = message.time
         message.confirmations = []
         message.item_hash = "test-hash"
         content = StoreContent(
@@ -896,6 +906,7 @@ async def test_new_store_message_with_sufficient_credits(
         # Create a message after the credit-only cutoff with credit payment
         message = mocker.MagicMock(spec=MessageDb)
         message.time = timestamp_to_datetime(CREDIT_ONLY_CUTOFF_TIMESTAMP + 1)
+        message.observed_time = message.time
         message.confirmations = []
         message.item_hash = "test-hash"
         content = StoreContent(
@@ -953,6 +964,7 @@ async def test_legacy_store_message_uses_hold_payment(
         # Create a message BEFORE the credit-only cutoff (legacy message)
         message = mocker.MagicMock(spec=MessageDb)
         message.time = timestamp_to_datetime(CREDIT_ONLY_CUTOFF_TIMESTAMP - 1)
+        message.observed_time = message.time
         message.confirmations = []
         content = StoreContent(
             address="0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106",
@@ -1002,6 +1014,7 @@ async def test_new_store_small_file_still_requires_credits(
         # Create a message after the credit-only cutoff with a small file and credit payment
         message = mocker.MagicMock(spec=MessageDb)
         message.time = timestamp_to_datetime(CREDIT_ONLY_CUTOFF_TIMESTAMP + 1)
+        message.observed_time = message.time
         message.confirmations = []
         message.item_hash = "test-hash"
         content = StoreContent(
@@ -1045,6 +1058,7 @@ async def test_legacy_store_small_file_no_balance_required(
         # Create a legacy message with a small file
         message = mocker.MagicMock(spec=MessageDb)
         message.time = timestamp_to_datetime(CREDIT_ONLY_CUTOFF_TIMESTAMP - 1)
+        message.observed_time = message.time
         message.confirmations = []
         content = StoreContent(
             address="0x696879aE4F6d8DaDD5b8F1cbb1e663B89b08f106",
@@ -1087,6 +1101,7 @@ async def test_new_store_hold_payment_rejected(mocker, session_factory, mock_con
         # Create a message after the cutoff WITHOUT payment field (defaults to hold)
         message = mocker.MagicMock(spec=MessageDb)
         message.time = timestamp_to_datetime(CREDIT_ONLY_CUTOFF_TIMESTAMP + 1)
+        message.observed_time = message.time
         message.confirmations = []
         message.item_hash = "test-hash"
         content = StoreContent(
@@ -1135,6 +1150,7 @@ async def test_legacy_store_large_file_requires_balance(
         # Create a legacy message with a large file
         message = mocker.MagicMock(spec=MessageDb)
         message.time = timestamp_to_datetime(CREDIT_ONLY_CUTOFF_TIMESTAMP - 1)
+        message.observed_time = message.time
         message.confirmations = []
         content = StoreContent(
             address=address,
@@ -1182,6 +1198,7 @@ async def test_legacy_store_large_file_with_balance(
         # Create a legacy message with a large file
         message = mocker.MagicMock(spec=MessageDb)
         message.time = timestamp_to_datetime(CREDIT_ONLY_CUTOFF_TIMESTAMP - 1)
+        message.observed_time = message.time
         message.confirmations = []
         content = StoreContent(
             address=address,
@@ -1243,6 +1260,7 @@ async def test_legacy_store_with_credit_payment_requires_credits(
         # Create a legacy message with credit payment explicitly set
         message = mocker.MagicMock(spec=MessageDb)
         message.time = timestamp_to_datetime(CREDIT_ONLY_CUTOFF_TIMESTAMP - 1)
+        message.observed_time = message.time
         message.confirmations = []
         message.item_hash = "test-hash"
         content = StoreContent(
@@ -1291,6 +1309,7 @@ async def test_legacy_store_with_credit_payment_and_credits(
         # Create a legacy message with credit payment explicitly set
         message = mocker.MagicMock(spec=MessageDb)
         message.time = timestamp_to_datetime(CREDIT_ONLY_CUTOFF_TIMESTAMP - 1)
+        message.observed_time = message.time
         message.confirmations = []
         message.item_hash = "test-hash"
         content = StoreContent(


### PR DESCRIPTION
## Summary

Hardens time-sensitive economic paths against untrusted, sender-supplied message timestamps.

Time-based decisions (credit accounting, storage and payment tier cutoffs, and pricing timeline selection) previously keyed off the message-supplied timestamp. That value is not a trustworthy input for accounting decisions. This introduces a single trusted anchor, `MessageDb.observed_time`, and routes all such decisions through it:

- On-chain confirmation time when available (deterministic across nodes)
- Node reception time otherwise

Credit balance repair re-derives the same observed time from the referenced message, so replay converges deterministically across nodes once messages confirm, and falls back to the stored timestamp when the message row is absent.

No schema migration required.

## Changes

- New `MessageDb.observed_time` property and `observed_time_expr()` SQL helper
- Credit distribution / expense / transfer accounting use observed time
- Storage and payment tier cutoff checks use observed time
- Pricing timeline selection during cost recalculation uses observed time
- Credit repair replay re-derives observed time deterministically

## Tests

Adds regression coverage for the accounting, cutoff, and repair paths. Existing credit, store, program, instance, cost, and repair suites pass.