### PR TITLE
test(db): reset the test database per test instead of re-migrating it

### DIFF
--- a/deployment/migrations/versions/0017_f9fa39b6bdef_vm_instances.py
+++ b/deployment/migrations/versions/0017_f9fa39b6bdef_vm_instances.py
@@ -50,7 +50,7 @@ def reprocess_failed_instance_messages():
             """
         UPDATE message_status
           SET status = 'pending'
-          FROM aleph.public.rejected_messages rm
+          FROM rejected_messages rm
           WHERE message_status.item_hash = rm.item_hash
             AND rm.message ->> 'type' = 'INSTANCE'
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,7 @@ norecursedirs = [ "*.egg", "dist", "build", ".tox", ".venv", "*/site-packages/*"
 testpaths = [ "tests/unit" ]
 markers = [
   "ledger_hardware: marks tests as requiring ledger hardware",
-  "fresh_schema: rebuild the database schema from migrations for this test instead of the fast TRUNCATE reset",
+  "fresh_schema: rebuild the database schema from migrations for this test instead of the fast DELETE-based reset",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,10 @@ filterwarnings = [
 ]
 norecursedirs = [ "*.egg", "dist", "build", ".tox", ".venv", "*/site-packages/*", ".claude", ".worktrees" ]
 testpaths = [ "tests/unit" ]
-markers = { ledger_hardware = "marks tests as requiring ledger hardware" }
+markers = [
+  "ledger_hardware: marks tests as requiring ledger hardware",
+  "fresh_schema: rebuild the database schema from migrations for this test instead of the fast TRUNCATE reset",
+]
 
 [tool.coverage.run]
 branch = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,9 +160,6 @@ def rebuild_schema(engine: Engine, config: Config) -> tuple[List[str], List[str]
     return snapshot_seed_tables(engine)
 
 
-USER_TRIGGER_TABLES = ("messages", "message_confirmations")
-
-
 def _non_empty_tables(conn, tables: List[str]) -> List[str]:
     """Return the subset of `tables` that currently holds at least one row.
 
@@ -197,9 +194,17 @@ def reset_database(migrated_db: MigratedDb) -> bool:
     repair, i.e. a test dropped a table (the metrics partition cron job does):
     the caller then has to fall back to a full rebuild. Tables a test *created*
     are dropped here, so that case does not need a rebuild.
+
+    Drift detection compares table *name sets* only. A test that alters an
+    existing table (adds or drops a column, index, constraint or trigger)
+    leaves that change in place for the tests that follow; mark such a test
+    `fresh_schema` to force a rebuild instead.
     """
     with migrated_db.engine.begin() as conn:
         conn.execute(text("SET LOCAL session_replication_role = replica"))
+        # Turn a reset blocked by a transaction some earlier test left open
+        # into a named error instead of an indefinite hang.
+        conn.execute(text("SET LOCAL lock_timeout = '5s'"))
         # The set of tables is re-read every time rather than taken from the
         # session-scoped snapshot: DDL in a test (partition create/drop) would
         # otherwise leave the snapshot stale and the probes below would fail.
@@ -236,8 +241,21 @@ def reset_database(migrated_db: MigratedDb) -> bool:
         )
         for sequence in dirty_sequences:
             conn.execute(text(f'ALTER SEQUENCE public."{sequence}" RESTART'))
-        for table in USER_TRIGGER_TABLES:
-            conn.execute(text(f'ALTER TABLE public."{table}" ENABLE TRIGGER ALL'))
+        # Re-enable whatever a test disabled, discovered from the catalog so
+        # that a new user trigger is covered without touching this fixture.
+        # regclass::text is already quoted as an identifier where it needs to be.
+        disabled_trigger_tables = (
+            conn.execute(
+                text(
+                    "SELECT DISTINCT tgrelid::regclass::text FROM pg_trigger "
+                    "WHERE NOT tgisinternal AND tgenabled <> 'O'"
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for table in disabled_trigger_tables:
+            conn.execute(text(f"ALTER TABLE {table} ENABLE TRIGGER ALL"))
     return True
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ import alembic.config
 import pytest
 import pytest_asyncio
 import pytz
+import sqlalchemy.exc
 from aleph_message.models import (
     Chain,
     ExecutableContent,
@@ -154,6 +155,9 @@ def snapshot_seed_tables(engine: Engine) -> tuple[List[str], List[str]]:
 def rebuild_schema(engine: Engine, config: Config) -> tuple[List[str], List[str]]:
     """Drop and re-migrate the public schema, then snapshot the seeds."""
     with engine.begin() as conn:
+        # DROP SCHEMA takes an ACCESS EXCLUSIVE lock on every object it removes;
+        # fail with a named error instead of hanging if a test left one open.
+        conn.execute(text("SET LOCAL lock_timeout = '30s'"))
         conn.execute(text("drop schema public cascade"))
         conn.execute(text("create schema public"))
     run_db_migrations(config=config)
@@ -170,7 +174,10 @@ def _non_empty_tables(conn, tables: List[str]) -> List[str]:
     if not tables:
         return []
     probes = " UNION ALL ".join(
-        f"SELECT '{table}' AS table_name WHERE EXISTS (SELECT 1 FROM public.\"{table}\")"
+        "SELECT '{literal}' AS table_name "
+        'WHERE EXISTS (SELECT 1 FROM public."{identifier}")'.format(
+            literal=table.replace("'", "''"), identifier=table
+        )
         for table in tables
     )
     return list(conn.execute(text(probes)).scalars().all())
@@ -195,13 +202,28 @@ def reset_database(migrated_db: MigratedDb) -> bool:
     the caller then has to fall back to a full rebuild. Tables a test *created*
     are dropped here, so that case does not need a rebuild.
 
-    Drift detection compares table *name sets* only. A test that alters an
-    existing table (adds or drops a column, index, constraint or trigger)
-    leaves that change in place for the tests that follow; mark such a test
-    `fresh_schema` to force a rebuild instead.
+    Drift detection compares table *name sets* only. Everything else a test
+    changes about the schema survives into the tests that follow: columns,
+    indexes, constraints, triggers, functions, views, types, extensions and
+    standalone sequences (as opposed to sequences owned by a table column,
+    whose values are rewound below). Mark such a test `fresh_schema` to force
+    a rebuild instead; that marker is the escape hatch for all of them.
+
+    Failure mode to recognise: if a test leaks a connection sitting
+    idle-in-transaction, it holds locks that this reset needs, so every
+    subsequent reset fails after 5 s with `lock_not_available`. The first such
+    error names the test that leaked; the ones after it are collateral.
     """
     with migrated_db.engine.begin() as conn:
