### PR TITLE
fix(cron): bound metrics-partition DDL lock wait so it can't stall message processing

### DIFF
--- a/src/aleph/jobs/cron/metrics_partition_job.py
+++ b/src/aleph/jobs/cron/metrics_partition_job.py
@@ -25,6 +25,7 @@ import logging
 from typing import Iterable, List, Tuple
 
 from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
 
 from aleph.db.models.cron_jobs import CronJobDb
 from aleph.jobs.cron.cron_job import BaseCronJob
@@ -40,6 +41,14 @@ from aleph.types.db_session import DbSession, DbSessionFactory
 LOGGER = logging.getLogger(__name__)
 
 PARTITIONED_TABLES = ("crn_metrics", "ccn_metrics")
+
+# Bound how long partition DDL may wait for the parent table's ACCESS EXCLUSIVE
+# lock. DETACH/CREATE PARTITION need that lock, and a scoring-metrics INSERT
+# holds ROW EXCLUSIVE; without a cap the maintenance job can queue ahead of — and
+# block — the message-processing INSERT path for a long time, stalling the whole
+# message-processing event loop. If the lock is contended the job defers this
+# table and retries next run (partition maintenance is idempotent).
+PARTITION_LOCK_TIMEOUT = "5s"
 
 
 class MetricsPartitionCronJob(BaseCronJob):
@@ -69,12 +78,29 @@ class MetricsPartitionCronJob(BaseCronJob):
         # exists, so range becomes [..., now_month + N + 1).
         lookahead_upper = add_months(now_month, self.lookahead_months + 1)
 
