### PR TITLE
fix(perf): stop channels cache growth and O(n) pubsub dedup scan

### DIFF
--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from collections import deque
+from collections import OrderedDict
 from typing import Any
 
 from aleph_p2p_client import AlephP2PServiceClient
@@ -12,6 +12,9 @@ from aleph.types.message_status import InvalidMessageException
 
 LOGGER = logging.getLogger(__name__)
 
+# Max entries kept in the per-topic dedup cache before FIFO eviction.
+SEEN_HASHES_MAXLEN = 200_000
+
 
 async def incoming_channel(
     p2p_client: AlephP2PServiceClient, topic: str, message_publisher: MessagePublisher
@@ -19,7 +22,10 @@ async def incoming_channel(
     LOGGER.debug("incoming channel started...")
 
     await p2p_client.subscribe(topic)
-    seen_hashes: deque[tuple[Any, Any, Any]] = deque([], maxlen=200000)
+    # Dedup cache: OrderedDict used as a bounded set — O(1) membership with
+    # FIFO eviction. A deque here made the per-message membership check an
+    # O(n) linear scan (up to SEEN_HASHES_MAXLEN) on the hot ingress path.
+    seen_hashes: "OrderedDict[tuple[Any, Any, Any], None]" = OrderedDict()
 
     while True:
         try:
@@ -37,23 +43,6 @@ async def incoming_channel(
                     # and such things...
                     try:
                         message_dict = await decode_pubsub_message(message.body)
-                        # Implemented an in-memory cache to avoid deal with the same messages different times.
-                        if (
-                            message_dict["sender"],
-                            message_dict["item_hash"],
-                            message_dict["signature"],
-                        ) in seen_hashes:
-                            # Messages are already ACKed on underlying implementation in p2p_client.receive_messages()
-                            # if the process don't have issues
-                            continue
-
-                        seen_hashes.append(
-                            (
-                                message_dict["sender"],
-                                message_dict["item_hash"],
-                                message_dict["signature"],
-                            )
-                        )
                     except InvalidMessageException:
                         LOGGER.warning(
                             "Received invalid message on P2P topic %s from %s",
@@ -61,6 +50,22 @@ async def incoming_channel(
                             peer_id,
                         )
                         continue
+
+                    # In-memory cache to avoid handling the same message twice.
+                    key = (
+                        message_dict["sender"],
+                        message_dict["item_hash"],
+                        message_dict["signature"],
+                    )
+                    if key in seen_hashes:
+                        # Messages are already ACKed by
+                        # p2p_client.receive_messages() when the process is
+                        # healthy.
+                        continue
+
+                    seen_hashes[key] = None
+                    if len(seen_hashes) > SEEN_HASHES_MAXLEN:
+                        seen_hashes.popitem(last=False)  # evict oldest (FIFO)
 
                     await message_publisher.add_pending_message(
                         message_dict=message_dict, reception_time=utc_now()

--- a/src/aleph/services/p2p/protocol.py
+++ b/src/aleph/services/p2p/protocol.py
@@ -16,16 +16,37 @@ LOGGER = logging.getLogger(__name__)
 SEEN_HASHES_MAXLEN = 200_000
 
 
+class _BoundedSeenCache:
+    """Insertion-ordered set with O(1) membership and FIFO eviction.
+
+    Dedups incoming pubsub messages on the hot ingress path. Backed by an
+    OrderedDict; a deque here made the per-message membership check an O(n)
+    linear scan.
+    """
+
+    def __init__(self, maxlen: int) -> None:
+        self._maxlen = maxlen
+        self._items: OrderedDict[tuple[Any, ...], None] = OrderedDict()
+
+    def __contains__(self, key: tuple[Any, ...]) -> bool:
+        return key in self._items
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def add(self, key: tuple[Any, ...]) -> None:
+        self._items[key] = None
+        if len(self._items) > self._maxlen:
+            self._items.popitem(last=False)  # evict oldest (FIFO)
+
+
 async def incoming_channel(
     p2p_client: AlephP2PServiceClient, topic: str, message_publisher: MessagePublisher
 ) -> None:
     LOGGER.debug("incoming channel started...")
 
     await p2p_client.subscribe(topic)
-    # Dedup cache: OrderedDict used as a bounded set — O(1) membership with
-    # FIFO eviction. A deque here made the per-message membership check an
-    # O(n) linear scan (up to SEEN_HASHES_MAXLEN) on the hot ingress path.
-    seen_hashes: "OrderedDict[tuple[Any, Any, Any], None]" = OrderedDict()
+    seen_hashes = _BoundedSeenCache(maxlen=SEEN_HASHES_MAXLEN)
 
     while True:
         try:
@@ -63,9 +84,7 @@ async def incoming_channel(
                         # healthy.
                         continue
 
-                    seen_hashes[key] = None
-                    if len(seen_hashes) > SEEN_HASHES_MAXLEN:
-                        seen_hashes.popitem(last=False)  # evict oldest (FIFO)
+                    seen_hashes.add(key)
 
                     await message_publisher.add_pending_message(
                         message_dict=message_dict, reception_time=utc_now()

--- a/src/aleph/web/controllers/channels.py
+++ b/src/aleph/web/controllers/channels.py
@@ -9,7 +9,16 @@ from aleph.types.db_session import DbSession
 from aleph.web.controllers.app_state_getters import get_session_factory_from_request
 
 
-@cached(ttl=60 * 120, cache=SimpleMemoryCache, timeout=120)
+@cached(
+    ttl=60 * 120,
+    cache=SimpleMemoryCache,
+    timeout=120,
+    # Constant key: the channel list does not depend on which request Session is
+    # passed. Without this, aiocache keys on the per-request Session's repr
+    # (its memory address), so every request is a cache miss that stores a new
+    # entry — the cache never hits and grows with traffic until TTL eviction.
+    key_builder=lambda *args, **kwargs: "used_channels",
+)
 async def get_channels(session: DbSession) -> List[Channel]:
     # Filter out None
     return [

--- a/src/aleph/web/controllers/channels.py
+++ b/src/aleph/web/controllers/channels.py
@@ -13,10 +13,12 @@ from aleph.web.controllers.app_state_getters import get_session_factory_from_req
     ttl=60 * 120,
     cache=SimpleMemoryCache,
     timeout=120,
-    # Constant key: the channel list does not depend on which request Session is
-    # passed. Without this, aiocache keys on the per-request Session's repr
-    # (its memory address), so every request is a cache miss that stores a new
-    # entry — the cache never hits and grows with traffic until TTL eviction.
+    # aiocache calls key_builder(f, *args, **kwargs); we ignore all of them and
+    # return a constant key. The channel list does not depend on which request
+    # Session is passed. Without this, aiocache's default key includes the
+    # per-request Session's repr (its memory address), so every request is a
+    # cache miss that stores a new entry — the cache never hits and grows with
+    # traffic until TTL eviction.
     key_builder=lambda *args, **kwargs: "used_channels",
 )
 async def get_channels(session: DbSession) -> List[Channel]:

--- a/tests/services/test_p2p_protocol.py
+++ b/tests/services/test_p2p_protocol.py
@@ -1,0 +1,22 @@
+from aleph.services.p2p.protocol import _BoundedSeenCache
+
+
+def test_bounded_seen_cache_membership_and_fifo_eviction():
+    """The pubsub dedup cache must give O(1) membership and evict oldest-first
+    once it exceeds its bound (regression for the O(n) deque scan it replaced)."""
+    cache = _BoundedSeenCache(maxlen=3)
+    keys = [("sender", f"hash{i}", "sig") for i in range(4)]
+
+    for key in keys[:3]:
+        assert key not in cache
+        cache.add(key)
+
+    assert len(cache) == 3
+    assert all(key in cache for key in keys[:3])
+
+    # Adding a 4th key evicts the oldest (FIFO), keeping the bound.
+    cache.add(keys[3])
+    assert len(cache) == 3
+    assert keys[0] not in cache  # evicted
+    assert keys[3] in cache
+    assert all(key in cache for key in keys[1:4])

--- a/tests/web/controllers/test_channels.py
+++ b/tests/web/controllers/test_channels.py
@@ -1,0 +1,38 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from aleph.web.controllers import channels as channels_module
+
+
+@pytest.mark.asyncio
+async def test_get_channels_caches_across_sessions():
+    """The channel-list cache must key on a constant, not the per-request
+    Session.
+
+    Regression for a memory leak: aiocache's default key builder includes the
+    Session argument's repr (its memory address), so every request produced a
+    distinct key -- the cache never hit and grew one entry per request until TTL
+    eviction. With a constant key, two calls made with different Session objects
+    must resolve to a single underlying query.
+    """
+    await channels_module.get_channels.cache.clear()
+
+    calls = {"n": 0}
+
+    def _fake_distinct(session):
+        calls["n"] += 1
+        return ["chanA", None, "chanB"]
+
+    try:
+        with patch.object(channels_module, "get_distinct_channels", _fake_distinct):
+            first = await channels_module.get_channels(Mock(name="session-1"))
+            second = await channels_module.get_channels(Mock(name="session-2"))
+
+        assert first == ["chanA", "chanB"]  # None filtered out
+        assert second == ["chanA", "chanB"]
+        # A per-Session key would call the DB twice (and cache two entries);
+        # the constant key hits the cache on the second, distinct Session.
+        assert calls["n"] == 1
+    finally:
+        await channels_module.get_channels.cache.clear()


### PR DESCRIPTION
Two findings from the memory-leak analysis.

## 1. `channels.get_channels` cache grows with traffic (the RSS culprit)
`@cached(ttl=7200, cache=SimpleMemoryCache)` had **no `key_builder`**, so aiocache's default key includes `str(args)` — i.e. the **per-request `Session`'s repr (its memory address)**. Every request opened a fresh `with session_factory() as session`, producing a distinct key, so:

- every call was a **cache miss** that stored a **new entry** (the cache never hit, and each request re-ran `get_distinct_channels`), and
- `SimpleMemoryCache` has no max size, so entries accumulated one-per-request until the 2h TTL evicted them → RSS rises with request volume.

**Fix:** a constant `key_builder` (the channel list is independent of which Session is passed), so it caches as intended — one entry, real hits, no growth. Adds a regression test asserting two distinct `Session` objects resolve to a single underlying query (fails on the old per-Session key).

The other three `@cached` in `metrics.py` are fine — they take no args or app-level singletons (stable keys), so they cache correctly.

## 2. P2P pubsub dedup: O(n) membership on the hot ingress path
`incoming_channel` used `deque(maxlen=200000)` for the seen-message cache, so the per-message `key in seen_hashes` check was an **O(n) linear scan** (up to 200k) on every inbound pubsub message — a CPU/throughput drag on a busy node.

**Fix:** use an `OrderedDict` as a bounded set — **O(1) membership** with identical FIFO eviction and bound (`SEEN_HASHES_MAXLEN = 200_000`). Dedup semantics (by `(sender, item_hash, signature)`) are unchanged.

## Not in this PR
The analysis's findings #2–#4 (PendingTxPublisher / second IpfsService / subprocess engine not disposed on shutdown) are **one-shot per-process resource leaks**, not traffic-proportional RAM growth — they belong in a separate "clean shutdown / resource disposal" PR. #5 is latent dead code.