### PR TITLE
chore(deps): adopt measurement registers from aleph-message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "aiohttp-swagger3>=0.10.0",
   "aioipfs~=0.7.1",
   "alembic==1.18.5",
-  "aleph-message @ git+https://github.com/aleph-im/aleph-message.git@bc9c0f86958a746faeecbd6c6f96cc6f5b4538de",
+  "aleph-message @ git+https://github.com/aleph-im/aleph-message.git@4ad261ff25f595a64589d49bf36f514c402e7c5e",
   "aleph-nuls2==0.1.1",
   "aleph-p2p-client @ git+https://github.com/aleph-im/p2p-service-client-python@1e992aaacdb0071a34ffb130cbbba9123509e08b",
   "asyncpg==0.31.0",

--- a/tests/messages/test_vprogram.py
+++ b/tests/messages/test_vprogram.py
@@ -29,7 +29,7 @@ VPROGRAM_CONTENT: Dict[str, Any] = {
         "measurements": [
             {
                 "platform": "sev_snp",
-                "digest": "ab" * 48,
+                "registers": {"launch": "ab" * 48},
                 "vcpu_type": "EPYC-v4",
             }
         ],
@@ -44,7 +44,7 @@ VPROGRAM_CONTENT: Dict[str, Any] = {
     ],
 }
 
-VPROGRAM_ITEM_HASH = "4c319b6bdf98f1e90f2bf8c69da175679fa21ca27d4547bbfa32f77dd3b49fe6"
+VPROGRAM_ITEM_HASH = "1f9df10846e37cfb1fee1bcf139309a449b7fdd005e633c3a38c663edc77a8c3"
 
 VPROGRAM_MESSAGE_DICT = {
     "chain": "ETH",


### PR DESCRIPTION
Adopts the register-map schema from aleph-im/aleph-message#159.

`LaunchMeasurement.digest` becomes a `registers` object, so a
multi-register TEE such as Intel TDX (MRTD plus RTMRs) fits later without a
breaking protocol change. SEV-SNP declares `{"launch": "<hex>"}`.

## Scope

No CCN code changes. V-PROGRAM measurement validation is not implemented
here yet, so pyaleph only sees the shape through the schema. This is the
dependency bump plus the test fixture.

`VPROGRAM_ITEM_HASH` is recomputed because `item_content` is generated from
the content dict. The new value matches the aleph-rs and aleph-vm fixtures
byte for byte, which keeps the existing cross-SDK canonical-serialization
check honest: if those three ever diverge, something is serializing
differently.

## Merge gate

The pin points at aleph-im/aleph-message#159, which must merge and be
reachable on `od/vprogram-schema` before this installs.

## Test plan

- `tests/messages/test_vprogram.py`: 4 passed

Design: aleph-vm `docs/superpowers/specs/2026-08-20-intel-tdx-design.md` §3, §4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaLi3sSGWh8EtWcVn64yni