-        conn.execute(text("SET LOCAL session_replication_role = replica"))
+        try:
+            conn.execute(text("SET LOCAL session_replication_role = replica"))
+        except sqlalchemy.exc.ProgrammingError as e:
+            raise RuntimeError(
+                "the test database role must be a superuser: the fast reset "
+                "relies on session_replication_role to suppress foreign key "
+                "triggers while it empties the tables (CI's POSTGRES_USER "
+                "'aleph' is the superuser of its postgres instance)"
+            ) from e
         # Turn a reset blocked by a transaction some earlier test left open
         # into a named error instead of an indefinite hang.
         conn.execute(text("SET LOCAL lock_timeout = '5s'"))
@@ -243,19 +265,26 @@ def reset_database(migrated_db: MigratedDb) -> bool:
             conn.execute(text(f'ALTER SEQUENCE public."{sequence}" RESTART'))
         # Re-enable whatever a test disabled, discovered from the catalog so
         # that a new user trigger is covered without touching this fixture.
+        # Only tables in `public` holding a user trigger that is actually
+        # disabled ('D'); triggers set to ALWAYS ('A') or REPLICA ('R') are left
+        # alone rather than demoted to 'O'.
         # regclass::text is already quoted as an identifier where it needs to be.
         disabled_trigger_tables = (
             conn.execute(
                 text(
-                    "SELECT DISTINCT tgrelid::regclass::text FROM pg_trigger "
-                    "WHERE NOT tgisinternal AND tgenabled <> 'O'"
+                    "SELECT DISTINCT tgrelid::regclass::text FROM pg_trigger t "
+                    "JOIN pg_class c ON c.oid = t.tgrelid "
+                    "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                    "WHERE n.nspname = 'public' AND NOT t.tgisinternal "
+                    "AND t.tgenabled = 'D'"
                 )
             )
             .scalars()
             .all()
         )
         for table in disabled_trigger_tables:
-            conn.execute(text(f"ALTER TABLE {table} ENABLE TRIGGER ALL"))
+            # USER, not ALL: never touch the internal foreign key triggers.
+            conn.execute(text(f"ALTER TABLE {table} ENABLE TRIGGER USER"))
     return True
 
 
@@ -273,8 +302,10 @@ def migrated_db():
 
     tables, seed_tables = rebuild_schema(engine, config)
 
-    # Running migrations pollutes aleph.config.app_config by loading config.yml.
-    # Replace the global with a completely fresh test config object.
+    # Defensive: migrations are run with `-x db_url=...`, and env.py returns the
+    # URL before it ever calls get_config(), so config.yml is no longer loaded
+    # into the global config. Reinstall a fresh test config anyway so that a
+    # future change to env.py cannot leak node settings into the test run.
     aleph.config.app_config = _create_test_config()
 
     yield MigratedDb(engine=engine, tables=tables, seed_tables=seed_tables)
@@ -300,10 +331,17 @@ def session_factory(request, mock_config, migrated_db: MigratedDb):
         migrated_db.tables, migrated_db.seed_tables = rebuild_schema(
             migrated_db.engine, config
         )
-        # Running migrations pollutes aleph.config.app_config by loading
-        # config.yml; restore the fresh test config as before.
+        # Defensive, as in `migrated_db`: env.py no longer loads config.yml
+        # when the URL comes from `-x db_url=...`, but reinstalling a fresh
+        # test config keeps that from mattering.
         aleph.config.app_config = _create_test_config()
-    return make_session_factory(migrated_db.engine)
+    yield make_session_factory(migrated_db.engine)
+    # A connection still checked out here is one the test never returned to the
+    # pool. It would sit idle-in-transaction holding locks and make the *next*
+    # test's reset fail with lock_not_available, so name the culprit here.
+    assert (
+        migrated_db.engine.pool.checkedout() == 0
+    ), "a test leaked a checked-out DB connection"
 
 
 def _create_test_config() -> Config:
@@ -330,10 +368,11 @@ class _ConfigProxy:
     """
     A proxy that always delegates to aleph.config.app_config.
 
-    Running migrations for tests updates the global config values by loading config.yml.
-    The session factory fixture does replace the global object with a fresh config for tests afterward,
-    but if mock_config() returns a Config object directly it will be the one that has been modified.
-    To avoid this, we use a proxy pattern to always return the current global config in mock_config().
+    The DB fixtures reinstall a fresh `aleph.config.app_config` after migrating,
+    now only defensively: migrations run with `-x db_url=...` and env.py returns
+    before `get_config()`, so config.yml is not loaded into the global config any
+    more. Returning a proxy instead of a Config object from mock_config() means
+    a test always sees whatever the current global config is, whoever replaced it.
     """
 
     def __getattr__(self, name):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import argparse
 import asyncio
 import contextlib
 import datetime as dt
