### PR TITLE
fix(metrics): do not report -1 as the ETH reference height on provider errors

### DIFF
--- a/src/aleph/web/controllers/metrics.py
+++ b/src/aleph/web/controllers/metrics.py
@@ -177,7 +177,8 @@ async def fetch_eth_height() -> Optional[int]:
         w3 = AsyncWeb3(provider)
         return await w3.eth.block_number
     except aiohttp.ClientResponseError:
-        return -1
+        LOGGER.warning("ETH height could not be obtained")
+        return None
     finally:
         await provider.disconnect()
 

--- a/tests/web/controllers/test_metrics.py
+++ b/tests/web/controllers/test_metrics.py
@@ -1,8 +1,13 @@
 from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
 
 from aleph.web.controllers.metrics import (
     BuildInfo,
     Metrics,
+    fetch_eth_height,
     format_dataclass_for_prometheus,
     format_dict_for_prometheus,
 )
@@ -39,6 +44,38 @@ def test_format_dataclass_for_prometheus() -> None:
         format_dataclass_for_prometheus(Tagged(Simple(1, 2.2, "3"), "e"))
         == 'd{a=1,b=2.2,c="3"} 1\ne "e"'
     )
+
+
+@pytest.mark.asyncio
+async def test_fetch_eth_height_returns_none_on_client_response_error(mock_config):
+    """A provider error (e.g. a 429 rate limit) must not be reported as a height.
+
+    Returning -1 used to make eth_height_remaining_total = 0, falsely
+    signaling a fully synced node. The metric must be omitted instead.
+    """
+    mock_config.ethereum.enabled.value = True
+
+    error = aiohttp.ClientResponseError(
+        request_info=MagicMock(), history=(), status=429
+    )
+
+    async def raise_client_response_error():
+        raise error
+
+    w3 = MagicMock()
+    w3.eth.block_number = raise_client_response_error()
+
+    with (
+        patch(
+            "aleph.web.controllers.metrics.AsyncHTTPProvider",
+            return_value=AsyncMock(),
+        ),
+        patch("aleph.web.controllers.metrics.AsyncWeb3", return_value=w3),
+    ):
+        # Call the undecorated function to bypass the aiocache TTL cache
+        height = await fetch_eth_height.__wrapped__()
+
+    assert height is None
 
 
 def test_metrics():


### PR DESCRIPTION
## Problem

`fetch_eth_height()` returns `-1` when the Ethereum RPC provider replies with an error (e.g. a 429 rate limit). The value is cached for 10 minutes and exported as `pyaleph_status_chain_eth_height_reference_total = -1`, which makes `pyaleph_status_chain_eth_height_remaining_total = max(-1 - last_committed_height, 0) = 0`. A failing provider therefore makes the node look fully synced.

## Fix

Return `None` instead (with a warning log), matching the behavior of `fetch_reference_total_messages()`. The Prometheus formatter and the remaining-height computation already skip `None`, so both metrics are simply omitted until the provider recovers.

## Tests

Added `test_fetch_eth_height_returns_none_on_client_response_error`, which mocks the web3 provider to raise `aiohttp.ClientResponseError` and asserts the function returns `None`.