### PR TITLE
fix(db): bound lock/statement/idle timeouts on the worker DB engine

### DIFF
--- a/src/aleph/api_entrypoint.py
+++ b/src/aleph/api_entrypoint.py
@@ -43,6 +43,11 @@ async def configure_aiohttp_app(
             config,
             echo=config.logging.level.value == logging.DEBUG,
             application_name="aleph-api",
+            # Some aggregate reads (dirty-refresh does a full jsonb_merge over
+            # all elements) can legitimately run longer than the worker default,
+            # so don't cap statement runtime on the API. lock_timeout and
+            # idle_in_transaction still apply.
+            statement_timeout_ms=0,
         )
         session_factory = make_session_factory(engine)
 

--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -228,6 +228,18 @@ def get_defaults():
             "pool_pre_ping": True,
             # Recycle DB connections after this many seconds of inactivity.
             "pool_recycle": 3600,
+            # Fail a statement that waits more than this long (ms) to acquire a
+            # lock. Bounds how long a blocked query can freeze the synchronous
+            # worker event loop (a lock wait took the node down for ~30 min).
+            # 0 disables.
+            "lock_timeout_ms": 30000,
+            # Abort any single statement running longer than this (ms), so a
+            # runaway query cannot wedge the loop. 0 disables. Migrations use a
+            # separate engine and are unaffected.
+            "statement_timeout_ms": 120000,
+            # Abort a transaction left open but idle longer than this (ms),
+            # reclaiming leaked "idle in transaction" sessions. 0 disables.
+            "idle_in_transaction_session_timeout_ms": 300000,
         },
         "ipfs": {
             # Whether to enable storage and communication on IPFS.

--- a/src/aleph/db/connection.py
+++ b/src/aleph/db/connection.py
@@ -88,6 +88,7 @@ def make_engine(
     config: Optional[Config] = None,
     echo: bool = False,
     application_name: Optional[str] = None,
+    statement_timeout_ms: Optional[int] = None,
 ) -> Engine:
     if config is None:
         config = get_config()
@@ -95,9 +96,15 @@ def make_engine(
     # Bound lock waits / statement runtime / idle transactions so a single
     # blocked query cannot freeze the synchronous worker event loop. Migrations
     # use their own engine (deployment/migrations/env.py) and are unaffected.
+    #
+    # statement_timeout_ms can be overridden per engine (e.g. the API passes 0
+    # to disable it, because some aggregate reads legitimately run longer than
+    # the worker default); None means use the config value.
+    if statement_timeout_ms is None:
+        statement_timeout_ms = config.postgres.statement_timeout_ms.value
     options = _timeout_options(
         config.postgres.lock_timeout_ms.value,
-        config.postgres.statement_timeout_ms.value,
+        statement_timeout_ms,
         config.postgres.idle_in_transaction_session_timeout_ms.value,
     )
     connect_args = {"options": options} if options else {}

--- a/src/aleph/db/connection.py
+++ b/src/aleph/db/connection.py
@@ -61,6 +61,29 @@ def make_db_url(
     return connection_string
 
 
+def _timeout_options(
+    lock_timeout_ms: int,
+    statement_timeout_ms: int,
+    idle_in_transaction_session_timeout_ms: int,
+) -> str:
+    """Build the libpq ``options`` string for the per-session timeouts.
+
+    Each timeout is included only when non-zero (0 = disabled, Postgres default
+    of no limit).
+    """
+    parts = []
+    if lock_timeout_ms:
+        parts.append(f"-c lock_timeout={lock_timeout_ms}")
+    if statement_timeout_ms:
+        parts.append(f"-c statement_timeout={statement_timeout_ms}")
+    if idle_in_transaction_session_timeout_ms:
+        parts.append(
+            "-c idle_in_transaction_session_timeout="
+            f"{idle_in_transaction_session_timeout_ms}"
+        )
+    return " ".join(parts)
+
+
 def make_engine(
     config: Optional[Config] = None,
     echo: bool = False,
@@ -68,6 +91,16 @@ def make_engine(
 ) -> Engine:
     if config is None:
         config = get_config()
+
+    # Bound lock waits / statement runtime / idle transactions so a single
+    # blocked query cannot freeze the synchronous worker event loop. Migrations
+    # use their own engine (deployment/migrations/env.py) and are unaffected.
+    options = _timeout_options(
+        config.postgres.lock_timeout_ms.value,
+        config.postgres.statement_timeout_ms.value,
+        config.postgres.idle_in_transaction_session_timeout_ms.value,
+    )
+    connect_args = {"options": options} if options else {}
 
     return create_engine(
         make_db_url(
@@ -77,6 +110,7 @@ def make_engine(
         pool_size=config.postgres.pool_size.value,
         pool_pre_ping=config.postgres.pool_pre_ping.value,
         pool_recycle=config.postgres.pool_recycle.value,
+        connect_args=connect_args,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,11 @@ def run_db_migrations(config: Config):
 def session_factory(mock_config):
     # mock_config is the proxy, but we need the actual config for engine creation
     actual_config = aleph.config.app_config
+    # Tests must not inherit the production statement/lock/idle timeouts: they
+    # can cause spurious failures during schema setup/teardown under load.
+    actual_config.postgres.lock_timeout_ms.value = 0
+    actual_config.postgres.statement_timeout_ms.value = 0
+    actual_config.postgres.idle_in_transaction_session_timeout_ms.value = 0
     engine = make_engine(
         config=actual_config, echo=False, application_name="aleph-tests"
     )

--- a/tests/db/test_connection.py
+++ b/tests/db/test_connection.py
@@ -2,7 +2,40 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from aleph.db.connection import disposing_engine
+from aleph.db.connection import _timeout_options, disposing_engine
+
+
+def test_timeout_options_includes_all_nonzero():
+    opts = _timeout_options(
+        lock_timeout_ms=30000,
+        statement_timeout_ms=120000,
+        idle_in_transaction_session_timeout_ms=300000,
+    )
+    assert opts == (
+        "-c lock_timeout=30000 "
+        "-c statement_timeout=120000 "
+        "-c idle_in_transaction_session_timeout=300000"
+    )
+
+
+def test_timeout_options_skips_zero_values():
+    opts = _timeout_options(
+        lock_timeout_ms=30000,
+        statement_timeout_ms=0,
+        idle_in_transaction_session_timeout_ms=0,
+    )
+    assert opts == "-c lock_timeout=30000"
+
+
+def test_timeout_options_all_zero_is_empty():
+    assert (
+        _timeout_options(
+            lock_timeout_ms=0,
+            statement_timeout_ms=0,
+            idle_in_transaction_session_timeout_ms=0,
+        )
+        == ""
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/db/test_connection.py
+++ b/tests/db/test_connection.py
@@ -1,8 +1,45 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from aleph.db.connection import _timeout_options, disposing_engine
+from aleph.db.connection import _timeout_options, disposing_engine, make_engine
+
+
+def _fake_config(lock=30000, statement=120000, idle=300000):
+    config = MagicMock()
+    config.postgres.lock_timeout_ms.value = lock
+    config.postgres.statement_timeout_ms.value = statement
+    config.postgres.idle_in_transaction_session_timeout_ms.value = idle
+    config.postgres.pool_size.value = 5
+    config.postgres.pool_pre_ping.value = True
+    config.postgres.pool_recycle.value = 3600
+    return config
+
+
+@patch("aleph.db.connection.make_db_url", return_value="postgresql://x")
+@patch("aleph.db.connection.create_engine")
+def test_make_engine_applies_config_timeouts(mock_create_engine, _mock_url):
+    make_engine(config=_fake_config())
+    options = mock_create_engine.call_args.kwargs["connect_args"]["options"]
+    assert options == (
+        "-c lock_timeout=30000 "
+        "-c statement_timeout=120000 "
+        "-c idle_in_transaction_session_timeout=300000"
+    )
+
+
+@patch("aleph.db.connection.make_db_url", return_value="postgresql://x")
+@patch("aleph.db.connection.create_engine")
+def test_make_engine_statement_timeout_override_disables_it(
+    mock_create_engine, _mock_url
+):
+    # The API passes statement_timeout_ms=0 so slow aggregate reads are not
+    # aborted; lock_timeout and idle_in_transaction must still apply.
+    make_engine(config=_fake_config(), statement_timeout_ms=0)
+    options = mock_create_engine.call_args.kwargs["connect_args"]["options"]
+    assert "statement_timeout" not in options
+    assert "lock_timeout=30000" in options
+    assert "idle_in_transaction_session_timeout=300000" in options
 
 
 def test_timeout_options_includes_all_nonzero():

--- a/tests/db/test_connection.py
+++ b/tests/db/test_connection.py
@@ -30,6 +30,14 @@ def test_make_engine_applies_config_timeouts(mock_create_engine, _mock_url):
 
 @patch("aleph.db.connection.make_db_url", return_value="postgresql://x")
 @patch("aleph.db.connection.create_engine")
+def test_make_engine_no_timeouts_omits_options(mock_create_engine, _mock_url):
+    make_engine(config=_fake_config(lock=0, statement=0, idle=0))
+    # With every timeout disabled, no libpq options are passed at all.
+    assert mock_create_engine.call_args.kwargs["connect_args"] == {}
+
+
+@patch("aleph.db.connection.make_db_url", return_value="postgresql://x")
+@patch("aleph.db.connection.create_engine")
 def test_make_engine_statement_timeout_override_disables_it(
     mock_create_engine, _mock_url
 ):


### PR DESCRIPTION
## Why
Message processing and the cron jobs run **synchronous** psycopg2 on a single asyncio loop. A single query that blocks, waiting forever on a lock, or running unbounded — freezes the **entire** loop, and with it the RabbitMQ heartbeat and all message processing. This is the root pattern behind the two stalls fixed earlier (the credit/balance cron and the metrics-partition DDL lock): the node was frozen for ~30 minutes until the lock cleared.

By default Postgres never times these out (`lock_timeout = 0`, `statement_timeout = 0`, `idle_in_transaction_session_timeout = 0`), so there is no floor on how long the loop can be wedged.

## What
Set three per-session timeouts on the engine built by `make_engine`, via libpq `connect_args={"options": ...}`, configurable under `config.postgres` (each `0` disables):

| setting | default | caps |
|---|---|---|
| `lock_timeout_ms` | 30000 | time waiting to acquire a lock |
| `statement_timeout_ms` | 120000 | total runtime of a single statement |
| `idle_in_transaction_session_timeout_ms` | 300000 | a transaction left open but idle (reclaims leaked "idle in transaction" sessions — we observed one parked ~1h) |

A blocked/runaway query now fails fast with `OperationalError` (message retried) instead of freezing the loop. This is a safety net that would have **contained both prior incidents**.

## Scope / safety
- Applies to every engine from `make_engine` (API, main process, and the `fetch`/`txs`/`process` subprocesses) — all the right targets.
- **Migrations are unaffected**: `deployment/migrations/env.py` builds its own `create_engine`, so long backfills (e.g. 0056) won't be killed.
- The metrics-partition cron's `SET LOCAL lock_timeout = '5s'` still overrides the connection default within its own transaction.
- Defaults are generous (a real query never waits 30s on a lock or runs 120s); they only trip on genuinely stuck/runaway work, and ops can tune or disable per deployment.

Adds unit tests for the options builder (all set / some zero / all zero).

## Note
This is the "engine timeouts" safety-net item from the perf backlog; it complements — not replaces — the targeted fixes already merged (chunked crons, partition `lock_timeout`, cache/dedup, resource disposal). It does **not** address the `message_counts` trigger contention (separate, measure-first item).

## Update: API exempt from statement_timeout
Some aggregate reads legitimately run longer than the worker default — `address_aggregate` refreshes dirty aggregates on read, and `refresh_aggregate` does a full `jsonb_merge` over every element, which can exceed 120s for a large aggregate on a slow disk. The API path doesn't retry, so capping it would surface a 500.

`make_engine` now takes a `statement_timeout_ms` override; the API entrypoint passes `0` (uncapped statement runtime), while `lock_timeout` and `idle_in_transaction_session_timeout` still apply there. The workers (fetch/txs/process) and the main process keep the full set. The real fix for slow aggregate reads is the separate dirty-refresh optimization on the perf backlog.