-        with self.session_factory() as session:
-            for table in PARTITIONED_TABLES:
-                self._ensure_partitions(session, table, now_month, lookahead_upper)
-                self._drop_past_cutoff(session, table, cutoff)
-                self._warn_if_default_has_rows(session, table)
-            session.commit()
+        # One transaction per table so a lock timeout on one does not undo the
+        # other, and each runs under a bounded lock_timeout so maintenance never
+        # blocks the message-processing INSERT path.
+        for table in PARTITIONED_TABLES:
+            try:
+                with self.session_factory() as session:
+                    session.execute(
+                        text(f"SET LOCAL lock_timeout = '{PARTITION_LOCK_TIMEOUT}'")
+                    )
+                    self._ensure_partitions(session, table, now_month, lookahead_upper)
+                    self._drop_past_cutoff(session, table, cutoff)
+                    self._warn_if_default_has_rows(session, table)
+                    session.commit()
+            except OperationalError as err:
+                # lock_timeout fired: the parent lock is contended (a scoring
+                # INSERT is in flight). Defer this table and retry next run
+                # rather than blocking the write path.
+                LOGGER.warning(
+                    "Partition maintenance for %s deferred (lock contended); "
+                    "will retry next run: %s",
+                    table,
+                    err,
+                )
 
     @staticmethod
     def _ensure_partitions(

--- a/src/aleph/jobs/cron/metrics_partition_job.py
+++ b/src/aleph/jobs/cron/metrics_partition_job.py
@@ -71,7 +71,7 @@ class MetricsPartitionCronJob(BaseCronJob):
         self.retention_months = retention_months
         self.lookahead_months = lookahead_months
 
-    async def run(self, now: dt.datetime, job: CronJobDb) -> None:
+    async def run(self, now: dt.datetime, job: CronJobDb) -> bool:
         now_month = month_floor(now)
         cutoff = add_months(now_month, -self.retention_months)
         # Lookahead is inclusive: ensure partition for now_month + N
@@ -81,6 +81,7 @@ class MetricsPartitionCronJob(BaseCronJob):
         # One transaction per table so a lock timeout on one does not undo the
         # other, and each runs under a bounded lock_timeout so maintenance never
         # blocks the message-processing INSERT path.
+        deferred = False
         for table in PARTITIONED_TABLES:
             try:
                 with self.session_factory() as session:
@@ -92,15 +93,20 @@ class MetricsPartitionCronJob(BaseCronJob):
                     self._warn_if_default_has_rows(session, table)
                     session.commit()
             except OperationalError as err:
-                # lock_timeout fired: the parent lock is contended (a scoring
-                # INSERT is in flight). Defer this table and retry next run
-                # rather than blocking the write path.
+                # The parent lock is contended (a scoring INSERT is in flight)
+                # and lock_timeout fired -- or another transient operational
+                # error occurred. Either way, defer this table rather than
+                # blocking the write path. Returning False keeps last_run
+                # unadvanced so the next cron tick retries, instead of waiting a
+                # full interval.
+                deferred = True
                 LOGGER.warning(
-                    "Partition maintenance for %s deferred (lock contended); "
-                    "will retry next run: %s",
+                    "Partition maintenance for %s deferred (%s); will retry next run",
                     table,
                     err,
                 )
+
+        return not deferred
 
     @staticmethod
     def _ensure_partitions(

--- a/tests/jobs/test_metrics_partition_job.py
+++ b/tests/jobs/test_metrics_partition_job.py
@@ -289,16 +289,14 @@ async def test_cron_defers_table_when_parent_lock_is_contended(
 
     # Hold ACCESS EXCLUSIVE on crn_metrics in a separate connection so the cron's
     # CREATE PARTITION on it must wait — and time out.
-    holder = session_factory()
-    holder.execute(text("LOCK TABLE crn_metrics IN ACCESS EXCLUSIVE MODE"))
-    try:
+    with session_factory() as holder:
+        holder.execute(text("LOCK TABLE crn_metrics IN ACCESS EXCLUSIVE MODE"))
         with caplog.at_level(logging.WARNING):
-            # Must return (not hang or raise) despite the contended lock.
-            await job.run(now=now, job=_make_cron_row())
-    finally:
-        holder.rollback()
-        holder.close()
+            # Must return (not hang or raise) despite the contended lock, and
+            # report incomplete so the framework retries next tick.
+            result = await job.run(now=now, job=_make_cron_row())
 
+    assert result is False
     assert "Partition maintenance for crn_metrics deferred" in caplog.text
 
     with session_factory() as session:
@@ -308,3 +306,9 @@ async def test_cron_defers_table_when_parent_lock_is_contended(
     # crn_metrics was deferred (lock contended); ccn_metrics still maintained.
     assert crn_expected not in crn_after
     assert ccn_expected in ccn_after
+
+    # With the lock released, a re-run completes (returns True) and creates the
+    # previously-deferred crn_metrics partition.
+    assert await job.run(now=now, job=_make_cron_row()) is True
+    with session_factory() as session:
+        assert crn_expected in {n for n, _, _ in _list(session, "crn_metrics")}

--- a/tests/jobs/test_metrics_partition_job.py
+++ b/tests/jobs/test_metrics_partition_job.py
@@ -7,6 +7,7 @@ that force the job to either create or drop partitions.
 """
 
 import datetime as dt
+import logging
 
 import pytest
 from aleph_message.models import Chain, ItemType, MessageType
@@ -257,3 +258,53 @@ async def test_partition_routing_places_rows_in_correct_child(
 
     assert child_count == 1
     assert default_count == 0
+
+
+@pytest.mark.asyncio
+async def test_cron_defers_table_when_parent_lock_is_contended(
+    session_factory: DbSessionFactory, monkeypatch, caplog
+):
+    """Partition DDL must not block on the parent's ACCESS EXCLUSIVE lock: when a
+    concurrent transaction holds it (as a scoring-metrics INSERT effectively does
+    against the write path), the cron's bounded lock_timeout fires, the job defers
+    that table and moves on, and the other (uncontended) table still succeeds."""
+    import aleph.jobs.cron.metrics_partition_job as mpj
+
+    monkeypatch.setattr(mpj, "PARTITION_LOCK_TIMEOUT", "200ms")
+
+    now = dt.datetime.now(tz=dt.timezone.utc)
+    expected_month = add_months(month_floor(now), 2)
+    crn_expected = partition_name("crn_metrics", expected_month)
+    ccn_expected = partition_name("ccn_metrics", expected_month)
+
+    with session_factory() as session:
+        assert crn_expected not in {n for n, _, _ in _list(session, "crn_metrics")}
+        assert ccn_expected not in {n for n, _, _ in _list(session, "ccn_metrics")}
+
+    job = MetricsPartitionCronJob(
+        session_factory=session_factory,
+        retention_months=12,
+        lookahead_months=2,
+    )
+
+    # Hold ACCESS EXCLUSIVE on crn_metrics in a separate connection so the cron's
+    # CREATE PARTITION on it must wait — and time out.
+    holder = session_factory()
+    holder.execute(text("LOCK TABLE crn_metrics IN ACCESS EXCLUSIVE MODE"))
+    try:
+        with caplog.at_level(logging.WARNING):
+            # Must return (not hang or raise) despite the contended lock.
+            await job.run(now=now, job=_make_cron_row())
+    finally:
+        holder.rollback()
+        holder.close()
+
+    assert "Partition maintenance for crn_metrics deferred" in caplog.text
+
+    with session_factory() as session:
+        crn_after = {n for n, _, _ in _list(session, "crn_metrics")}
+        ccn_after = {n for n, _, _ in _list(session, "ccn_metrics")}
+
+    # crn_metrics was deferred (lock contended); ccn_metrics still maintained.
+    assert crn_expected not in crn_after
+    assert ccn_expected in ccn_after


### PR DESCRIPTION
## Problem
The message-processing subprocess froze for ~30 minutes right after "Persisting scoring metrics", which starved the RabbitMQ heartbeat (connection declared stuck after 1803s, in-flight `publish` cancelled) and left the CCN unable to process incoming messages — the pending backlog kept climbing.

Root cause is a lock coupling, not raw I/O (a few-hundred-row insert can't take 30 min):

- `insert_node_metrics` (`post.py:369`) does a synchronous `INSERT` into the partitioned `crn_metrics`/`ccn_metrics` — on the message-processing event loop.
- `MetricsPartitionCronJob` takes **ACCESS EXCLUSIVE** on the parent tables for `DETACH`/`CREATE PARTITION`.
- When the cron waits for that lock (behind an in-flight scoring INSERT), its **pending exclusive request queues ahead of subsequent INSERTs** (Postgres fair queuing). Those INSERTs — and therefore the whole message-processing loop — block until the cron's DDL resolves. On the contended HDD this stretched to ~30 min.

The `CancelledError` / "Future exception was never retrieved" and "cancelled by signal" are downstream symptoms (dropped MQ connection + supervisor restart), not the disease.

## Fix
Run each table's partition maintenance in its own transaction under a bounded `SET LOCAL lock_timeout = '5s'`. If the parent lock is contended, the DDL aborts, the job **defers that table and retries next run** (partition maintenance is idempotent), and the write path is never blocked for more than the timeout. Maintenance yields to message processing instead of the reverse.

Per-table transactions also mean a lock timeout on one table doesn't undo the other's maintenance.

## Test
`test_cron_defers_table_when_parent_lock_is_contended`: holds `ACCESS EXCLUSIVE` on `crn_metrics` in a second connection (as an in-flight INSERT effectively does), runs the cron with `lock_timeout` shrunk to 200ms, and asserts it returns without hanging or raising, logs the deferral warning for `crn_metrics`, leaves that table's new partition uncreated, and still creates `ccn_metrics`'s partition.

## Notes
- Pairs with the balance/credit cron event-loop fix (#1244) — same class of "a synchronous DB operation blocks the async loop" problem.
- Root amplifier remains the DB sharing an HDD spindle with IPFS; moving it to SSD removes the contention that turns a "brief" lock into a long one.
- If a stall recurs from a different lock source, `pg_stat_activity` + `pg_blocking_pids` during the block will identify it.