### PR TITLE
chore(deps): use released aleph-message 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "aiohttp-swagger3>=0.10.0",
   "aioipfs~=0.7.1",
   "alembic==1.18.5",
-  "aleph-message @ git+https://github.com/aleph-im/aleph-message.git@4ad261ff25f595a64589d49bf36f514c402e7c5e",
+  "aleph-message==1.3.0",
   "aleph-nuls2==0.1.1",
   "aleph-p2p-client @ git+https://github.com/aleph-im/p2p-service-client-python@1e992aaacdb0071a34ffb130cbbba9123509e08b",
   "asyncpg==0.31.0",


### PR DESCRIPTION
Replaces the `aleph-message` git pin with the PyPI release now that 1.3.0
is out, carrying both the V-PROGRAM schema (#158) and the
measurement-registers change (#159).

```diff
-"aleph-message @ git+https://github.com/aleph-im/aleph-message.git@4ad261ff...",
+"aleph-message==1.3.0",
```

Exact `==` pin, matching how the rest of the dependency list is specified.

This discharges the merge gate that the git pin existed for: `main` was
pointing at an unreleased commit, which meant installs depended on a branch
staying reachable.

## Verification

Checked against the **published wheel**, not a working tree:

- `LaunchMeasurement` exposes `{platform, registers, vcpu_type}` and
  `registers.launch` round-trips
- `TeePlatform` is `["sev_snp"]`
- 1.3.0 requires `pydantic>=2` and `typing-extensions>=4.5`; the existing
  pins (2.13.4, 4.15.0) satisfy both, so there is no resolution conflict
- `tests/messages`: 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaLi3sSGWh8EtWcVn64yni
