### PR TITLE
fix(cleanup): close leaked MQ/IPFS/DB resources on shutdown

### DIFF
--- a/src/aleph/chains/chain_data_service.py
+++ b/src/aleph/chains/chain_data_service.py
@@ -225,26 +225,21 @@ class ChainDataService:
                 raise InvalidContent(error_msg)
 
 
-async def make_pending_tx_exchange(config: Config) -> aio_pika.abc.AbstractExchange:
-    mq_conn = await aio_pika.connect_robust(
-        host=config.p2p.mq_host.value,
-        port=config.rabbitmq.port.value,
-        login=config.rabbitmq.username.value,
-        password=config.rabbitmq.password.value,
-        heartbeat=config.rabbitmq.heartbeat.value,
-    )
-    channel = await mq_conn.channel()
-    pending_tx_exchange = await channel.declare_exchange(
-        name=config.rabbitmq.pending_tx_exchange.value,
-        type=aio_pika.ExchangeType.TOPIC,
-        auto_delete=False,
-    )
-    return pending_tx_exchange
-
-
 class PendingTxPublisher:
-    def __init__(self, pending_tx_exchange: aio_pika.abc.AbstractExchange):
+    def __init__(
+        self,
+        mq_conn: aio_pika.abc.AbstractConnection,
+        pending_tx_exchange: aio_pika.abc.AbstractExchange,
+    ):
+        self.mq_conn = mq_conn
         self.pending_tx_exchange = pending_tx_exchange
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        # Own the MQ connection so it is closed on shutdown instead of leaked.
+        await self.mq_conn.close()
 
     @staticmethod
     def add_pending_tx(session: DbSession, tx: ChainTxDb):
@@ -272,7 +267,17 @@ class PendingTxPublisher:
 
     @classmethod
     async def new(cls, config: Config) -> Self:
-        pending_tx_exchange = await make_pending_tx_exchange(config=config)
-        return cls(
-            pending_tx_exchange=pending_tx_exchange,
+        mq_conn = await aio_pika.connect_robust(
+            host=config.p2p.mq_host.value,
+            port=config.rabbitmq.port.value,
+            login=config.rabbitmq.username.value,
+            password=config.rabbitmq.password.value,
+            heartbeat=config.rabbitmq.heartbeat.value,
         )
+        channel = await mq_conn.channel()
+        pending_tx_exchange = await channel.declare_exchange(
+            name=config.rabbitmq.pending_tx_exchange.value,
+            type=aio_pika.ExchangeType.TOPIC,
+            auto_delete=False,
+        )
+        return cls(mq_conn=mq_conn, pending_tx_exchange=pending_tx_exchange)

--- a/src/aleph/chains/chain_data_service.py
+++ b/src/aleph/chains/chain_data_service.py
@@ -29,6 +29,7 @@ from aleph.schemas.chains.tezos_indexer_response import (
     MessageEventPayload as TezosMessageEventPayload,
 )
 from aleph.storage import StorageService
+from aleph.toolkit.lifecycle import safe_async_cleanup
 from aleph.toolkit.timestamp import utc_now
 from aleph.types.chain_sync import ChainSyncProtocol
 from aleph.types.db_session import DbSession, DbSessionFactory
@@ -239,7 +240,9 @@ class PendingTxPublisher:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         # Own the MQ connection so it is closed on shutdown instead of leaked.
-        await self.mq_conn.close()
+        # Log-and-swallow close errors (matching the other shutdown paths) so an
+        # unreachable broker cannot mask the original shutdown exception.
+        await safe_async_cleanup("pending-tx MQ connection", self.mq_conn.close())
 
     @staticmethod
     def add_pending_tx(session: DbSession, tx: ChainTxDb):

--- a/src/aleph/commands.py
+++ b/src/aleph/commands.py
@@ -184,6 +184,7 @@ async def main(args: List[str]) -> None:
             storage_service=storage_service,
         )
         pending_tx_publisher = await PendingTxPublisher.new(config=config)
