### PR TITLE
fix(config): lower the default ethereum.max_block_range from 100k to 10k

### DIFF
--- a/src/aleph/config.py
+++ b/src/aleph/config.py
@@ -191,7 +191,7 @@ def get_defaults():
             # Ethereum block height to start from when fetching sync events.
             "start_height": 11_400_000,
             # Largest range of blocks used when synchronizing messages in batches.
-            "max_block_range": 100_000,
+            "max_block_range": 10_000,
             # Delay in seconds between publication attempts.
             "commit_delay": 35,
             # Maximum gas price accepted when publishing to Ethereum.


### PR DESCRIPTION
Lowers the default `ethereum.max_block_range` from 100,000 to 10,000 blocks.

Many RPC providers reject or rate-limit `eth_getLogs` queries spanning very large block ranges, which breaks batch synchronization with the 100k default. 10k stays within common provider limits. Operators with permissive endpoints can still raise the value in their node configuration.

One-line change to the default in `src/aleph/config.py`; no code path depends on the previous value.