### PR TITLE
fix(cron): chunk + yield + cap balance/credit removal to stop event-loop stalls

### DIFF
--- a/src/aleph/db/accessors/balances.py
+++ b/src/aleph/db/accessors/balances.py
@@ -236,10 +236,13 @@ def update_balances(
 
 
 def get_updated_balance_accounts(session: DbSession, last_update: dt.datetime):
+    # Ordered so that a per-run cap in the balance cron defers accounts
+    # deterministically (fair resumption) rather than by scan order.
     select_stmt = (
         select(AlephBalanceDb.address)
         .where(AlephBalanceDb.last_update >= last_update)
         .distinct()
+        .order_by(AlephBalanceDb.address)
     )
     return (session.execute(select_stmt)).scalars().all()
 
@@ -564,10 +567,13 @@ def get_updated_credit_balance_accounts(session: DbSession, last_update: dt.date
     """
     Get addresses that have had their credit history updated since the given timestamp.
     """
+    # Ordered so that a per-run cap in the credit cron defers accounts
+    # deterministically (fair resumption) rather than by scan order.
     select_stmt = (
         select(AlephCreditHistoryDb.address)
         .where(AlephCreditHistoryDb.last_update >= last_update)
         .distinct()
+        .order_by(AlephCreditHistoryDb.address)
     )
     return session.execute(select_stmt).scalars().all()
 

--- a/src/aleph/jobs/cron/balance_job.py
+++ b/src/aleph/jobs/cron/balance_job.py
@@ -110,7 +110,7 @@ class BalanceCronJob(BaseCronJob):
                     if index % COMMIT_CHUNK == 0:
                         await asyncio.sleep(0)
 
-                if to_delete:
+                if budget > 0 and to_delete:
                     LOGGER.info(
                         f"'{len(to_delete)}' messages to delete for account '{address}'..."
                     )

--- a/src/aleph/jobs/cron/balance_job.py
+++ b/src/aleph/jobs/cron/balance_job.py
@@ -116,10 +116,12 @@ class BalanceCronJob(BaseCronJob):
                         await asyncio.sleep(0)
 
                 if to_delete:
+                    processing = min(len(to_delete), budget)
                     if len(to_delete) > budget:
                         deferred = True
                     LOGGER.info(
-                        f"'{len(to_delete)}' messages to delete for account '{address}'..."
+                        f"Deleting '{processing}' of '{len(to_delete)}' messages "
+                        f"for account '{address}'..."
                     )
                     budget -= await self.delete_messages(session, to_delete[:budget])
 
@@ -128,8 +130,10 @@ class BalanceCronJob(BaseCronJob):
                     if budget <= 0 or len(to_recover) > budget:
                         deferred = True
                     if budget > 0:
+                        processing = min(len(to_recover), budget)
                         LOGGER.info(
-                            f"'{len(to_recover)}' messages to recover for account '{address}'..."
+                            f"Recovering '{processing}' of '{len(to_recover)}' messages "
+                            f"for account '{address}'..."
                         )
                         budget -= await self.recover_messages(
                             session, to_recover[:budget]

--- a/src/aleph/jobs/cron/balance_job.py
+++ b/src/aleph/jobs/cron/balance_job.py
@@ -127,8 +127,12 @@ class BalanceCronJob(BaseCronJob):
     async def delete_messages(
         self, session: DbSession, messages: List[ItemHash]
     ) -> int:
-        """Return the number of messages attempted (including skipped no-ops),
-        used by the caller to decrement the per-run budget."""
+        """Return the number of messages attempted, used by the caller to
+        decrement the per-run budget. Skipped no-ops (missing message,
+        small-file exception, or a status guard that prevents the flip) count
+        on purpose: the budget bounds the number of delete/recover attempts —
+        each a DB round-trip — not only the flips that succeed, because
+        bounding per-tick work is what the cap exists to do."""
         for index, item_hash in enumerate(messages, start=1):
             message = get_message_by_item_hash(session, item_hash)
 
@@ -195,8 +199,12 @@ class BalanceCronJob(BaseCronJob):
     async def recover_messages(
         self, session: DbSession, messages: List[ItemHash]
     ) -> int:
-        """Return the number of messages attempted (including skipped no-ops),
-        used by the caller to decrement the per-run budget."""
+        """Return the number of messages attempted, used by the caller to
+        decrement the per-run budget. Skipped no-ops (missing message,
+        small-file exception, or a status guard that prevents the flip) count
+        on purpose: the budget bounds the number of delete/recover attempts —
+        each a DB round-trip — not only the flips that succeed, because
+        bounding per-tick work is what the cap exists to do."""
         for index, item_hash in enumerate(messages, start=1):
             message = get_message_by_item_hash(session, item_hash)
             if message is None:

--- a/src/aleph/jobs/cron/balance_job.py
+++ b/src/aleph/jobs/cron/balance_job.py
@@ -127,6 +127,8 @@ class BalanceCronJob(BaseCronJob):
     async def delete_messages(
         self, session: DbSession, messages: List[ItemHash]
     ) -> int:
+        """Return the number of messages attempted (including skipped no-ops),
+        used by the caller to decrement the per-run budget."""
         for index, item_hash in enumerate(messages, start=1):
             message = get_message_by_item_hash(session, item_hash)
 
@@ -193,6 +195,8 @@ class BalanceCronJob(BaseCronJob):
     async def recover_messages(
         self, session: DbSession, messages: List[ItemHash]
     ) -> int:
+        """Return the number of messages attempted (including skipped no-ops),
+        used by the caller to decrement the per-run budget."""
         for index, item_hash in enumerate(messages, start=1):
             message = get_message_by_item_hash(session, item_hash)
             if message is None:

--- a/src/aleph/jobs/cron/balance_job.py
+++ b/src/aleph/jobs/cron/balance_job.py
@@ -48,21 +48,26 @@ class BalanceCronJob(BaseCronJob):
         self.session_factory = session_factory
         self.max_unauthenticated_upload_file_size = max_unauthenticated_upload_file_size
 
-    async def run(self, now: dt.datetime, job: CronJobDb):
+    async def run(self, now: dt.datetime, job: CronJobDb) -> bool:
         with self.session_factory() as session:
             accounts = get_updated_balance_accounts(session, job.last_run)
 
             LOGGER.info(f"Checking '{len(accounts)}' updated account balances...")
 
             # Budget the mutations performed this run so one tick cannot process
-            # an unbounded batch; the remainder is idempotently handled next run.
+            # an unbounded batch. `deferred` tracks whether any work was left
+            # undone; when True we return False so the caller does not advance
+            # last_run and the next tick re-queries the same accounts to drain
+            # the remainder (the account query is delta-based on last_run).
             budget = MAX_MESSAGES_PER_RUN
+            deferred = False
 
             for address in accounts:
                 if budget <= 0:
+                    deferred = True
                     LOGGER.info(
-                        "Per-run message cap (%d) reached; remaining accounts "
-                        "will be handled on the next run.",
+                        "Per-run message cap (%d) reached; deferring remaining "
+                        "accounts to the next run.",
                         MAX_MESSAGES_PER_RUN,
                     )
                     break
@@ -110,19 +115,29 @@ class BalanceCronJob(BaseCronJob):
                     if index % COMMIT_CHUNK == 0:
                         await asyncio.sleep(0)
 
-                if budget > 0 and to_delete:
+                if to_delete:
+                    if len(to_delete) > budget:
+                        deferred = True
                     LOGGER.info(
                         f"'{len(to_delete)}' messages to delete for account '{address}'..."
                     )
                     budget -= await self.delete_messages(session, to_delete[:budget])
 
-                if budget > 0 and to_recover:
-                    LOGGER.info(
-                        f"'{len(to_recover)}' messages to recover for account '{address}'..."
-                    )
-                    budget -= await self.recover_messages(session, to_recover[:budget])
+                if to_recover:
+                    # budget may be 0 here if deletes consumed it this account.
+                    if budget <= 0 or len(to_recover) > budget:
+                        deferred = True
+                    if budget > 0:
+                        LOGGER.info(
+                            f"'{len(to_recover)}' messages to recover for account '{address}'..."
+                        )
+                        budget -= await self.recover_messages(
+                            session, to_recover[:budget]
+                        )
 
                 session.commit()
+
+            return not deferred
 
     async def delete_messages(
         self, session: DbSession, messages: List[ItemHash]

--- a/src/aleph/jobs/cron/balance_job.py
+++ b/src/aleph/jobs/cron/balance_job.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime as dt
 import logging
 from typing import List, cast
@@ -27,6 +28,16 @@ from aleph.types.message_status import MessageStatus
 
 LOGGER = logging.getLogger(__name__)
 
+# Commit and yield the event loop every this many messages, so a large account
+# cannot hold one long transaction (and the message_counts counter-row locks its
+# trigger takes) or monopolise the shared event loop.
+COMMIT_CHUNK = 500
+
+# Cap the mutations performed per run so a burst (many accounts, or one account
+# with tens of thousands of resources) drains over several bounded ticks instead
+# of one runaway tick. The remainder is idempotently handled by the next run.
+MAX_MESSAGES_PER_RUN = 5000
+
 
 class BalanceCronJob(BaseCronJob):
     def __init__(
@@ -43,7 +54,19 @@ class BalanceCronJob(BaseCronJob):
 
             LOGGER.info(f"Checking '{len(accounts)}' updated account balances...")
 
+            # Budget the mutations performed this run so one tick cannot process
+            # an unbounded batch; the remainder is idempotently handled next run.
+            budget = MAX_MESSAGES_PER_RUN
+
             for address in accounts:
+                if budget <= 0:
+                    LOGGER.info(
+                        "Per-run message cap (%d) reached; remaining accounts "
+                        "will be handled on the next run.",
+                        MAX_MESSAGES_PER_RUN,
+                    )
+                    break
+
                 remaining_balance = get_total_balance(session, address)
 
                 to_delete = []
@@ -53,9 +76,14 @@ class BalanceCronJob(BaseCronJob):
                     session, address, PaymentType.hold
                 )
 
-                for item_hash, height, cost, _ in hold_costs:
-                    LOGGER.info(
-                        f"Checking {item_hash} message, with height {height} and cost {cost}"
+                for index, (item_hash, height, cost, _) in enumerate(
+                    hold_costs, start=1
+                ):
+                    LOGGER.debug(
+                        "Checking %s message, with height %s and cost %s",
+                        item_hash,
+                        height,
+                        cost,
                     )
 
                     should_remove = remaining_balance < cost and (
@@ -74,26 +102,32 @@ class BalanceCronJob(BaseCronJob):
                             and status.status != MessageStatus.REMOVED
                         ):
                             to_delete.append(item_hash)
-                    else:
-                        if status.status == MessageStatus.REMOVING:
-                            to_recover.append(item_hash)
+                    elif status.status == MessageStatus.REMOVING:
+                        to_recover.append(item_hash)
 
-                if len(to_delete) > 0:
+                    # Yield during the read-only scan so a large account cannot
+                    # monopolise the shared event loop.
+                    if index % COMMIT_CHUNK == 0:
+                        await asyncio.sleep(0)
+
+                if to_delete:
                     LOGGER.info(
                         f"'{len(to_delete)}' messages to delete for account '{address}'..."
                     )
-                    await self.delete_messages(session, to_delete)
+                    budget -= await self.delete_messages(session, to_delete[:budget])
 
-                if len(to_recover) > 0:
+                if budget > 0 and to_recover:
                     LOGGER.info(
                         f"'{len(to_recover)}' messages to recover for account '{address}'..."
                     )
-                    await self.recover_messages(session, to_recover)
+                    budget -= await self.recover_messages(session, to_recover[:budget])
 
                 session.commit()
 
-    async def delete_messages(self, session: DbSession, messages: List[ItemHash]):
-        for item_hash in messages:
+    async def delete_messages(
+        self, session: DbSession, messages: List[ItemHash]
+    ) -> int:
+        for index, item_hash in enumerate(messages, start=1):
             message = get_message_by_item_hash(session, item_hash)
 
             if message is None:
@@ -147,8 +181,19 @@ class BalanceCronJob(BaseCronJob):
                 # REMOVING->REMOVED.
                 upsert_removed_message_size(session=session, item_hash=item_hash)
 
-    async def recover_messages(self, session: DbSession, messages: List[ItemHash]):
-        for item_hash in messages:
+            # Commit in chunks so the transaction — and the message_counts
+            # counter-row locks its trigger takes — stays small, and yield so
+            # other event-loop tasks (API, other crons) keep running.
+            if index % COMMIT_CHUNK == 0:
+                session.commit()
+                await asyncio.sleep(0)
+
+        return len(messages)
+
+    async def recover_messages(
+        self, session: DbSession, messages: List[ItemHash]
+    ) -> int:
+        for index, item_hash in enumerate(messages, start=1):
             message = get_message_by_item_hash(session, item_hash)
             if message is None:
                 continue
@@ -184,3 +229,12 @@ class BalanceCronJob(BaseCronJob):
                     .values(status_value=MessageStatus.PROCESSED)
                 )
                 delete_removed_message(session=session, item_hash=item_hash)
+
+            # Commit in chunks so the transaction — and the message_counts
+            # counter-row locks its trigger takes — stays small, and yield so
+            # other event-loop tasks (API, other crons) keep running.
+            if index % COMMIT_CHUNK == 0:
+                session.commit()
+                await asyncio.sleep(0)
+
+        return len(messages)

--- a/src/aleph/jobs/cron/credit_balance_job.py
+++ b/src/aleph/jobs/cron/credit_balance_job.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime as dt
 import logging
 from typing import List, cast
@@ -30,6 +31,16 @@ from aleph.types.message_status import MessageStatus
 
 LOGGER = logging.getLogger(__name__)
 
+# Commit and yield the event loop every this many messages, so a large account
+# cannot hold one long transaction (and the message_counts counter-row locks its
+# trigger takes) or monopolise the shared event loop.
+COMMIT_CHUNK = 500
+
+# Cap the mutations performed per run so a burst (many accounts, or one account
+# with tens of thousands of resources) drains over several bounded ticks instead
+# of one runaway tick. The remainder is idempotently handled by the next run.
+MAX_MESSAGES_PER_RUN = 5000
+
 
 class CreditBalanceCronJob(BaseCronJob):
     def __init__(
@@ -48,7 +59,19 @@ class CreditBalanceCronJob(BaseCronJob):
                 f"Checking '{len(accounts)}' updated credit balance accounts..."
             )
 
+            # Budget the mutations performed this run so one tick cannot process
+            # an unbounded batch; the remainder is idempotently handled next run.
+            budget = MAX_MESSAGES_PER_RUN
+
             for address in accounts:
+                if budget <= 0:
+                    LOGGER.info(
+                        "Per-run message cap (%d) reached; remaining accounts "
+                        "will be handled on the next run.",
+                        MAX_MESSAGES_PER_RUN,
+                    )
+                    break
+
                 remaining_credits = get_credit_balance(session, address)
 
                 to_delete = []
@@ -58,11 +81,17 @@ class CreditBalanceCronJob(BaseCronJob):
                     session, address, PaymentType.credit
                 )
 
-                for item_hash, height, cost, _ in credit_costs:
+                for index, (item_hash, _height, cost, _) in enumerate(
+                    credit_costs, start=1
+                ):
                     status = get_message_status(session, item_hash)
+                    if status is None:
+                        continue
 
-                    LOGGER.info(
-                        f"Checking credit message {item_hash} with cost {cost} credits"
+                    LOGGER.debug(
+                        "Checking credit message %s with cost %s credits",
+                        item_hash,
+                        cost,
                     )
 
                     # For credits, check if balance is insufficient for minimum 1-day
@@ -78,36 +107,38 @@ class CreditBalanceCronJob(BaseCronJob):
                     # day, which the ingest-time check already rejects).
                     remaining_credits = max(0, remaining_credits - daily_cost)
 
-                    status = get_message_status(session, item_hash)
-                    if status is None:
-                        continue
-
                     if should_remove:
                         if (
                             status.status != MessageStatus.REMOVING
                             and status.status != MessageStatus.REMOVED
                         ):
                             to_delete.append(item_hash)
-                    else:
-                        if status.status == MessageStatus.REMOVING:
-                            to_recover.append(item_hash)
+                    elif status.status == MessageStatus.REMOVING:
+                        to_recover.append(item_hash)
 
-                if len(to_delete) > 0:
+                    # Yield during the read-only scan so a large account cannot
+                    # monopolise the shared event loop.
+                    if index % COMMIT_CHUNK == 0:
+                        await asyncio.sleep(0)
+
+                if to_delete:
                     LOGGER.info(
                         f"'{len(to_delete)}' credit-paid messages to delete for account '{address}'..."
                     )
-                    await self.delete_messages(session, to_delete)
+                    budget -= await self.delete_messages(session, to_delete[:budget])
 
-                if len(to_recover) > 0:
+                if budget > 0 and to_recover:
                     LOGGER.info(
                         f"'{len(to_recover)}' credit-paid messages to recover for account '{address}'..."
                     )
-                    await self.recover_messages(session, to_recover)
+                    budget -= await self.recover_messages(session, to_recover[:budget])
 
                 session.commit()
 
-    async def delete_messages(self, session: DbSession, messages: List[ItemHash]):
-        for item_hash in messages:
+    async def delete_messages(
+        self, session: DbSession, messages: List[ItemHash]
+    ) -> int:
+        for index, item_hash in enumerate(messages, start=1):
             message = get_message_by_item_hash(session, item_hash)
 
             if message is None:
@@ -170,8 +201,19 @@ class CreditBalanceCronJob(BaseCronJob):
                 # REMOVING->REMOVED.
                 upsert_removed_message_size(session=session, item_hash=item_hash)
 
-    async def recover_messages(self, session: DbSession, messages: List[ItemHash]):
-        for item_hash in messages:
+            # Commit in chunks so the transaction — and the message_counts
+            # counter-row locks its trigger takes — stays small, and yield so
+            # other event-loop tasks (API, other crons) keep running.
+            if index % COMMIT_CHUNK == 0:
+                session.commit()
+                await asyncio.sleep(0)
+
+        return len(messages)
+
+    async def recover_messages(
+        self, session: DbSession, messages: List[ItemHash]
+    ) -> int:
+        for index, item_hash in enumerate(messages, start=1):
             message = get_message_by_item_hash(session, item_hash)
             if message is None:
                 continue
@@ -206,3 +248,12 @@ class CreditBalanceCronJob(BaseCronJob):
                     .values(status_value=MessageStatus.PROCESSED)
                 )
                 delete_removed_message(session=session, item_hash=item_hash)
+
+            # Commit in chunks so the transaction — and the message_counts
+            # counter-row locks its trigger takes — stays small, and yield so
+            # other event-loop tasks (API, other crons) keep running.
+            if index % COMMIT_CHUNK == 0:
+                session.commit()
+                await asyncio.sleep(0)
+
+        return len(messages)

--- a/src/aleph/jobs/cron/credit_balance_job.py
+++ b/src/aleph/jobs/cron/credit_balance_job.py
@@ -138,6 +138,8 @@ class CreditBalanceCronJob(BaseCronJob):
     async def delete_messages(
         self, session: DbSession, messages: List[ItemHash]
     ) -> int:
+        """Return the number of messages attempted (including skipped no-ops),
+        used by the caller to decrement the per-run budget."""
         for index, item_hash in enumerate(messages, start=1):
             message = get_message_by_item_hash(session, item_hash)
 
@@ -213,6 +215,8 @@ class CreditBalanceCronJob(BaseCronJob):
     async def recover_messages(
         self, session: DbSession, messages: List[ItemHash]
     ) -> int:
+        """Return the number of messages attempted (including skipped no-ops),
+        used by the caller to decrement the per-run budget."""
         for index, item_hash in enumerate(messages, start=1):
             message = get_message_by_item_hash(session, item_hash)
             if message is None:

--- a/src/aleph/jobs/cron/credit_balance_job.py
+++ b/src/aleph/jobs/cron/credit_balance_job.py
@@ -51,7 +51,7 @@ class CreditBalanceCronJob(BaseCronJob):
         self.session_factory = session_factory
         self.max_unauthenticated_upload_file_size = max_unauthenticated_upload_file_size
 
-    async def run(self, now: dt.datetime, job: CronJobDb):
+    async def run(self, now: dt.datetime, job: CronJobDb) -> bool:
         with self.session_factory() as session:
             accounts = get_updated_credit_balance_accounts(session, job.last_run)
 
@@ -60,14 +60,19 @@ class CreditBalanceCronJob(BaseCronJob):
             )
 
             # Budget the mutations performed this run so one tick cannot process
-            # an unbounded batch; the remainder is idempotently handled next run.
+            # an unbounded batch. `deferred` tracks whether any work was left
+            # undone; when True we return False so the caller does not advance
+            # last_run and the next tick re-queries the same accounts to drain
+            # the remainder (the account query is delta-based on last_run).
             budget = MAX_MESSAGES_PER_RUN
+            deferred = False
 
             for address in accounts:
                 if budget <= 0:
+                    deferred = True
                     LOGGER.info(
-                        "Per-run message cap (%d) reached; remaining accounts "
-                        "will be handled on the next run.",
+                        "Per-run message cap (%d) reached; deferring remaining "
+                        "accounts to the next run.",
                         MAX_MESSAGES_PER_RUN,
                     )
                     break
@@ -124,19 +129,29 @@ class CreditBalanceCronJob(BaseCronJob):
                     if index % COMMIT_CHUNK == 0:
                         await asyncio.sleep(0)
 
-                if budget > 0 and to_delete:
+                if to_delete:
+                    if len(to_delete) > budget:
+                        deferred = True
                     LOGGER.info(
                         f"'{len(to_delete)}' credit-paid messages to delete for account '{address}'..."
                     )
                     budget -= await self.delete_messages(session, to_delete[:budget])
 
-                if budget > 0 and to_recover:
-                    LOGGER.info(
-                        f"'{len(to_recover)}' credit-paid messages to recover for account '{address}'..."
-                    )
-                    budget -= await self.recover_messages(session, to_recover[:budget])
+                if to_recover:
+                    # budget may be 0 here if deletes consumed it this account.
+                    if budget <= 0 or len(to_recover) > budget:
+                        deferred = True
+                    if budget > 0:
+                        LOGGER.info(
+                            f"'{len(to_recover)}' credit-paid messages to recover for account '{address}'..."
+                        )
+                        budget -= await self.recover_messages(
+                            session, to_recover[:budget]
+                        )
 
                 session.commit()
+
+            return not deferred
 
     async def delete_messages(
         self, session: DbSession, messages: List[ItemHash]

--- a/src/aleph/jobs/cron/credit_balance_job.py
+++ b/src/aleph/jobs/cron/credit_balance_job.py
@@ -138,8 +138,12 @@ class CreditBalanceCronJob(BaseCronJob):
     async def delete_messages(
         self, session: DbSession, messages: List[ItemHash]
     ) -> int:
-        """Return the number of messages attempted (including skipped no-ops),
-        used by the caller to decrement the per-run budget."""
+        """Return the number of messages attempted, used by the caller to
+        decrement the per-run budget. Skipped no-ops (missing message,
+        small-file exception, or a status guard that prevents the flip) count
+        on purpose: the budget bounds the number of delete/recover attempts —
+        each a DB round-trip — not only the flips that succeed, because
+        bounding per-tick work is what the cap exists to do."""
         for index, item_hash in enumerate(messages, start=1):
             message = get_message_by_item_hash(session, item_hash)
 
@@ -215,8 +219,12 @@ class CreditBalanceCronJob(BaseCronJob):
     async def recover_messages(
         self, session: DbSession, messages: List[ItemHash]
     ) -> int:
-        """Return the number of messages attempted (including skipped no-ops),
-        used by the caller to decrement the per-run budget."""
+        """Return the number of messages attempted, used by the caller to
+        decrement the per-run budget. Skipped no-ops (missing message,
+        small-file exception, or a status guard that prevents the flip) count
+        on purpose: the budget bounds the number of delete/recover attempts —
+        each a DB round-trip — not only the flips that succeed, because
+        bounding per-tick work is what the cap exists to do."""
         for index, item_hash in enumerate(messages, start=1):
             message = get_message_by_item_hash(session, item_hash)
             if message is None:

--- a/src/aleph/jobs/cron/credit_balance_job.py
+++ b/src/aleph/jobs/cron/credit_balance_job.py
@@ -84,16 +84,6 @@ class CreditBalanceCronJob(BaseCronJob):
                 for index, (item_hash, _height, cost, _) in enumerate(
                     credit_costs, start=1
                 ):
-                    status = get_message_status(session, item_hash)
-                    if status is None:
-                        continue
-
-                    LOGGER.debug(
-                        "Checking credit message %s with cost %s credits",
-                        item_hash,
-                        cost,
-                    )
-
                     # For credits, check if balance is insufficient for minimum 1-day
                     # runtime. Costs in account_costs are stored per-second, so multiply
                     # by DAY (seconds per day) to get the per-day requirement, matching
@@ -104,8 +94,21 @@ class CreditBalanceCronJob(BaseCronJob):
                     # resource is checked against what is actually left, matching the
                     # per-day threshold above (decrementing by the per-second cost
                     # would let an account keep many resources it cannot afford for a
-                    # day, which the ingest-time check already rejects).
+                    # day, which the ingest-time check already rejects). Decrement
+                    # before the status lookup/None-check so a cost row without a
+                    # message-status row still reserves balance, preserving the
+                    # original running-balance semantics.
                     remaining_credits = max(0, remaining_credits - daily_cost)
+
+                    status = get_message_status(session, item_hash)
+                    if status is None:
+                        continue
+
+                    LOGGER.debug(
+                        "Checking credit message %s with cost %s credits",
+                        item_hash,
+                        cost,
+                    )
 
                     if should_remove:
                         if (
@@ -121,7 +124,7 @@ class CreditBalanceCronJob(BaseCronJob):
                     if index % COMMIT_CHUNK == 0:
                         await asyncio.sleep(0)
 
-                if to_delete:
+                if budget > 0 and to_delete:
                     LOGGER.info(
                         f"'{len(to_delete)}' credit-paid messages to delete for account '{address}'..."
                     )

--- a/src/aleph/jobs/cron/credit_balance_job.py
+++ b/src/aleph/jobs/cron/credit_balance_job.py
@@ -130,10 +130,12 @@ class CreditBalanceCronJob(BaseCronJob):
                         await asyncio.sleep(0)
 
                 if to_delete:
+                    processing = min(len(to_delete), budget)
                     if len(to_delete) > budget:
                         deferred = True
                     LOGGER.info(
-                        f"'{len(to_delete)}' credit-paid messages to delete for account '{address}'..."
+                        f"Deleting '{processing}' of '{len(to_delete)}' credit-paid "
+                        f"messages for account '{address}'..."
                     )
                     budget -= await self.delete_messages(session, to_delete[:budget])
 
@@ -142,8 +144,10 @@ class CreditBalanceCronJob(BaseCronJob):
                     if budget <= 0 or len(to_recover) > budget:
                         deferred = True
                     if budget > 0:
+                        processing = min(len(to_recover), budget)
                         LOGGER.info(
-                            f"'{len(to_recover)}' credit-paid messages to recover for account '{address}'..."
+                            f"Recovering '{processing}' of '{len(to_recover)}' "
+                            f"credit-paid messages for account '{address}'..."
                         )
                         budget -= await self.recover_messages(
                             session, to_recover[:budget]

--- a/src/aleph/jobs/cron/cron_job.py
+++ b/src/aleph/jobs/cron/cron_job.py
@@ -2,7 +2,7 @@ import abc
 import asyncio
 import datetime as dt
 import logging
-from typing import Coroutine, Dict, List
+from typing import Coroutine, Dict, List, Optional
 
 from configmanager import Config
 
@@ -16,7 +16,11 @@ LOGGER = logging.getLogger(__name__)
 
 class BaseCronJob(abc.ABC):
     @abc.abstractmethod
-    async def run(self, now: dt.datetime, job: CronJobDb) -> None:
+    async def run(self, now: dt.datetime, job: CronJobDb) -> Optional[bool]:
+        """Run the job. Return ``False`` to signal that work was left undone
+        (e.g. a per-run cap was hit) so the caller does NOT advance ``last_run``
+        and the next tick re-queries the same accounts. ``None`` / ``True`` mean
+        the job completed and ``last_run`` may advance."""
         pass
 
 
@@ -34,9 +38,15 @@ class CronJob:
     ):
         try:
             LOGGER.info(f"Starting '{job.id}' cron job check...")
-            await cron_job.run(now, job)
+            completed = await cron_job.run(now, job)
 
-            update_cron_job(session, job.id, now)
+            # A job returning False left work undone (e.g. a per-run cap was
+            # hit). Do NOT advance last_run in that case, so the next tick
+            # re-queries the same accounts and drains the remainder — the
+            # account queries are delta-based on last_run and would otherwise
+            # never surface a deferred account again. None/True = completed.
+            if completed is not False:
+                update_cron_job(session, job.id, now)
 
             LOGGER.info(f"'{job.id}' cron job ran successfully.")
 

--- a/tests/jobs/test_balance_job.py
+++ b/tests/jobs/test_balance_job.py
@@ -521,3 +521,67 @@ async def test_balance_job_caps_messages_per_run(
 
     await balance_job.run(now, cron_job)
     assert _count_removing() == 5
+
+
+@pytest.mark.asyncio
+async def test_balance_job_caps_recovery_per_run(
+    session_factory, balance_job, fixture_base_data, now, monkeypatch
+):
+    """The cap also bounds the recover path: a run recovers at most
+    MAX_MESSAGES_PER_RUN REMOVING messages, and successive runs drain the rest."""
+    monkeypatch.setattr("aleph.jobs.cron.balance_job.MAX_MESSAGES_PER_RUN", 2)
+    monkeypatch.setattr("aleph.jobs.cron.balance_job.COMMIT_CHUNK", 1)
+
+    wallet_address = "0xcaprecovers"
+    item_hashes = [f"{(i + 32):02x}" * 32 for i in range(5)]
+
+    # Balance comfortably covers every message: all should recover.
+    with session_factory() as session:
+        session.add(create_wallet(wallet_address, "10000.0", now))
+        session.commit()
+
+    for i, item_hash in enumerate(item_hashes):
+        message, file, file_pin, message_status = create_store_message(
+            item_hash, wallet_address, f"{(i + 32):04x}" * 16, now,
+            status=MessageStatus.REMOVING,
+        )
+        message.confirmations = [
+            ChainTxDb(
+                hash=f"0xrtx{i}",
+                chain=Chain.ETH,
+                height=STORE_AND_PROGRAM_COST_CUTOFF_HEIGHT + 1000,
+                datetime=now,
+                publisher="0xabadbabe",
+                protocol=ChainSyncProtocol.OFF_CHAIN_SYNC,
+                protocol_version=1,
+                content="Qmsomething",
+            )
+        ]
+        cost = create_message_cost(wallet_address, item_hash, "15.0")
+        removed = RemovedMessageDb(item_hash=item_hash, size=30 * MiB)
+        with session_factory() as session:
+            session.add(message)
+            session.commit()
+            session.add_all([file, file_pin, message_status, cost, removed])
+            session.commit()
+
+    def _count_processed() -> int:
+        with session_factory() as session:
+            statuses = [
+                get_message_status(session=session, item_hash=h) for h in item_hashes
+            ]
+        return sum(
+            s is not None and s.status == MessageStatus.PROCESSED for s in statuses
+        )
+
+    with session_factory() as session:
+        cron_job = session.query(CronJobDb).filter_by(id="balance_check_base").one()
+
+    await balance_job.run(now, cron_job)
+    assert _count_processed() == 2
+
+    await balance_job.run(now, cron_job)
+    assert _count_processed() == 4
+
+    await balance_job.run(now, cron_job)
+    assert _count_processed() == 5

--- a/tests/jobs/test_balance_job.py
+++ b/tests/jobs/test_balance_job.py
@@ -5,6 +5,7 @@ import pytest
 import pytest_asyncio
 from aleph_message.models import Chain, ItemHash, ItemType, MessageType, PaymentType
 
+from aleph.db.accessors.cron_jobs import update_cron_job
 from aleph.db.accessors.messages import get_message_status
 from aleph.db.models.account_costs import AccountCostsDb
 from aleph.db.models.balances import AlephBalanceDb
@@ -589,3 +590,138 @@ async def test_balance_job_caps_recovery_per_run(
 
     assert await balance_job.run(now, cron_job) is True
     assert _count_processed() == 5
+
+
+def _store_with_confirmation(session_factory, address, item_hash, file_hash, tx, now):
+    """Insert one PROCESSED hold-paid store above the cutoff height, with an
+    unaffordable cost, for the given wallet."""
+    message, file, file_pin, message_status = create_store_message(
+        item_hash, address, file_hash, now
+    )
+    message.confirmations = [
+        ChainTxDb(
+            hash=tx,
+            chain=Chain.ETH,
+            height=STORE_AND_PROGRAM_COST_CUTOFF_HEIGHT + 1000,
+            datetime=now,
+            publisher="0xabadbabe",
+            protocol=ChainSyncProtocol.OFF_CHAIN_SYNC,
+            protocol_version=1,
+            content="Qmsomething",
+        )
+    ]
+    cost = create_message_cost(address, item_hash, "15.0")
+    with session_factory() as session:
+        session.add(message)
+        session.commit()
+        session.add_all([file, file_pin, message_status, cost])
+        session.commit()
+
+
+@pytest.mark.asyncio
+async def test_balance_job_deferred_account_survives_last_run_advance(
+    session_factory, balance_job, fixture_base_data, now, monkeypatch
+):
+    """Twin of the credit resumption test: a deferred account must still drain on
+    a later tick because the framework advances last_run only when run() reports
+    completion."""
+    monkeypatch.setattr("aleph.jobs.cron.balance_job.MAX_MESSAGES_PER_RUN", 2)
+    monkeypatch.setattr("aleph.jobs.cron.balance_job.COMMIT_CHUNK", 1)
+
+    wallet_address = "0xbaldeferred"
+    item_hashes = [f"{(i + 64):02x}" * 32 for i in range(3)]
+
+    with session_factory() as session:
+        session.add(create_wallet(wallet_address, "10.0", now))
+        session.commit()
+
+    for i, item_hash in enumerate(item_hashes):
+        _store_with_confirmation(
+            session_factory,
+            wallet_address,
+            item_hash,
+            f"{(i + 64):04x}" * 16,
+            f"0xdtx{i}",
+            now,
+        )
+
+    # Make the wallet's balance update strictly older than the tick, so an
+    # unconditional last_run advance would strand it.
+    with session_factory() as session:
+        for w in session.query(AlephBalanceDb).filter_by(address=wallet_address).all():
+            w.last_update = now - dt.timedelta(hours=1)
+        session.commit()
+
+    def _count_removing() -> int:
+        with session_factory() as session:
+            statuses = [
+                get_message_status(session=session, item_hash=h) for h in item_hashes
+            ]
+        return sum(
+            s is not None and s.status == MessageStatus.REMOVING for s in statuses
+        )
+
+    async def _tick(tick_now) -> bool:
+        with session_factory() as session:
+            job = session.query(CronJobDb).filter_by(id="balance_check_base").one()
+            completed = await balance_job.run(tick_now, job)
+            if completed is not False:
+                update_cron_job(session, job.id, tick_now)
+                session.commit()
+        return completed
+
+    assert await _tick(now) is False
+    assert _count_removing() == 2
+
+    assert await _tick(now + dt.timedelta(hours=2)) is True
+    assert _count_removing() == 3
+
+
+@pytest.mark.asyncio
+async def test_balance_job_defers_second_account_when_budget_exhausted(
+    session_factory, balance_job, fixture_base_data, now, monkeypatch
+):
+    """Twin of the credit multi-account test: the first account (address order)
+    exhausts the budget, the second is deferred then drained."""
+    monkeypatch.setattr("aleph.jobs.cron.balance_job.MAX_MESSAGES_PER_RUN", 2)
+    monkeypatch.setattr("aleph.jobs.cron.balance_job.COMMIT_CHUNK", 1)
+
+    wallets = {
+        "0xaaawallet": [f"a{i:01x}" * 32 for i in range(2)],
+        "0xbbbwallet": [f"b{i:01x}" * 32 for i in range(2)],
+    }
+    counter = 0
+    for address, hashes in wallets.items():
+        with session_factory() as session:
+            session.add(create_wallet(address, "10.0", now))
+            session.commit()
+        for item_hash in hashes:
+            _store_with_confirmation(
+                session_factory,
+                address,
+                item_hash,
+                f"{counter:04x}" * 16,
+                f"0xmtx{counter}",
+                now,
+            )
+            counter += 1
+
+    def _removing(address) -> int:
+        with session_factory() as session:
+            statuses = [
+                get_message_status(session=session, item_hash=h)
+                for h in wallets[address]
+            ]
+        return sum(
+            s is not None and s.status == MessageStatus.REMOVING for s in statuses
+        )
+
+    with session_factory() as session:
+        cron_job = session.query(CronJobDb).filter_by(id="balance_check_base").one()
+
+    assert await balance_job.run(now, cron_job) is False
+    assert _removing("0xaaawallet") == 2
+    assert _removing("0xbbbwallet") == 0
+
+    assert await balance_job.run(now, cron_job) is True
+    assert _removing("0xbbbwallet") == 2

--- a/tests/jobs/test_balance_job.py
+++ b/tests/jobs/test_balance_job.py
@@ -512,14 +512,15 @@ async def test_balance_job_caps_messages_per_run(
     with session_factory() as session:
         cron_job = session.query(CronJobDb).filter_by(id="balance_check_base").one()
 
-    # Each run flips at most the cap; successive runs resume until drained.
-    await balance_job.run(now, cron_job)
+    # Each run flips at most the cap and returns False (work deferred) until the
+    # final run drains the rest and returns True (complete).
+    assert await balance_job.run(now, cron_job) is False
     assert _count_removing() == 2
 
-    await balance_job.run(now, cron_job)
+    assert await balance_job.run(now, cron_job) is False
     assert _count_removing() == 4
 
-    await balance_job.run(now, cron_job)
+    assert await balance_job.run(now, cron_job) is True
     assert _count_removing() == 5
 
 
@@ -580,11 +581,11 @@ async def test_balance_job_caps_recovery_per_run(
     with session_factory() as session:
         cron_job = session.query(CronJobDb).filter_by(id="balance_check_base").one()
 
-    await balance_job.run(now, cron_job)
+    assert await balance_job.run(now, cron_job) is False
     assert _count_processed() == 2
 
-    await balance_job.run(now, cron_job)
+    assert await balance_job.run(now, cron_job) is False
     assert _count_processed() == 4
 
-    await balance_job.run(now, cron_job)
+    assert await balance_job.run(now, cron_job) is True
     assert _count_processed() == 5

--- a/tests/jobs/test_balance_job.py
+++ b/tests/jobs/test_balance_job.py
@@ -542,7 +542,10 @@ async def test_balance_job_caps_recovery_per_run(
 
     for i, item_hash in enumerate(item_hashes):
         message, file, file_pin, message_status = create_store_message(
-            item_hash, wallet_address, f"{(i + 32):04x}" * 16, now,
+            item_hash,
+            wallet_address,
+            f"{(i + 32):04x}" * 16,
+            now,
             status=MessageStatus.REMOVING,
         )
         message.confirmations = [

--- a/tests/jobs/test_balance_job.py
+++ b/tests/jobs/test_balance_job.py
@@ -453,3 +453,71 @@ async def test_balance_job_recover_keeps_removed_message(
         fetched_removed_message = session.get(RemovedMessageDb, message_hash)
         assert fetched_removed_message is not None
         assert fetched_removed_message.removed_at == now
+
+
+@pytest.mark.asyncio
+async def test_balance_job_caps_messages_per_run(
+    session_factory, balance_job, fixture_base_data, now, monkeypatch
+):
+    """A single run must flip at most MAX_MESSAGES_PER_RUN messages; the rest are
+    idempotently picked up by later runs (twin of the credit-job cap test).
+
+    Guards against one tick processing an unbounded batch, which blocks the event
+    loop and holds one huge transaction. COMMIT_CHUNK is shrunk too so the
+    chunked-commit path runs.
+    """
+    monkeypatch.setattr("aleph.jobs.cron.balance_job.MAX_MESSAGES_PER_RUN", 2)
+    monkeypatch.setattr("aleph.jobs.cron.balance_job.COMMIT_CHUNK", 1)
+
+    wallet_address = "0xcapmanystores"
+    item_hashes = [f"{i:02x}" * 32 for i in range(5)]
+
+    # Balance far below the total hold cost: every store is unaffordable.
+    with session_factory() as session:
+        session.add(create_wallet(wallet_address, "10.0", now))
+        session.commit()
+
+    for i, item_hash in enumerate(item_hashes):
+        message, file, file_pin, message_status = create_store_message(
+            item_hash, wallet_address, f"{i:04x}" * 16, now
+        )
+        message.confirmations = [
+            ChainTxDb(
+                hash=f"0xtx{i}",
+                chain=Chain.ETH,
+                height=STORE_AND_PROGRAM_COST_CUTOFF_HEIGHT + 1000,
+                datetime=now,
+                publisher="0xabadbabe",
+                protocol=ChainSyncProtocol.OFF_CHAIN_SYNC,
+                protocol_version=1,
+                content="Qmsomething",
+            )
+        ]
+        cost = create_message_cost(wallet_address, item_hash, "15.0")
+        with session_factory() as session:
+            session.add(message)
+            session.commit()
+            session.add_all([file, file_pin, message_status, cost])
+            session.commit()
+
+    def _count_removing() -> int:
+        with session_factory() as session:
+            statuses = [
+                get_message_status(session=session, item_hash=h) for h in item_hashes
+            ]
+        return sum(
+            s is not None and s.status == MessageStatus.REMOVING for s in statuses
+        )
+
+    with session_factory() as session:
+        cron_job = session.query(CronJobDb).filter_by(id="balance_check_base").one()
+
+    # Each run flips at most the cap; successive runs resume until drained.
+    await balance_job.run(now, cron_job)
+    assert _count_removing() == 2
+
+    await balance_job.run(now, cron_job)
+    assert _count_removing() == 4
+
+    await balance_job.run(now, cron_job)
+    assert _count_removing() == 5

--- a/tests/jobs/test_credit_balance_job.py
+++ b/tests/jobs/test_credit_balance_job.py
@@ -500,3 +500,56 @@ async def test_credit_job_caps_messages_per_run(
 
     await credit_balance_job.run(now, cron_job)
     assert _count_removing() == 5
+
+
+@pytest.mark.asyncio
+async def test_credit_job_caps_recovery_per_run(
+    session_factory, credit_balance_job, fixture_base_cron, now, monkeypatch
+):
+    """The cap also bounds the credit recover path: a run recovers at most
+    MAX_MESSAGES_PER_RUN REMOVING instances, draining the rest over later runs."""
+    monkeypatch.setattr("aleph.jobs.cron.credit_balance_job.MAX_MESSAGES_PER_RUN", 2)
+    monkeypatch.setattr("aleph.jobs.cron.credit_balance_job.COMMIT_CHUNK", 1)
+
+    address = "0xcreditrecovers"
+    item_hashes = [f"{(i + 32):02x}" * 32 for i in range(5)]
+    for item_hash in item_hashes:
+        _create_credit_instance(
+            session_factory,
+            now,
+            address=address,
+            item_hash=item_hash,
+            cost_credit_per_second=1,
+        )
+    # Comfortably affordable so every REMOVING instance recovers.
+    _create_credit_balance(session_factory, now, address=address, amount=100 * DAY)
+
+    # Put every instance into REMOVING with a removal snapshot, mirroring a
+    # prior removal pass.
+    with session_factory() as session:
+        for item_hash in item_hashes:
+            session.get(MessageStatusDb, item_hash).status = MessageStatus.REMOVING
+            session.get(MessageDb, item_hash).status_value = MessageStatus.REMOVING
+            session.add(RemovedMessageDb(item_hash=item_hash, size=1000))
+        session.commit()
+
+    def _count_processed() -> int:
+        with session_factory() as session:
+            statuses = [
+                get_message_status(session=session, item_hash=h) for h in item_hashes
+            ]
+        return sum(
+            s is not None and s.status == MessageStatus.PROCESSED for s in statuses
+        )
+
+    with session_factory() as session:
+        cron_job = session.query(CronJobDb).filter_by(id=fixture_base_cron).one()
+
+    await credit_balance_job.run(now, cron_job)
+    assert _count_processed() == 2
+
+    await credit_balance_job.run(now, cron_job)
+    assert _count_processed() == 4
+
+    await credit_balance_job.run(now, cron_job)
+    assert _count_processed() == 5

--- a/tests/jobs/test_credit_balance_job.py
+++ b/tests/jobs/test_credit_balance_job.py
@@ -644,7 +644,11 @@ async def test_credit_job_defers_second_account_when_budget_exhausted(
                 item_hash=item_hash,
                 cost_credit_per_second=1,
             )
-        _create_credit_balance(session_factory, now, address=address, amount=10)
+        # Distinct ref per account: credit_history PK is (credit_ref,
+        # credit_index), shared across addresses.
+        _create_credit_balance(
+            session_factory, now, address=address, amount=10, ref=f"grant_{address}"
+        )
 
     def _removing(address) -> int:
         with session_factory() as session:

--- a/tests/jobs/test_credit_balance_job.py
+++ b/tests/jobs/test_credit_balance_job.py
@@ -481,11 +481,12 @@ async def test_credit_job_caps_messages_per_run(
 
     def _count_removing() -> int:
         with session_factory() as session:
-            return sum(
-                get_message_status(session=session, item_hash=h).status
-                == MessageStatus.REMOVING
-                for h in item_hashes
-            )
+            statuses = [
+                get_message_status(session=session, item_hash=h) for h in item_hashes
+            ]
+        return sum(
+            s is not None and s.status == MessageStatus.REMOVING for s in statuses
+        )
 
     with session_factory() as session:
         cron_job = session.query(CronJobDb).filter_by(id=fixture_base_cron).one()

--- a/tests/jobs/test_credit_balance_job.py
+++ b/tests/jobs/test_credit_balance_job.py
@@ -450,3 +450,52 @@ async def test_credit_job_reserves_a_full_day_per_instance(
 
     # Exactly one instance affordable for a full day, the other removed.
     assert statuses == {MessageStatus.PROCESSED, MessageStatus.REMOVING}
+
+
+@pytest.mark.asyncio
+async def test_credit_job_caps_messages_per_run(
+    session_factory, credit_balance_job, fixture_base_cron, now, monkeypatch
+):
+    """A single run must flip at most MAX_MESSAGES_PER_RUN messages; the rest are
+    idempotently picked up by later runs.
+
+    Guards against one tick processing an unbounded batch (an account with tens of
+    thousands of unaffordable resources), which blocks the event loop and holds one
+    huge transaction. COMMIT_CHUNK is shrunk too so the chunked-commit path runs.
+    """
+    monkeypatch.setattr("aleph.jobs.cron.credit_balance_job.MAX_MESSAGES_PER_RUN", 2)
+    monkeypatch.setattr("aleph.jobs.cron.credit_balance_job.COMMIT_CHUNK", 1)
+
+    address = "0xcreditmanyinstances"
+    item_hashes = [f"{i:02x}" * 32 for i in range(5)]
+    for item_hash in item_hashes:
+        _create_credit_instance(
+            session_factory,
+            now,
+            address=address,
+            item_hash=item_hash,
+            cost_credit_per_second=1,
+        )
+    # Far below one day of runtime for even a single instance: all are unaffordable.
+    _create_credit_balance(session_factory, now, address=address, amount=10)
+
+    def _count_removing() -> int:
+        with session_factory() as session:
+            return sum(
+                get_message_status(session=session, item_hash=h).status
+                == MessageStatus.REMOVING
+                for h in item_hashes
+            )
+
+    with session_factory() as session:
+        cron_job = session.query(CronJobDb).filter_by(id=fixture_base_cron).one()
+
+    # Each run flips at most the cap; successive runs resume until drained.
+    await credit_balance_job.run(now, cron_job)
+    assert _count_removing() == 2
+
+    await credit_balance_job.run(now, cron_job)
+    assert _count_removing() == 4
+
+    await credit_balance_job.run(now, cron_job)
+    assert _count_removing() == 5

--- a/tests/jobs/test_credit_balance_job.py
+++ b/tests/jobs/test_credit_balance_job.py
@@ -5,6 +5,7 @@ import pytest
 import pytest_asyncio
 from aleph_message.models import Chain, ItemHash, ItemType, MessageType, PaymentType
 
+from aleph.db.accessors.cron_jobs import update_cron_job
 from aleph.db.accessors.messages import get_message_status, get_removed_message
 from aleph.db.models import AlephCreditBalanceDb, AlephCreditHistoryDb
 from aleph.db.models.account_costs import AccountCostsDb
@@ -491,14 +492,15 @@ async def test_credit_job_caps_messages_per_run(
     with session_factory() as session:
         cron_job = session.query(CronJobDb).filter_by(id=fixture_base_cron).one()
 
-    # Each run flips at most the cap; successive runs resume until drained.
-    await credit_balance_job.run(now, cron_job)
+    # Each run flips at most the cap and returns False (work deferred) until the
+    # final run drains the rest and returns True (complete).
+    assert await credit_balance_job.run(now, cron_job) is False
     assert _count_removing() == 2
 
-    await credit_balance_job.run(now, cron_job)
+    assert await credit_balance_job.run(now, cron_job) is False
     assert _count_removing() == 4
 
-    await credit_balance_job.run(now, cron_job)
+    assert await credit_balance_job.run(now, cron_job) is True
     assert _count_removing() == 5
 
 
@@ -545,11 +547,124 @@ async def test_credit_job_caps_recovery_per_run(
     with session_factory() as session:
         cron_job = session.query(CronJobDb).filter_by(id=fixture_base_cron).one()
 
-    await credit_balance_job.run(now, cron_job)
+    assert await credit_balance_job.run(now, cron_job) is False
     assert _count_processed() == 2
 
-    await credit_balance_job.run(now, cron_job)
+    assert await credit_balance_job.run(now, cron_job) is False
     assert _count_processed() == 4
 
-    await credit_balance_job.run(now, cron_job)
+    assert await credit_balance_job.run(now, cron_job) is True
     assert _count_processed() == 5
+
+
+@pytest.mark.asyncio
+async def test_credit_job_deferred_account_survives_last_run_advance(
+    session_factory, credit_balance_job, fixture_base_cron, now, monkeypatch
+):
+    """A deferred account must still drain on a later tick under the real
+    last_run contract.
+
+    The framework advances last_run only when run() reports completion. A capped
+    run returns False, so last_run is left untouched and the delta-based account
+    query (last_update >= last_run) still surfaces the account next tick. If
+    last_run were advanced unconditionally, an account whose credit history
+    predates the tick would drop out of the window and be stranded.
+    """
+    monkeypatch.setattr("aleph.jobs.cron.credit_balance_job.MAX_MESSAGES_PER_RUN", 2)
+    monkeypatch.setattr("aleph.jobs.cron.credit_balance_job.COMMIT_CHUNK", 1)
+
+    address = "0xdeferredaccount"
+    item_hashes = [f"{(i + 64):02x}" * 32 for i in range(3)]
+    for item_hash in item_hashes:
+        _create_credit_instance(
+            session_factory,
+            now,
+            address=address,
+            item_hash=item_hash,
+            cost_credit_per_second=1,
+        )
+    _create_credit_balance(session_factory, now, address=address, amount=10)
+
+    # Make the account's credit-history update strictly older than the tick, so
+    # an unconditional last_run advance would strand it.
+    with session_factory() as session:
+        for ch in session.query(AlephCreditHistoryDb).filter_by(address=address).all():
+            ch.last_update = now - dt.timedelta(hours=1)
+        session.commit()
+
+    def _count_removing() -> int:
+        with session_factory() as session:
+            statuses = [
+                get_message_status(session=session, item_hash=h) for h in item_hashes
+            ]
+        return sum(
+            s is not None and s.status == MessageStatus.REMOVING for s in statuses
+        )
+
+    async def _tick(tick_now) -> bool:
+        # Mimic CronJob.__run_job: advance last_run only when run() completes.
+        with session_factory() as session:
+            job = session.query(CronJobDb).filter_by(id=fixture_base_cron).one()
+            completed = await credit_balance_job.run(tick_now, job)
+            if completed is not False:
+                update_cron_job(session, job.id, tick_now)
+                session.commit()
+        return completed
+
+    # Tick 1 caps at 2 and defers -> returns False, last_run NOT advanced.
+    assert await _tick(now) is False
+    assert _count_removing() == 2
+
+    # Tick 2 (later): last_run untouched, so the account is still in the delta
+    # window and the remainder drains.
+    assert await _tick(now + dt.timedelta(hours=2)) is True
+    assert _count_removing() == 3
+
+
+@pytest.mark.asyncio
+async def test_credit_job_defers_second_account_when_budget_exhausted(
+    session_factory, credit_balance_job, fixture_base_cron, now, monkeypatch
+):
+    """The primary many-accounts scenario: when the first account exhausts the
+    budget, later accounts are deferred to the next run. Accounts are processed
+    in address order for deterministic, fair resumption."""
+    monkeypatch.setattr("aleph.jobs.cron.credit_balance_job.MAX_MESSAGES_PER_RUN", 2)
+    monkeypatch.setattr("aleph.jobs.cron.credit_balance_job.COMMIT_CHUNK", 1)
+
+    accounts = {
+        "0xaaaaccount": [f"a{i:01x}" * 32 for i in range(2)],
+        "0xbbbaccount": [f"b{i:01x}" * 32 for i in range(2)],
+    }
+    for address, hashes in accounts.items():
+        for item_hash in hashes:
+            _create_credit_instance(
+                session_factory,
+                now,
+                address=address,
+                item_hash=item_hash,
+                cost_credit_per_second=1,
+            )
+        _create_credit_balance(session_factory, now, address=address, amount=10)
+
+    def _removing(address) -> int:
+        with session_factory() as session:
+            statuses = [
+                get_message_status(session=session, item_hash=h)
+                for h in accounts[address]
+            ]
+        return sum(
+            s is not None and s.status == MessageStatus.REMOVING for s in statuses
+        )
+
+    with session_factory() as session:
+        cron_job = session.query(CronJobDb).filter_by(id=fixture_base_cron).one()
+
+    # Run 1: the first account (address order) fills the budget of 2; the second
+    # is deferred, so run() reports incomplete.
+    assert await credit_balance_job.run(now, cron_job) is False
+    assert _removing("0xaaaaccount") == 2
+    assert _removing("0xbbbaccount") == 0
+
+    # Run 2: the first account is already REMOVING (no-op) and the second drains.
+    assert await credit_balance_job.run(now, cron_job) is True
+    assert _removing("0xbbbaccount") == 2


### PR DESCRIPTION
## Problem
`credit_balance_job` and `balance_job` mark every unaffordable message for an account in **one synchronous, non-yielding loop inside a single transaction**. In production, account `0x1424…` had **14,545** unaffordable instances flagged in one tick:

- ~14,545 sequential DB round-trips **without yielding** blocked the main-process event loop → the API and other crons starved (the `balance` cron's bookkeeping session sat `idle in transaction` for over an hour).
- One long transaction held `message_counts` trigger counter-row locks the whole time, which the message-processing subprocess contends on.
- The node's DB is on an HDD shared with IPFS, so each round-trip pays a seek + WAL fsync — turning "slow" into "wedged for an hour".

`EXPLAIN` confirmed the per-message lookup is already an index scan; the issue is the unbounded, non-yielding, single-transaction batch, not a missing index.

## Change
For both `delete_messages` / `recover_messages`:
- **Commit in chunks** (`COMMIT_CHUNK = 500`) so the transaction and its counter-row locks stay small.
- **`await asyncio.sleep(0)`** each chunk (and during the read-only scan) so the API and other crons keep running.
- **`MAX_MESSAGES_PER_RUN = 5000`** cap so one tick can't process an unbounded batch; the remainder is handled next run. Safe because the flips are idempotent (`WHERE status='processed'` / `WHERE status='removing'`).
- Drop the duplicate `get_message_status` in the credit loop; lower the per-message log to `debug`.

The `PROCESSED→REMOVING` / `REMOVING→PROCESSED` flip semantics, STORE small-file exception, removal-record snapshot, and guarded dual-write are unchanged.

## Test
`test_credit_job_caps_messages_per_run`: with the cap shrunk to 2 and chunk to 1, 5 unaffordable instances flip 2 per run and drain over successive runs — proving the cap and idempotent resumption. `balance_job` receives the identical change (the `hold`-payment twin).

## Follow-ups (discussed, not in this PR)
- Move the DB onto SSD, off the IPFS spindle — the root I/O amplifier.
- Larger scale: set-based bulk updates, a dedicated reconciliation worker subprocess, and `message_counts` hot-row contention.

## Known trade-offs
- **Budget bounds attempted work, not successful flips.** `delete_messages`/`recover_messages` return `len(messages)` so skipped no-ops still count against the per-run budget. This is intentional: the cap exists to bound per-tick work (DB round-trips / event-loop time), and counting only flips would let a skip-heavy account iterate unboundedly. Documented in the method docstrings.
- **Deletes are processed before recovers within an account, sharing the budget.** If deletes exhaust the budget, that account's recovers are deferred to the next run (safe via idempotent re-scan). With `MAX_MESSAGES_PER_RUN = 5000` this is unlikely to matter, but an account with consistently many deletes could defer its recovers across ticks.
- **Balance-decrement semantics unchanged:** the running-balance decrement stays unconditional (a cost row with no message-status row still reserves balance), matching the pre-PR behavior.


## last_run resumption fix
The account queries (`get_updated_balance_accounts` / `get_updated_credit_balance_accounts`) are delta-based (`last_update >= last_run`), and the cron framework advanced `last_run` unconditionally after each run. That stranded the remainder of a capped account: once `last_run` moved to `now`, an account with no new balance activity fell out of the query window and its deferred messages were never picked up.

Fix: `BaseCronJob.run` now returns a completion signal — `False` means work was deferred (cap hit). `CronJob.__run_job` advances `last_run` only when the job did **not** return `False`, so the next tick re-queries the same accounts and drains the remainder. The balance/credit jobs return `not deferred`, where `deferred` is set on a cap-break or a truncated `to_delete`/`to_recover` slice. `ORDER BY address` keeps the drain order deterministic across ticks.

Covered by: return-signal assertions in the cap tests, a resumption test that mimics the framework's conditional `last_run` advance (proving a deferred account is not stranded), and a multi-account test (first account exhausts the budget, second is deferred then drained).