+        await stack.enter_async_context(pending_tx_publisher)
         chain_connector = await ChainConnector.new(
             config=config,
             session_factory=session_factory,
@@ -232,9 +233,10 @@ async def main(args: List[str]) -> None:
         tasks += await listener_tasks(
             config=config,
             session_factory=session_factory,
-            node_cache=node_cache,
             p2p_client=p2p_client,
             mq_channel=mq_channel,
+            ipfs_service=ipfs_service,
+            storage_service=storage_service,
         )
         tasks.append(chain_connector.chain_event_loop(config))
         LOGGER.debug("Initialized listeners")

--- a/src/aleph/db/connection.py
+++ b/src/aleph/db/connection.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Optional
 
 from configmanager import Config
 from sqlalchemy import create_engine
@@ -8,6 +9,20 @@ from sqlalchemy.orm import sessionmaker
 
 from aleph.config import get_config
 from aleph.types.db_session import DbSessionFactory
+
+
+@asynccontextmanager
+async def disposing_engine(engine: Engine) -> AsyncIterator[Engine]:
+    """Yield ``engine``, disposing its connection pool on exit.
+
+    Lets a long-running subprocess close its DB connections gracefully on
+    shutdown instead of dropping them (which leaves the Postgres backends to
+    time out and logs unexpected-EOF on the server).
+    """
+    try:
+        yield engine
+    finally:
+        engine.dispose()
 
 
 def make_db_url(

--- a/src/aleph/jobs/fetch_pending_messages.py
+++ b/src/aleph/jobs/fetch_pending_messages.py
@@ -24,7 +24,7 @@ from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
 from aleph.services.storage.fileystem_engine import FileSystemStorageEngine
 from aleph.storage import StorageService
-from aleph.toolkit.lifecycle import install_signal_handlers
+from aleph.toolkit.lifecycle import closing_quietly, install_signal_handlers
 from aleph.toolkit.logging import setup_logging
 from aleph.toolkit.monitoring import setup_sentry
 from aleph.toolkit.timestamp import utc_now
@@ -299,7 +299,7 @@ async def fetch_messages_task(config: Config):
 
     async with (
         disposing_engine(engine),
-        mq_conn,
+        closing_quietly("aleph-fetch MQ connection", mq_conn),
         NodeCache(
             redis_host=config.redis.host.value,
             redis_port=config.redis.port.value,

--- a/src/aleph/jobs/fetch_pending_messages.py
+++ b/src/aleph/jobs/fetch_pending_messages.py
@@ -17,7 +17,7 @@ from aleph.db.accessors.pending_messages import (
     get_next_pending_messages,
     make_pending_message_fetched_statement,
 )
-from aleph.db.connection import make_engine, make_session_factory
+from aleph.db.connection import disposing_engine, make_engine, make_session_factory
 from aleph.db.models import MessageDb, PendingMessageDb
 from aleph.handlers.message_handler import MessageHandler
 from aleph.services.cache.node_cache import NodeCache
@@ -298,6 +298,8 @@ async def fetch_messages_task(config: Config):
     )
 
     async with (
+        disposing_engine(engine),
+        mq_conn,
         NodeCache(
             redis_host=config.redis.host.value,
             redis_port=config.redis.port.value,

--- a/src/aleph/jobs/job_utils.py
+++ b/src/aleph/jobs/job_utils.py
@@ -2,7 +2,7 @@ import asyncio
 import datetime as dt
 import logging
 import random
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 
 import aio_pika
 from configmanager import Config
@@ -30,22 +30,11 @@ MAX_RETRY_INTERVAL: int = 300
 
 
 async def _make_pending_queue(
-    config: Config,
     exchange_name: str,
     queue_name: str,
     routing_key: str,
-    channel: Optional[aio_pika.abc.AbstractChannel] = None,
+    channel: aio_pika.abc.AbstractChannel,
 ) -> aio_pika.abc.AbstractQueue:
-    if not channel:
-        mq_conn = await aio_pika.connect_robust(
-            host=config.p2p.mq_host.value,
-            port=config.rabbitmq.port.value,
-            login=config.rabbitmq.username.value,
-            password=config.rabbitmq.password.value,
-            heartbeat=config.rabbitmq.heartbeat.value,
-        )
-        channel = await mq_conn.channel()
-
     exchange = await channel.declare_exchange(
         name=exchange_name,
         type=aio_pika.ExchangeType.TOPIC,
@@ -60,7 +49,6 @@ async def make_pending_tx_queue(
     config: Config, channel: aio_pika.abc.AbstractChannel
 ) -> aio_pika.abc.AbstractQueue:
     return await _make_pending_queue(
-        config=config,
         exchange_name=config.rabbitmq.pending_tx_exchange.value,
         queue_name="pending-tx-queue",
         routing_key="#",
@@ -71,10 +59,9 @@ async def make_pending_tx_queue(
 async def make_pending_message_queue(
     config: Config,
     routing_key: str,
-    channel: Optional[aio_pika.abc.AbstractChannel] = None,
+    channel: aio_pika.abc.AbstractChannel,
 ) -> aio_pika.abc.AbstractQueue:
     return await _make_pending_queue(
-        config=config,
         exchange_name=config.rabbitmq.pending_message_exchange.value,
         queue_name="pending_message_queue",
         routing_key=routing_key,

--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -15,7 +15,7 @@ from setproctitle import setproctitle
 import aleph.toolkit.json as aleph_json
 from aleph.chains.signature_verifier import SignatureVerifier
 from aleph.db.accessors.pending_messages import get_next_pending_message
-from aleph.db.connection import make_engine, make_session_factory
+from aleph.db.connection import disposing_engine, make_engine, make_session_factory
 from aleph.handlers.message_handler import MessageHandler
 from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
@@ -161,6 +161,7 @@ async def fetch_and_process_messages_task(config: Config):
     session_factory = make_session_factory(engine)
 
     async with (
+        disposing_engine(engine),
         NodeCache(
             redis_host=config.redis.host.value,
             redis_port=config.redis.port.value,

--- a/src/aleph/jobs/process_pending_messages.py
+++ b/src/aleph/jobs/process_pending_messages.py
@@ -21,7 +21,7 @@ from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
 from aleph.services.storage.fileystem_engine import FileSystemStorageEngine
 from aleph.storage import StorageService
-from aleph.toolkit.lifecycle import install_signal_handlers
+from aleph.toolkit.lifecycle import install_signal_handlers, safe_async_cleanup
 from aleph.toolkit.logging import setup_logging
 from aleph.toolkit.monitoring import setup_sentry
 from aleph.toolkit.timestamp import utc_now
@@ -104,6 +104,15 @@ class PendingMessageProcessor(MessageJob):
 
     async def close(self):
         await self.mq_conn.close()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        # The base MqWatcher.__aexit__ only cancels the watcher task; this
+        # processor owns the MQ connection created in new(), so close it here
+        # (log-and-swallow so it can't mask the original shutdown exception).
+        try:
+            await super().__aexit__(exc_type, exc_val, exc_tb)
+        finally:
+            await safe_async_cleanup("process MQ connection", self.close())
 
     async def process_messages(
         self,

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -14,7 +14,7 @@ from setproctitle import setproctitle
 
 from aleph.chains.chain_data_service import ChainDataService
 from aleph.db.accessors.pending_txs import delete_pending_tx, get_pending_txs
-from aleph.db.connection import make_engine, make_session_factory
+from aleph.db.connection import disposing_engine, make_engine, make_session_factory
 from aleph.db.models import PendingTxDb
 from aleph.handlers.message_handler import MessagePublisher
 from aleph.services.cache.node_cache import NodeCache
@@ -135,6 +135,8 @@ async def handle_txs_task(config: Config):
     pending_tx_queue = await make_pending_tx_queue(config=config, channel=mq_channel)
 
     async with (
+        disposing_engine(engine),
+        mq_conn,
         NodeCache(
             redis_host=config.redis.host.value,
             redis_port=config.redis.port.value,

--- a/src/aleph/jobs/process_pending_txs.py
+++ b/src/aleph/jobs/process_pending_txs.py
@@ -21,7 +21,7 @@ from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs.service import IpfsService
 from aleph.services.storage.fileystem_engine import FileSystemStorageEngine
 from aleph.storage import StorageService
-from aleph.toolkit.lifecycle import install_signal_handlers
+from aleph.toolkit.lifecycle import closing_quietly, install_signal_handlers
 from aleph.toolkit.logging import setup_logging
 from aleph.toolkit.monitoring import setup_sentry
 from aleph.toolkit.rabbitmq import make_mq_conn
@@ -136,7 +136,7 @@ async def handle_txs_task(config: Config):
 
     async with (
         disposing_engine(engine),
-        mq_conn,
+        closing_quietly("aleph-txs MQ connection", mq_conn),
         NodeCache(
             redis_host=config.redis.host.value,
             redis_port=config.redis.port.value,

--- a/src/aleph/network.py
+++ b/src/aleph/network.py
@@ -7,11 +7,8 @@ from aleph_p2p_client import AlephP2PServiceClient
 
 import aleph.toolkit.json as aleph_json
 from aleph.handlers.message_handler import MessagePublisher
-from aleph.services.cache.node_cache import NodeCache
 from aleph.services.ipfs import IpfsService
-from aleph.services.ipfs.common import make_ipfs_p2p_client
 from aleph.services.ipfs.pubsub import incoming_channel as incoming_ipfs_channel
-from aleph.services.storage.fileystem_engine import FileSystemStorageEngine
 from aleph.storage import StorageService
 from aleph.types.db_session import DbSessionFactory
 from aleph.types.message_status import InvalidMessageFormat
@@ -39,20 +36,16 @@ async def decode_pubsub_message(message_data: bytes) -> Dict[str, Any]:
 async def listener_tasks(
     config,
     session_factory: DbSessionFactory,
-    node_cache: NodeCache,
     p2p_client: AlephP2PServiceClient,
     mq_channel: aio_pika.abc.AbstractChannel,
+    ipfs_service: IpfsService,
+    storage_service: StorageService,
 ) -> List[Coroutine]:
     from aleph.services.p2p.protocol import incoming_channel as incoming_p2p_channel
 
-    # TODO: these should be passed as parameters. This module could probably be a class instead?
-    ipfs_client = make_ipfs_p2p_client(config)
-    ipfs_service = IpfsService(ipfs_client=ipfs_client)
-    storage_service = StorageService(
-        storage_engine=FileSystemStorageEngine(folder=config.storage.folder.value),
-        ipfs_service=ipfs_service,
-        node_cache=node_cache,
-    )
+    # Reuse the shared IpfsService/StorageService (owned by the caller's exit
+    # stack) instead of building a second IpfsService whose aiohttp pool would
+    # be abandoned for the process lifetime.
     pending_message_exchange = await mq_channel.declare_exchange(
         name=config.rabbitmq.pending_message_exchange.value,
         type=aio_pika.ExchangeType.TOPIC,

--- a/src/aleph/toolkit/lifecycle.py
+++ b/src/aleph/toolkit/lifecycle.py
@@ -1,9 +1,14 @@
 import asyncio
 import logging
 import signal
-from typing import Awaitable, Callable
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Awaitable, Callable, Protocol
 
 LOGGER = logging.getLogger(__name__)
+
+
+class _AsyncCloseable(Protocol):
+    async def close(self) -> Any: ...
 
 
 def install_signal_handlers(
@@ -30,3 +35,18 @@ async def safe_async_cleanup(name: str, awaitable: Awaitable[object]) -> None:
         await awaitable
     except Exception:
         LOGGER.exception("Error during cleanup of %s", name)
+
+
+@asynccontextmanager
+async def closing_quietly(
+    name: str, closeable: _AsyncCloseable
+) -> AsyncIterator[_AsyncCloseable]:
+    """Yield ``closeable``, awaiting ``.close()`` on exit via safe_async_cleanup.
+
+    For shutdown paths that want a resource closed without a close() failure
+    (e.g. an unreachable broker) masking the original exception.
+    """
+    try:
+        yield closeable
+    finally:
+        await safe_async_cleanup(name, closeable.close())

--- a/tests/chains/test_pending_tx_publisher.py
+++ b/tests/chains/test_pending_tx_publisher.py
@@ -1,0 +1,20 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aleph.chains.chain_data_service import PendingTxPublisher
+
+
+@pytest.mark.asyncio
+async def test_pending_tx_publisher_closes_connection_on_exit():
+    """The publisher owns its MQ connection and must close it on context exit
+    (regression: the connection used to be a local in make_pending_tx_exchange
+    and was leaked for the process lifetime)."""
+    mq_conn = AsyncMock()
+    publisher = PendingTxPublisher(mq_conn=mq_conn, pending_tx_exchange=MagicMock())
+
+    async with publisher as entered:
+        assert entered is publisher
+        mq_conn.close.assert_not_called()
+
+    mq_conn.close.assert_awaited_once()

--- a/tests/db/test_connection.py
+++ b/tests/db/test_connection.py
@@ -1,0 +1,23 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from aleph.db.connection import disposing_engine
+
+
+@pytest.mark.asyncio
+async def test_disposing_engine_disposes_on_exit():
+    engine = MagicMock()
+    async with disposing_engine(engine) as yielded:
+        assert yielded is engine
+        engine.dispose.assert_not_called()
+    engine.dispose.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_disposing_engine_disposes_on_exception():
+    engine = MagicMock()
+    with pytest.raises(RuntimeError):
+        async with disposing_engine(engine):
+            raise RuntimeError("boom")
+    engine.dispose.assert_called_once()

--- a/tests/jobs/test_process_pending_messages_cleanup.py
+++ b/tests/jobs/test_process_pending_messages_cleanup.py
@@ -1,0 +1,27 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aleph.jobs.process_pending_messages import PendingMessageProcessor
+
+
+@pytest.mark.asyncio
+async def test_processor_closes_its_mq_connection_on_exit():
+    """PendingMessageProcessor owns the MQ connection created in new(); its
+    __aexit__ must close it (the base MqWatcher.__aexit__ only cancels the
+    watcher task, so without this override the connection leaks)."""
+    mq_conn = AsyncMock()
+    processor = PendingMessageProcessor(
+        session_factory=MagicMock(),
+        message_handler=MagicMock(),
+        max_retries=0,
+        mq_conn=mq_conn,
+        mq_message_exchange=MagicMock(),
+        pending_message_queue=MagicMock(),
+    )
+
+    # No __aenter__, so the base watcher task is None and its __aexit__ is a
+    # no-op; the override must still close the connection.
+    await processor.__aexit__(None, None, None)
+
+    mq_conn.close.assert_awaited_once()

--- a/tests/toolkit/test_lifecycle.py
+++ b/tests/toolkit/test_lifecycle.py
@@ -1,10 +1,15 @@
 import asyncio
 import os
 import signal
+from unittest.mock import AsyncMock
 
 import pytest
 
-from aleph.toolkit.lifecycle import install_signal_handlers, safe_async_cleanup
+from aleph.toolkit.lifecycle import (
+    closing_quietly,
+    install_signal_handlers,
+    safe_async_cleanup,
+)
 
 
 @pytest.mark.asyncio
@@ -42,3 +47,24 @@ async def test_safe_async_cleanup_runs_coroutine_to_completion():
 
     await safe_async_cleanup("slow", slow())
     assert completed
+
+
+@pytest.mark.asyncio
+async def test_closing_quietly_closes_on_exit():
+    closeable = AsyncMock()
+    async with closing_quietly("resource", closeable) as yielded:
+        assert yielded is closeable
+        closeable.close.assert_not_called()
+    closeable.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_closing_quietly_swallows_close_errors(caplog):
+    closeable = AsyncMock()
+    closeable.close.side_effect = RuntimeError("broker down")
+
+    # A close() failure on exit must not propagate (would mask the real cause).
+    async with closing_quietly("resource", closeable):
+        pass
+
+    assert "resource" in caplog.text


### PR DESCRIPTION
Resource-disposal fixes for **one-shot per-process leaks** surfaced by the memory-leak analysis — connection/pool drift that lingers for the process lifetime (and lingers on the server after an ungraceful restart), *not* traffic-proportional RAM growth. Complements the earlier cache/dedup fixes.

## Changes
- **`PendingTxPublisher` owns and closes its MQ connection.** Previously the connection was a local in `make_pending_tx_exchange` and only the exchange was kept, so the connection was never closed. The publisher is now an async context manager (closes the connection on `__aexit__`) and is entered on the startup exit stack. `make_pending_tx_exchange` is inlined into `PendingTxPublisher.new`.
- **`network.listener_tasks` reuses the shared `IpfsService`/`StorageService`.** It was building a *second* `IpfsService` directly (not via `.new()`, not on any stack), abandoning its aiohttp pool for the process lifetime. It now takes the caller's already-managed services as parameters.
- **Subprocesses dispose the DB engine and close their standalone MQ connection on shutdown.** `fetch_pending_messages`, `process_pending_txs`, and `process_pending_messages` never disposed the engine (and the first two never closed their `make_mq_conn` connection). Added a `disposing_engine` helper and put the engine + connection in the outer `async with` so they're cleaned up on shutdown.
- **Removed dead code in `_make_pending_queue`.** The `if not channel:` branch opened an MQ connection it never closed; all callers pass a channel, so it was unreachable. `channel` is now required.

## Tests
Unit tests for the two new cleanup contracts: `disposing_engine` disposes on normal and exceptional exit, and `PendingTxPublisher` closes its connection on context exit. Both are DB-free.

## Scope note
These are graceful-shutdown / resource-hygiene fixes; they don't change runtime behavior on a live node (resources are used the same way, just closed on exit). Subprocess recycling already bounded these, so impact is connection drift on restart rather than live growth.