@@ -6,6 +7,7 @@ import logging
 import os
 import shutil
 import sys
+from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
 from typing import List, Protocol
@@ -26,6 +28,7 @@ from aleph_message.models import (
 from aleph_message.models.execution.volume import ImmutableVolume
 from configmanager import Config
 from sqlalchemy import text
+from sqlalchemy.engine import Engine
 
 import aleph.config
 from aleph.db.accessors.files import insert_message_file_pin, upsert_file_tag
@@ -86,36 +89,110 @@ def run_db_migrations(config: Config):
     db_url = make_db_url(driver="psycopg2", config=config)
     alembic_cfg = alembic.config.Config("alembic.ini")
     alembic_cfg.attributes["configure_logger"] = False
+    # env.py reads the target URL from `-x db_url=...`; alembic's `tag`
+    # argument is ignored there, so pass the URL the way env.py expects.
+    alembic_cfg.cmd_opts = argparse.Namespace(x=[f"db_url={db_url}"])
     logging.getLogger("alembic").setLevel(logging.CRITICAL)
 
     with change_dir(project_dir):
-        alembic.command.upgrade(alembic_cfg, "head", tag=db_url)
+        alembic.command.upgrade(alembic_cfg, "head")
 
 
-@pytest.fixture
-def session_factory(mock_config):
-    # mock_config is the proxy, but we need the actual config for engine creation
-    actual_config = aleph.config.app_config
-    # Tests must not inherit the production statement/lock/idle timeouts: they
-    # can cause spurious failures during schema setup/teardown under load.
-    actual_config.postgres.lock_timeout_ms.value = 0
-    actual_config.postgres.statement_timeout_ms.value = 0
-    actual_config.postgres.idle_in_transaction_session_timeout_ms.value = 0
-    engine = make_engine(
-        config=actual_config, echo=False, application_name="aleph-tests"
+@dataclass
+class MigratedDb:
+    """A freshly migrated schema plus a snapshot of its seeded rows.
+
+    `tables` lists every table in `public`; `seed_tables` the subset that
+    migrations populate (copied to `seed.<table>` so per-test resets can
+    restore them without re-running migrations).
+    """
+
+    engine: Engine
+    tables: List[str]
+    seed_tables: List[str]
+
+
+SEED_SCHEMA = "seed"
+
+
+def _public_tables(conn) -> List[str]:
+    rows = conn.execute(
+        text(
+            "SELECT table_name FROM information_schema.tables "
+            "WHERE table_schema = 'public' AND table_type = 'BASE TABLE' "
+            "ORDER BY table_name"
+        )
     )
+    return [row[0] for row in rows]
 
+
+def snapshot_seed_tables(engine: Engine) -> tuple[List[str], List[str]]:
+    """Copy every non-empty public table into the `seed` schema.
+
+    Returns (all public tables, seeded tables). Discovery is by row count so
+    a new migration that seeds another table is picked up automatically.
+    """
+    with engine.begin() as conn:
+        conn.execute(text(f"DROP SCHEMA IF EXISTS {SEED_SCHEMA} CASCADE"))
+        conn.execute(text(f"CREATE SCHEMA {SEED_SCHEMA}"))
+        tables = _public_tables(conn)
+        seed_tables = []
+        for table in tables:
+            count = conn.execute(
+                text(f'SELECT count(*) FROM public."{table}"')
+            ).scalar()
+            if count:
+                conn.execute(
+                    text(
+                        f'CREATE TABLE {SEED_SCHEMA}."{table}" AS TABLE public."{table}"'
+                    )
+                )
+                seed_tables.append(table)
+    return tables, seed_tables
+
+
+def rebuild_schema(engine: Engine, config: Config) -> tuple[List[str], List[str]]:
+    """Drop and re-migrate the public schema, then snapshot the seeds."""
     with engine.begin() as conn:
         conn.execute(text("drop schema public cascade"))
         conn.execute(text("create schema public"))
+    run_db_migrations(config=config)
+    return snapshot_seed_tables(engine)
 
-    run_db_migrations(config=actual_config)
+
+@pytest.fixture(scope="session")
+def migrated_db():
+    # Session-scoped, so it cannot depend on the function-scoped mock_config:
+    # build the same test config it would install.
+    config = _create_test_config()
+    # Tests must not inherit the production statement/lock/idle timeouts: they
+    # can cause spurious failures during schema setup/teardown under load.
+    config.postgres.lock_timeout_ms.value = 0
+    config.postgres.statement_timeout_ms.value = 0
+    config.postgres.idle_in_transaction_session_timeout_ms.value = 0
+    engine = make_engine(config=config, echo=False, application_name="aleph-tests")
+
+    tables, seed_tables = rebuild_schema(engine, config)
 
     # Running migrations pollutes aleph.config.app_config by loading config.yml.
     # Replace the global with a completely fresh test config object.
     aleph.config.app_config = _create_test_config()
 
-    return make_session_factory(engine)
+    yield MigratedDb(engine=engine, tables=tables, seed_tables=seed_tables)
+    engine.dispose()
+
+
+@pytest.fixture
+def session_factory(mock_config, migrated_db: MigratedDb):
+    # Temporary: Task 3 replaces the body with the TRUNCATE + reseed reset.
+    config = aleph.config.app_config
+    config.postgres.lock_timeout_ms.value = 0
+    config.postgres.statement_timeout_ms.value = 0
+    config.postgres.idle_in_transaction_session_timeout_ms.value = 0
+    tables, seed_tables = rebuild_schema(migrated_db.engine, config)
+    migrated_db.tables, migrated_db.seed_tables = tables, seed_tables
+    aleph.config.app_config = _create_test_config()
+    return make_session_factory(migrated_db.engine)
 
 
 def _create_test_config() -> Config:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,6 +160,87 @@ def rebuild_schema(engine: Engine, config: Config) -> tuple[List[str], List[str]
     return snapshot_seed_tables(engine)
 
 
+USER_TRIGGER_TABLES = ("messages", "message_confirmations")
+
+
+def _non_empty_tables(conn, tables: List[str]) -> List[str]:
+    """Return the subset of `tables` that currently holds at least one row.
+
+    A single statement with one EXISTS probe per table: a few milliseconds for
+    this schema's ~70 tables, which keeps the reset proportional to what the
+    test actually wrote instead of to the size of the schema.
+    """
+    if not tables:
+        return []
+    probes = " UNION ALL ".join(
+        f"SELECT '{table}' AS table_name WHERE EXISTS (SELECT 1 FROM public.\"{table}\")"
+        for table in tables
+    )
+    return list(conn.execute(text(probes)).scalars().all())
+
+
+def reset_database(migrated_db: MigratedDb) -> bool:
+    """Return the schema to its freshly migrated state without migrating.
+
+    Empties every public table except alembic_version, restores the seeded rows
+    from the `seed` schema, rewinds any sequence a test advanced, and re-enables
+    user triggers a previous test may have left disabled.
+
+    DELETE rather than TRUNCATE: TRUNCATE gives each table a new relfilenode and
+    the commit fsyncs all of them, which costs ~4.5 s for this schema's 68 tables
+    (~112 ms even for a single table). Deleting only the handful of tables a test
+    touched takes ~10 ms. `session_replication_role = replica` suppresses foreign
+    key triggers so the tables can be emptied in any order, which is what CASCADE
+    bought us before.
+
+    Returns False if the schema itself drifted beyond what deleting rows can
+    repair, i.e. a test dropped a table (the metrics partition cron job does):
+    the caller then has to fall back to a full rebuild. Tables a test *created*
+    are dropped here, so that case does not need a rebuild.
+    """
+    with migrated_db.engine.begin() as conn:
+        conn.execute(text("SET LOCAL session_replication_role = replica"))
+        # The set of tables is re-read every time rather than taken from the
+        # session-scoped snapshot: DDL in a test (partition create/drop) would
+        # otherwise leave the snapshot stale and the probes below would fail.
+        current = set(_public_tables(conn))
+        expected = set(migrated_db.tables)
+        for table in sorted(current - expected):
+            conn.execute(text(f'DROP TABLE IF EXISTS public."{table}" CASCADE'))
+        if expected - current:
+            return False
+        targets = sorted(expected - {"alembic_version"})
+        for table in _non_empty_tables(conn, targets):
+            conn.execute(text(f'DELETE FROM public."{table}"'))
+        for table in migrated_db.seed_tables:
+            if table == "alembic_version":
+                continue
+            conn.execute(
+                text(
+                    f'INSERT INTO public."{table}" SELECT * FROM {SEED_SCHEMA}."{table}"'
+                )
+            )
+        # A test can advance a sequence without leaving a row behind, so rewind
+        # every sequence that has been used. No migration seeds a serial column
+        # (the seeded tables carry explicit keys), so "unused" is the freshly
+        # migrated state for all of them.
+        dirty_sequences = (
+            conn.execute(
+                text(
+                    "SELECT sequencename FROM pg_sequences "
+                    "WHERE schemaname = 'public' AND last_value IS NOT NULL"
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for sequence in dirty_sequences:
+            conn.execute(text(f'ALTER SEQUENCE public."{sequence}" RESTART'))
+        for table in USER_TRIGGER_TABLES:
+            conn.execute(text(f'ALTER TABLE public."{table}" ENABLE TRIGGER ALL'))
+    return True
+
+
 @pytest.fixture(scope="session")
 def migrated_db():
     # Session-scoped, so it cannot depend on the function-scoped mock_config:
@@ -183,15 +264,27 @@ def migrated_db():
 
 
 @pytest.fixture
-def session_factory(mock_config, migrated_db: MigratedDb):
-    # Temporary: Task 3 replaces the body with the TRUNCATE + reseed reset.
-    config = aleph.config.app_config
-    config.postgres.lock_timeout_ms.value = 0
-    config.postgres.statement_timeout_ms.value = 0
-    config.postgres.idle_in_transaction_session_timeout_ms.value = 0
-    tables, seed_tables = rebuild_schema(migrated_db.engine, config)
-    migrated_db.tables, migrated_db.seed_tables = tables, seed_tables
-    aleph.config.app_config = _create_test_config()
+def session_factory(request, mock_config, migrated_db: MigratedDb):
+    """A session factory on a database in its freshly migrated state.
+
+    Fast path: delete the rows a test wrote and restore the seeds (tens of
+    milliseconds). Tests marked `fresh_schema` get the slow path: drop the
+    schema and re-run migrations. A test that drops a table forces the slow
+    path for the test after it, since only migrations can bring the table back.
+    """
+    if request.node.get_closest_marker("fresh_schema") or not reset_database(
+        migrated_db
+    ):
+        config = aleph.config.app_config
+        config.postgres.lock_timeout_ms.value = 0
+        config.postgres.statement_timeout_ms.value = 0
+        config.postgres.idle_in_transaction_session_timeout_ms.value = 0
+        migrated_db.tables, migrated_db.seed_tables = rebuild_schema(
+            migrated_db.engine, config
+        )
+        # Running migrations pollutes aleph.config.app_config by loading
+        # config.yml; restore the fresh test config as before.
+        aleph.config.app_config = _create_test_config()
     return make_session_factory(migrated_db.engine)
 
 

--- a/tests/db/test_messages.py
+++ b/tests/db/test_messages.py
@@ -716,6 +716,9 @@ async def test_migration_backfill_forgotten_at(
         assert forgotten_message.forgotten_at == fixture_message.time
 
 
+# Marked: the ALTER TABLE statements below are schema drift the row-level reset
+# cannot detect or undo, so this test needs a schema rebuilt from migrations.
+@pytest.mark.fresh_schema
 @pytest.mark.asyncio
 async def test_migration_0061_column_additions_are_rerunnable(
     session_factory: DbSessionFactory,

--- a/tests/db/test_migrations.py
+++ b/tests/db/test_migrations.py
@@ -1,0 +1,69 @@
+"""Migrations must not depend on the database being named `aleph`."""
+
+import argparse
+import logging
+from pathlib import Path
+
+import alembic.command
+import alembic.config
+import pytest
+from sqlalchemy import create_engine, text
+
+import aleph.config
+from aleph.db.connection import make_db_url
+
+SCRATCH_DB = "aleph_migration_probe"
+
+
+def _terminate_other_sessions(conn, dbname: str) -> None:
+    """Terminate any other backends connected to `dbname`.
+
+    Alembic's `env.py` is exec'd as a module and keeps a reference cycle
+    (its globals reference functions whose __globals__ point back to the
+    module dict), so the engine it creates is not reclaimed by CPython's
+    refcounting alone; it lingers until a cyclic GC pass runs. Without
+    terminating it explicitly, DROP DATABASE can fail with
+    "database is being accessed by other users".
+    """
+    conn.execute(
+        text(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+            "WHERE datname = :dbname AND pid <> pg_backend_pid()"
+        ),
+        {"dbname": dbname},
+    )
+
+
+@pytest.fixture
+def scratch_db_url(mock_config):
+    """Create an empty database with a non-default name and return its URL."""
+    admin_url = make_db_url(driver="psycopg2", config=aleph.config.app_config)
+    admin_engine = create_engine(
+        admin_url.rsplit("/", 1)[0] + "/postgres", isolation_level="AUTOCOMMIT"
+    )
+    with admin_engine.connect() as conn:
+        _terminate_other_sessions(conn, SCRATCH_DB)
+        conn.execute(text(f"DROP DATABASE IF EXISTS {SCRATCH_DB}"))
+        conn.execute(text(f"CREATE DATABASE {SCRATCH_DB}"))
+    yield admin_url.rsplit("/", 1)[0] + f"/{SCRATCH_DB}"
+    with admin_engine.connect() as conn:
+        _terminate_other_sessions(conn, SCRATCH_DB)
+        conn.execute(text(f"DROP DATABASE IF EXISTS {SCRATCH_DB}"))
+    admin_engine.dispose()
+
+
+def test_migrations_apply_to_any_database_name(scratch_db_url):
+    project_dir = Path(__file__).parent.parent.parent
+    alembic_cfg = alembic.config.Config(str(project_dir / "alembic.ini"))
+    alembic_cfg.attributes["configure_logger"] = False
+    alembic_cfg.cmd_opts = argparse.Namespace(x=[f"db_url={scratch_db_url}"])
+    logging.getLogger("alembic").setLevel(logging.CRITICAL)
+
+    alembic.command.upgrade(alembic_cfg, "head")
+
+    engine = create_engine(scratch_db_url)
+    with engine.connect() as conn:
+        version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar()
+        assert version is not None
+        assert conn.execute(text("SELECT count(*) FROM error_codes")).scalar() == 25
+    engine.dispose()

--- a/tests/db/test_migrations.py
+++ b/tests/db/test_migrations.py
@@ -1,12 +1,21 @@
-"""Migrations must not depend on the database being named `aleph`."""
+"""Migrations must not depend on the database being named `aleph`.
+
+Requires the test database role to be a superuser: the scratch database is
+created and dropped with CREATE DATABASE / DROP DATABASE and any leftover
+backend on it is closed with pg_terminate_backend. CI runs postgres with
+`POSTGRES_USER: aleph`, which is the superuser of that instance.
+"""
 
 import argparse
+import contextlib
 import logging
+import os
 from pathlib import Path
 
 import alembic.command
 import alembic.config
 import pytest
+from db_seeds import EXPECTED_ERROR_CODE_ROWS
 from sqlalchemy import create_engine, text
 
 import aleph.config
@@ -15,15 +24,31 @@ from aleph.db.connection import make_db_url
 SCRATCH_DB = "aleph_migration_probe"
 
 
+@contextlib.contextmanager
+def change_dir(directory: Path):
+    """Run the block with `directory` as the working directory.
+
+    Copied from `tests/conftest.py` rather than imported: conftest is not an
+    importable module for tests.
+    """
+    current_directory = Path.cwd()
+    try:
+        os.chdir(directory)
+        yield
+    finally:
+        os.chdir(current_directory)
+
+
 def _terminate_other_sessions(conn, dbname: str) -> None:
     """Terminate any other backends connected to `dbname`.
 
-    Alembic's `env.py` is exec'd as a module and keeps a reference cycle
-    (its globals reference functions whose __globals__ point back to the
-    module dict), so the engine it creates is not reclaimed by CPython's
-    refcounting alone; it lingers until a cyclic GC pass runs. Without
-    terminating it explicitly, DROP DATABASE can fail with
-    "database is being accessed by other users".
+    `deployment/migrations/env.py` never disposes the engine its
+    `run_migrations_online` creates, and SQLAlchemy's pool keeps the physical
+    connection open after the `connect()` block exits. The pooled connection is
+    only released when the engine is garbage collected, and the `QueuePool` /
+    `_ConnectionRecord` reference cycle defers that to a cyclic GC pass. So the
+    scratch database may still have a live backend when we DROP it, which fails
+    with "database is being accessed by other users" unless we close it here.
     """
     conn.execute(
         text(
@@ -59,11 +84,16 @@ def test_migrations_apply_to_any_database_name(scratch_db_url):
     alembic_cfg.cmd_opts = argparse.Namespace(x=[f"db_url={scratch_db_url}"])
     logging.getLogger("alembic").setLevel(logging.CRITICAL)
 
-    alembic.command.upgrade(alembic_cfg, "head")
+    # alembic.ini's `script_location` is relative to the working directory.
+    with change_dir(project_dir):
+        alembic.command.upgrade(alembic_cfg, "head")
 
     engine = create_engine(scratch_db_url)
     with engine.connect() as conn:
         version = conn.execute(text("SELECT version_num FROM alembic_version")).scalar()
         assert version is not None
-        assert conn.execute(text("SELECT count(*) FROM error_codes")).scalar() == 25
+        assert (
+            conn.execute(text("SELECT count(*) FROM error_codes")).scalar()
+            == EXPECTED_ERROR_CODE_ROWS
+        )
     engine.dispose()

--- a/tests/db/test_session_factory.py
+++ b/tests/db/test_session_factory.py
@@ -12,6 +12,15 @@ from aleph.types.files import FileType
 
 SEED_COUNTS = {"alembic_version": 1, "cron_jobs": 3, "error_codes": 25}
 
+# Filled in by the step tests below so that a later step can tell whether the
+# schema was rebuilt between the two: re-running the migrations recreates every
+# table with a fresh OID, while the fast reset leaves the tables in place.
+OBSERVED_OIDS: dict[str, int] = {}
+
+
+def _messages_oid(session) -> int:
+    return session.execute(text("SELECT 'public.messages'::regclass::oid")).scalar()
+
 
 def test_migrated_db_snapshots_seed_tables(migrated_db):
     assert set(migrated_db.seed_tables) == set(SEED_COUNTS)
@@ -104,6 +113,48 @@ def test_reset_step_4_sees_trigger_enabled(session_factory: DbSessionFactory):
         assert state == "O"
 
 
+def test_reset_step_5_creates_a_table(session_factory: DbSessionFactory):
+    with session_factory() as session:
+        session.execute(text("CREATE TABLE leftover_t (i int)"))
+        OBSERVED_OIDS["before_created_table"] = _messages_oid(session)
+        session.commit()
+
+
+def test_reset_step_6_drops_the_created_table_without_rebuilding(
+    session_factory: DbSessionFactory,
+):
+    with session_factory() as session:
+        assert (
+            session.execute(text("SELECT to_regclass('public.leftover_t')")).scalar()
+            is None
+        )
+        # A table the test created is dropped in place: no rebuild needed.
+        assert _messages_oid(session) == OBSERVED_OIDS["before_created_table"]
+
+
+def test_reset_step_7_drops_an_expected_table(session_factory: DbSessionFactory):
+    with session_factory() as session:
+        session.execute(text("DROP TABLE public.ccn_metrics_default"))
+        OBSERVED_OIDS["before_dropped_table"] = _messages_oid(session)
+        session.commit()
+
+
+def test_reset_step_8_rebuilds_after_an_expected_table_was_dropped(
+    session_factory: DbSessionFactory,
+):
+    with session_factory() as session:
+        # Only re-running the migrations can bring a dropped table back.
+        assert (
+            session.execute(
+                text("SELECT to_regclass('public.ccn_metrics_default')")
+            ).scalar()
+            is not None
+        )
+        assert _messages_oid(session) != OBSERVED_OIDS["before_dropped_table"]
+        # Baseline for the marked test below, which must rebuild again.
+        OBSERVED_OIDS["before_fresh_schema"] = _messages_oid(session)
+
+
 @pytest.mark.fresh_schema
 def test_fresh_schema_marker_rebuilds(session_factory: DbSessionFactory, migrated_db):
     # A marked test gets a rebuilt schema and a refreshed seed snapshot.
@@ -112,4 +163,6 @@ def test_fresh_schema_marker_rebuilds(session_factory: DbSessionFactory, migrate
             assert (
                 session.execute(text(f"SELECT count(*) FROM {table}")).scalar() == count
             )
+        # The rebuild really re-ran the migrations rather than deleting rows.
+        assert _messages_oid(session) != OBSERVED_OIDS["before_fresh_schema"]
     assert set(migrated_db.seed_tables) == set(SEED_COUNTS)

--- a/tests/db/test_session_factory.py
+++ b/tests/db/test_session_factory.py
@@ -1,0 +1,17 @@
+"""The DB fixtures: one migration per session, TRUNCATE + seed restore per test."""
+
+from sqlalchemy import text
+
+SEED_COUNTS = {"alembic_version": 1, "cron_jobs": 3, "error_codes": 25}
+
+
+def test_migrated_db_snapshots_seed_tables(migrated_db):
+    assert set(migrated_db.seed_tables) == set(SEED_COUNTS)
+    assert "messages" in migrated_db.tables
+    assert len(migrated_db.tables) >= 60
+    with migrated_db.engine.connect() as conn:
+        for table, count in SEED_COUNTS.items():
+            assert (
+                conn.execute(text(f"SELECT count(*) FROM seed.{table}")).scalar()
+                == count
+            )

--- a/tests/db/test_session_factory.py
+++ b/tests/db/test_session_factory.py
@@ -1,6 +1,14 @@
-"""The DB fixtures: one migration per session, TRUNCATE + seed restore per test."""
+"""The DB fixtures: one migration per session, delete + seed restore per test."""
 
-from sqlalchemy import text
+import datetime as dt
+
+import pytest
+from aleph_message.models import Chain, ItemType, MessageType
+from sqlalchemy import select, text
+
+from aleph.db.models import ErrorCodeDb, PendingMessageDb, StoredFileDb
+from aleph.types.db_session import DbSessionFactory
+from aleph.types.files import FileType
 
 SEED_COUNTS = {"alembic_version": 1, "cron_jobs": 3, "error_codes": 25}
 
@@ -15,3 +23,93 @@ def test_migrated_db_snapshots_seed_tables(migrated_db):
                 conn.execute(text(f"SELECT count(*) FROM seed.{table}")).scalar()
                 == count
             )
+
+
+def _insert_residue(session_factory: DbSessionFactory) -> None:
+    with session_factory() as session:
+        session.add(StoredFileDb(hash="ab" * 32, size=1, type=FileType.FILE))
+        session.add(
+            PendingMessageDb(
+                item_hash="cd" * 32,
+                type=MessageType.post,
+                chain=Chain.ETH,
+                sender="0x" + "1" * 40,
+                signature=None,
+                item_type=ItemType.inline,
+                item_content="{}",
+                time=dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc),
+                channel=None,
+                reception_time=dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc),
+                fetched=True,
+                check_message=False,
+                retries=0,
+                next_attempt=dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc),
+            )
+        )
+        # Burn a sequence value so the next test can see it was restarted.
+        session.execute(
+            text("SELECT nextval(pg_get_serial_sequence('file_pins', 'id'))")
+        )
+        session.commit()
+
+
+def test_reset_step_1_leaves_residue(session_factory: DbSessionFactory):
+    _insert_residue(session_factory)
+    with session_factory() as session:
+        assert session.execute(text("SELECT count(*) FROM files")).scalar() == 1
+
+
+def test_reset_step_2_starts_from_a_clean_seeded_schema(
+    session_factory: DbSessionFactory,
+):
+    with session_factory() as session:
+        assert session.execute(text("SELECT count(*) FROM files")).scalar() == 0
+        assert (
+            session.execute(text("SELECT count(*) FROM pending_messages")).scalar() == 0
+        )
+        for table, count in SEED_COUNTS.items():
+            assert (
+                session.execute(text(f"SELECT count(*) FROM {table}")).scalar() == count
+            )
+        assert len(session.execute(select(ErrorCodeDb)).scalars().all()) == 25
+        # RESTART IDENTITY: the burnt sequence value is back to 1.
+        assert (
+            session.execute(
+                text("SELECT nextval(pg_get_serial_sequence('file_pins', 'id'))")
+            ).scalar()
+            == 1
+        )
+        # Triggers are enabled again even if a previous test disabled one.
+        enabled = session.execute(
+            text(
+                "SELECT count(*) FROM pg_trigger WHERE NOT tgisinternal AND tgenabled = 'O'"
+            )
+        ).scalar()
+        assert enabled == 2
+
+
+def test_reset_step_3_trigger_left_disabled_is_re_enabled(
+    session_factory: DbSessionFactory,
+):
+    with session_factory() as session:
+        session.execute(text("ALTER TABLE messages DISABLE TRIGGER trg_message_counts"))
+        session.commit()
+
+
+def test_reset_step_4_sees_trigger_enabled(session_factory: DbSessionFactory):
+    with session_factory() as session:
+        state = session.execute(
+            text("SELECT tgenabled FROM pg_trigger WHERE tgname = 'trg_message_counts'")
+        ).scalar()
+        assert state == "O"
+
+
+@pytest.mark.fresh_schema
+def test_fresh_schema_marker_rebuilds(session_factory: DbSessionFactory, migrated_db):
+    # A marked test gets a rebuilt schema and a refreshed seed snapshot.
+    with session_factory() as session:
+        for table, count in SEED_COUNTS.items():
+            assert (
+                session.execute(text(f"SELECT count(*) FROM {table}")).scalar() == count
+            )
+    assert set(migrated_db.seed_tables) == set(SEED_COUNTS)

--- a/tests/db/test_session_factory.py
+++ b/tests/db/test_session_factory.py
@@ -1,16 +1,28 @@
-"""The DB fixtures: one migration per session, delete + seed restore per test."""
+"""The DB fixtures: one migration per session, delete + seed restore per test.
+
+The `test_reset_step_N` tests are a deliberate ordered sequence: each one sets
+up the state the next one asserts on. pytest collects tests in definition order
+and the project uses neither pytest-randomly nor pytest-xdist, so the order
+holds for a normal run. Running a subset (`-k`, `--lf`) skips the steps whose
+predecessor did not run rather than failing.
+"""
 
 import datetime as dt
 
 import pytest
 from aleph_message.models import Chain, ItemType, MessageType
+from db_seeds import EXPECTED_CRON_JOB_ROWS, EXPECTED_ERROR_CODE_ROWS
 from sqlalchemy import select, text
 
 from aleph.db.models import ErrorCodeDb, PendingMessageDb, StoredFileDb
 from aleph.types.db_session import DbSessionFactory
 from aleph.types.files import FileType
 
-SEED_COUNTS = {"alembic_version": 1, "cron_jobs": 3, "error_codes": 25}
+SEED_COUNTS = {
+    "alembic_version": 1,
+    "cron_jobs": EXPECTED_CRON_JOB_ROWS,
+    "error_codes": EXPECTED_ERROR_CODE_ROWS,
+}
 
 # Filled in by the step tests below so that a later step can tell whether the
 # schema was rebuilt between the two: re-running the migrations recreates every
@@ -20,6 +32,13 @@ OBSERVED_OIDS: dict[str, int] = {}
 
 def _messages_oid(session) -> int:
     return session.execute(text("SELECT 'public.messages'::regclass::oid")).scalar()
+
+
+def _observed_oid(key: str, step: str) -> int:
+    """Read an OID recorded by an earlier step, or skip if that step did not run."""
+    if key not in OBSERVED_OIDS:
+        pytest.skip(f"runs only in sequence after {step}")
+    return OBSERVED_OIDS[key]
 
 
 def test_migrated_db_snapshots_seed_tables(migrated_db):
@@ -80,7 +99,10 @@ def test_reset_step_2_starts_from_a_clean_seeded_schema(
             assert (
                 session.execute(text(f"SELECT count(*) FROM {table}")).scalar() == count
             )
-        assert len(session.execute(select(ErrorCodeDb)).scalars().all()) == 25
+        assert (
+            len(session.execute(select(ErrorCodeDb)).scalars().all())
+            == EXPECTED_ERROR_CODE_ROWS
+        )
         # RESTART IDENTITY: the burnt sequence value is back to 1.
         assert (
             session.execute(
@@ -129,11 +151,15 @@ def test_reset_step_6_drops_the_created_table_without_rebuilding(
             is None
         )
         # A table the test created is dropped in place: no rebuild needed.
-        assert _messages_oid(session) == OBSERVED_OIDS["before_created_table"]
+        assert _messages_oid(session) == _observed_oid(
+            "before_created_table", "test_reset_step_5_creates_a_table"
+        )
 
 
 def test_reset_step_7_drops_an_expected_table(session_factory: DbSessionFactory):
     with session_factory() as session:
+        # ccn_metrics_default is a leaf partition with no dependents, so dropping
+        # it exercises the missing-table path without cascading to other tables.
         session.execute(text("DROP TABLE public.ccn_metrics_default"))
         OBSERVED_OIDS["before_dropped_table"] = _messages_oid(session)
         session.commit()
@@ -150,7 +176,9 @@ def test_reset_step_8_rebuilds_after_an_expected_table_was_dropped(
             ).scalar()
             is not None
         )
-        assert _messages_oid(session) != OBSERVED_OIDS["before_dropped_table"]
+        assert _messages_oid(session) != _observed_oid(
+            "before_dropped_table", "test_reset_step_7_drops_an_expected_table"
+        )
         # Baseline for the marked test below, which must rebuild again.
         OBSERVED_OIDS["before_fresh_schema"] = _messages_oid(session)
 
@@ -164,5 +192,8 @@ def test_fresh_schema_marker_rebuilds(session_factory: DbSessionFactory, migrate
                 session.execute(text(f"SELECT count(*) FROM {table}")).scalar() == count
             )
         # The rebuild really re-ran the migrations rather than deleting rows.
-        assert _messages_oid(session) != OBSERVED_OIDS["before_fresh_schema"]
+        assert _messages_oid(session) != _observed_oid(
+            "before_fresh_schema",
+            "test_reset_step_8_rebuilds_after_an_expected_table_was_dropped",
+        )
     assert set(migrated_db.seed_tables) == set(SEED_COUNTS)

--- a/tests/helpers/db_seeds.py
+++ b/tests/helpers/db_seeds.py
@@ -1,0 +1,8 @@
+"""Row counts of the tables the migrations seed on a fresh schema.
+
+Shared by the tests that assert on a freshly migrated database so that a
+migration adding a seeded row is updated in one place instead of several.
+"""
+
+EXPECTED_ERROR_CODE_ROWS = 25
+EXPECTED_CRON_JOB_ROWS = 3


### PR DESCRIPTION
## Summary
`session_factory` dropped the schema and re-ran all 68 migrations for every DB-backed test (~0.8 s per test on CI, ~9 min of pytest per run; 30+ min on fsync-bound local disks). This PR migrates once per session and resets per test.

- **Session-scoped `migrated_db`**: one drop + `alembic upgrade head`, then a snapshot of the seeded tables (`alembic_version`, `cron_jobs`, `error_codes`, discovered by row count) into a `seed` schema.
- **Per-test reset** (`session_factory`, contract unchanged): probe non-empty tables with `EXISTS`, `DELETE` them under `SET LOCAL session_replication_role = replica` with a 5 s `lock_timeout`, restore seeds, `ALTER SEQUENCE ... RESTART` for read sequences, re-enable disabled user triggers, drop tables a test created. If an expected table is missing the schema is rebuilt. `TRUNCATE` was measured and rejected: it fsyncs a new relfilenode per relation (~112 ms/table locally, 4.5 s per reset).
- **`fresh_schema` marker** forces a full rebuild for tests that alter the schema (`test_migration_0061_column_additions_are_rerunnable` is marked). Drift detection compares table name sets only; DDL on existing tables is the marker's job.
- **Teardown guard**: a test that leaks a checked-out connection now fails at its source.
- **Migration 0017** no longer hard-codes `aleph.public.rejected_messages` (same table, same rows; nodes that already applied it are unaffected), and `run_db_migrations` passes `-x db_url=` (env.py ignored alembic's `tag=`). Covered by a test that migrates a scratch database under another name.
- Markers are now registered in pytest's list form (the inline-table form registered nothing; `ledger_hardware` was never registered either).

## Numbers
- Local full suite (fsync-bound disk): 30+ min before, **51 s** after (1026 passed, 6 pre-existing Ethereum-RPC errors).
- `session_factory` setup: ~0.8 s -> ~0.03 s per test; `tests/db/test_credit_balances.py` 288 s -> 7.5 s locally.
- CI `tests` job baseline on `main`: ~10 min (7.5 min in May). Fill in the after number from this PR's run.

## Requirements
The test role must be a superuser (`session_replication_role`, `CREATE DATABASE` in the migration test); CI's `postgres:15.1` with `POSTGRES_USER: aleph` already is. A non-superuser now gets a clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEusSpUkyY6EU1JayZJpHh