### PR TITLE
fix(ethereum): always fetch logs in bounded batches

### DIFF
--- a/src/aleph/chains/ethereum.py
+++ b/src/aleph/chains/ethereum.py
@@ -2,17 +2,7 @@ import asyncio
 import importlib.resources
 import json
 import logging
-from typing import (
-    Any,
-    AsyncIterator,
-    Dict,
-    List,
-    Literal,
-    Self,
-    Tuple,
-    TypedDict,
-    Union,
-)
+from typing import Any, AsyncIterator, Dict, List, Self, Tuple, TypedDict, Union
 
 from aleph_message.models import Chain
 from configmanager import Config
@@ -53,7 +43,7 @@ class GetLogsException(Exception): ...
 
 class TooManyLogsInRange(GetLogsException):
     start_block: BlockNumber
-    end_block: BlockNumber | Literal["latest"]
+    end_block: BlockNumber
 
 
 class FeeEstimate(TypedDict, total=False):
@@ -172,7 +162,7 @@ class EthereumConnector(ChainWriter):
     async def _get_logs_in_block_range(
         self,
         start_block: BlockNumber,
-        end_block: BlockNumber | Literal["latest"] = "latest",
+        end_block: BlockNumber,
     ) -> List[LogReceipt]:
         """
         Retrieves logs from the Aleph message sync contract and handles RPC-specific exceptions.
@@ -197,9 +187,6 @@ class EthereumConnector(ChainWriter):
             # Unexpected issue, pass the exception to the caller
             raise
 
-    async def _get_all_logs(self, start_block: BlockNumber) -> List[LogReceipt]:
-        return await self._get_logs_in_block_range(start_block, "latest")
-
     async def _get_all_logs_in_batches(
         self, start_block: BlockNumber, max_block_range: int
     ) -> AsyncIterator[LogReceipt]:
@@ -207,6 +194,10 @@ class EthereumConnector(ChainWriter):
 
         while True:
             last_eth_block = await self.web3_client.eth.block_number
+            # Already synced to the chain tip, nothing to fetch. Some RPC
+            # providers reject requests where fromBlock > toBlock.
+            if start_block > last_eth_block:
+                return
             # Note: the range in get_logs is [start, end].
             end_block = min(last_eth_block, BlockNumber(start_block + block_range - 1))
 
@@ -231,17 +222,9 @@ class EthereumConnector(ChainWriter):
                 break
 
     async def _get_logs(self, start_block: BlockNumber) -> AsyncIterator[LogReceipt]:
-        # First, try to fetch all available blocks
-        try:
-            for log in await self._get_all_logs(start_block=start_block):
-                yield log
-            return
-        except TooManyLogsInRange:
-            LOGGER.info(
-                f"Too many logs in range {start_block}..latest, fetching in batches"
-            )
-
-        # If that fails, try fetching in batches until we get all logs.
+        # Always fetch in batches of at most `max_block_range` blocks. Fetching
+        # everything in one request is not an option as RPC providers signal
+        # oversized requests in provider-specific ways we cannot all detect.
         async for log in self._get_all_logs_in_batches(
             start_block=start_block, max_block_range=self.max_block_range
         ):

--- a/tests/chains/test_ethereum.py
+++ b/tests/chains/test_ethereum.py
@@ -465,6 +465,144 @@ async def test_fetch_ethereum_sync_events_sync_failure(
 
 
 @pytest.mark.asyncio
+async def test_sync_fetches_logs_in_bounded_block_ranges(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+    web3_client: AsyncWeb3,
+    deployed_contract,
+):
+    mock_config.ethereum.max_gas_price.value = 100_000_000_000
+    mock_config.ethereum.message_delay.value = 0.1
+    mock_config.ethereum.client_timeout.value = 1
+
+    account = Account.from_key(HexBytes(mock_config.ethereum.private_key.value))
+    mock_config.ethereum.authorized_emitters.value = [account.address]
+
+    pending_tx_publisher = mocker.AsyncMock()
+    chain_data_service = mocker.AsyncMock()
+    mock_payload = mocker.MagicMock()
+    mock_payload.json.return_value = json.dumps(
+        {"protocol": "on_chain_sync", "version": 1, "content": {"test": "data"}}
+    )
+    chain_data_service.prepare_sync_event_payload = mocker.AsyncMock(
+        return_value=mock_payload
+    )
+
+    connector = await EthereumConnector.new(
+        config=mock_config,
+        session_factory=session_factory,
+        pending_tx_publisher=pending_tx_publisher,
+        chain_data_service=chain_data_service,
+    )
+    connector.max_block_range = 2
+
+    start_height = await web3_client.eth.block_number
+
+    # Emit sync events in 3 different blocks so the sync spans several ranges
+    for i in range(3):
+        response = await connector.broadcast_messages(
+            account=account,
+            messages=[
+                MessageDb(
+                    item_hash=f"hash{i}",
+                    type="STORE",
+                    chain=Chain.ETH,
+                    sender="sender",
+                    signature=f"sig{i}",
+                    item_type="inline",
+                    item_content=f"content{i}",
+                    content={"address": "sender", "time": 1600000000 + i},
+                    time=timestamp_to_datetime(1600000000 + i),
+                    size=0,
+                )
+            ],
+            nonce=await web3_client.eth.get_transaction_count(account.address),
+        )
+        await web3_client.eth.wait_for_transaction_receipt(response)
+
+    with session_factory() as session:
+        upsert_chain_sync_status(
+            session=session,
+            chain=Chain.ETH,
+            sync_type=ChainEventType.SYNC,
+            height=start_height,
+            update_datetime=utc_now(),
+        )
+        session.commit()
+
+    # Spy on the actual RPC filters passed to eth_getLogs
+    real_get_logs = connector.web3_client.eth.get_logs
+    get_logs_filters = []
+
+    async def spy_get_logs(filter_params):
+        get_logs_filters.append(filter_params)
+        return await real_get_logs(filter_params)
+
+    mocker.patch.object(connector.web3_client.eth, "get_logs", side_effect=spy_get_logs)
+
+    await connector.fetch_ethereum_sync_events()
+
+    # All 3 events must be picked up despite the bounded ranges
+    assert pending_tx_publisher.add_and_publish_pending_tx.call_count == 3
+
+    # Every request must span a bounded, explicit block range: never
+    # "latest", and never more than max_block_range blocks at once.
+    assert get_logs_filters
+    for filter_params in get_logs_filters:
+        assert filter_params["toBlock"] != "latest"
+        block_span = filter_params["toBlock"] - filter_params["fromBlock"] + 1
+        assert block_span <= connector.max_block_range
+
+
+@pytest.mark.asyncio
+async def test_sync_when_already_at_chain_tip_requests_no_logs(
+    mocker,
+    mock_config: Config,
+    session_factory: DbSessionFactory,
+    web3_client: AsyncWeb3,
+    deployed_contract,
+):
+    mock_config.ethereum.max_gas_price.value = 100_000_000_000
+    mock_config.ethereum.message_delay.value = 0.1
+    mock_config.ethereum.client_timeout.value = 1
+
+    pending_tx_publisher = mocker.AsyncMock()
+    chain_data_service = mocker.AsyncMock()
+
+    connector = await EthereumConnector.new(
+        config=mock_config,
+        session_factory=session_factory,
+        pending_tx_publisher=pending_tx_publisher,
+        chain_data_service=chain_data_service,
+    )
+
+    # Mark the node as synced up to the current chain tip
+    current_height = await web3_client.eth.block_number
+    with session_factory() as session:
+        upsert_chain_sync_status(
+            session=session,
+            chain=Chain.ETH,
+            sync_type=ChainEventType.SYNC,
+            height=current_height,
+            update_datetime=utc_now(),
+        )
+        session.commit()
+
+    get_logs_spy = mocker.patch.object(
+        connector.web3_client.eth, "get_logs", side_effect=AssertionError
+    )
+
+    # There is nothing to fetch: the connector must return without issuing
+    # an inverted (fromBlock > toBlock) eth_getLogs request, which some RPC
+    # providers reject.
+    await connector.fetch_ethereum_sync_events()
+
+    get_logs_spy.assert_not_called()
+    pending_tx_publisher.add_and_publish_pending_tx.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_fetch_ethereum_sync_events_batching(
     mocker,
     mock_config: Config,


### PR DESCRIPTION
## Problem

Fresh installs cannot sync Ethereum on-chain messages with most RPC providers.

`_get_logs` first tried to fetch everything in a single `eth_getLogs` request from the last synced height (11.4M on a fresh install) to `latest`, and only fell back to batched fetching when the provider rejected the request with error code `-32005` (Infura's convention). Providers that signal oversized ranges differently (`-32000`, `-32602`, "block range too large", HTTP 413, or plain timeouts) made the request fail without triggering the fallback. The exception bubbled up to the retry loop in `fetch_sync_events_task`, which restarted the sync from scratch: an infinite retry loop with zero progress. Established nodes were unaffected since their block delta is small, which is why only fresh installs hit this.

## Solution

There is no reliable way to detect every provider-specific failure mode, so stop trying the optimistic full-range request altogether:

- `_get_logs` now always fetches in batches of at most `max_block_range` blocks (default 100,000). The existing range-halving logic for `-32005` responses within a batch is kept.
- When the node is already synced to the chain tip, return without issuing a request. This case was previously absorbed by the `start..latest` request; without a guard, every poll on a caught-up node would send `fromBlock > toBlock`, which some providers reject.
- Removed the now-unneeded `Literal["latest"]` typing.

A fresh mainnet install now issues ~120 bounded requests instead of one unbounded one.

## Tests

- `test_sync_fetches_logs_in_bounded_block_ranges`: spies on the actual filters passed to `eth_getLogs` and asserts every request spans an explicit range of at most `max_block_range` blocks while all emitted events are still picked up.
- `test_sync_when_already_at_chain_tip_requests_no_logs`: asserts a caught-up sync issues no `eth_getLogs` request at all.

Full `tests/chains/` suite passes locally (43 passed, 3 skipped) against anvil.
