### PR TITLE
fix(vprogram): reject coerced scalars at ingestion (serde parity)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,7 @@ dependencies = [
   "aiohttp-swagger3>=0.10.0",
   "aioipfs~=0.7.1",
   "alembic==1.19.1",
-  # TODO: swap for the aleph-message release carrying serde-strict
-  # V-PROGRAM scalars (aleph-im/aleph-message#160) before merging.
-  "aleph-message @ git+https://github.com/aleph-im/aleph-message@62d2cfcf8b1bd535e80b76256602507c9c574f9c",
+  "aleph-message==1.3.1",
   "aleph-nuls2==0.1.1",
   "aleph-p2p-client @ git+https://github.com/aleph-im/p2p-service-client-python@1e992aaacdb0071a34ffb130cbbba9123509e08b",
   "asyncpg==0.31.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "alembic==1.19.1",
   # TODO: swap for the aleph-message release carrying serde-strict
   # V-PROGRAM scalars (aleph-im/aleph-message#160) before merging.
-  "aleph-message @ git+https://github.com/aleph-im/aleph-message@e2feb5c1005a1344ea5c373f9485e0de6279b297",
+  "aleph-message @ git+https://github.com/aleph-im/aleph-message@62d2cfcf8b1bd535e80b76256602507c9c574f9c",
   "aleph-nuls2==0.1.1",
   "aleph-p2p-client @ git+https://github.com/aleph-im/p2p-service-client-python@1e992aaacdb0071a34ffb130cbbba9123509e08b",
   "asyncpg==0.31.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,9 @@ dependencies = [
   "aiohttp-swagger3>=0.10.0",
   "aioipfs~=0.7.1",
   "alembic==1.19.1",
-  "aleph-message==1.3.0",
+  # TODO: swap for the aleph-message release carrying serde-strict
+  # V-PROGRAM scalars (aleph-im/aleph-message#160) before merging.
+  "aleph-message @ git+https://github.com/aleph-im/aleph-message@e2feb5c1005a1344ea5c373f9485e0de6279b297",
   "aleph-nuls2==0.1.1",
   "aleph-p2p-client @ git+https://github.com/aleph-im/p2p-service-client-python@1e992aaacdb0071a34ffb130cbbba9123509e08b",
   "asyncpg==0.31.0",

--- a/tests/messages/test_vprogram.py
+++ b/tests/messages/test_vprogram.py
@@ -1,9 +1,15 @@
 import json
 from typing import Any, Dict
 
+import pytest
 from aleph_message.models import MessageType, VerifiableProgramContent
+from pydantic import ValidationError
 
-from aleph.db.models.messages import CONTENT_TYPE_MAP, extract_tags
+from aleph.db.models.messages import (
+    CONTENT_TYPE_MAP,
+    extract_tags,
+    validate_message_content,
+)
 from aleph.schemas.api.messages import VProgramMessage, format_message_dict
 from aleph.schemas.pending_messages import PendingVProgramMessage, parse_message
 
@@ -98,3 +104,45 @@ def test_format_message_dict_vprogram():
     assert isinstance(formatted, VProgramMessage)
     assert formatted.type == MessageType.v_program
     assert formatted.content.runtime.ref == "cafe" * 16
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("resources", "vcpus"), "2"),
+        (("resources", "vcpus"), 2.0),
+        (("resources", "memory"), "2048"),
+        (("verification", "policy"), 196608.0),
+        (("verification", "policy"), "196608"),
+        (("environment", "internet"), "true"),
+        (("environment", "internet"), 1),
+        (("allow_amend",), 0),
+        (("time",), "1719502000.0"),
+    ],
+)
+def test_ingestion_rejects_coerced_vprogram_scalars(path, value):
+    """A scalar serde would reject must not reach processed status.
+
+    The node stores and serves the raw item_content, so a value pydantic
+    would merely coerce ("1" -> 1, 196608.0 -> 196608, "true" -> True)
+    becomes a processed message that strict decoders (the aleph-rs SDK)
+    cannot parse; one such message used to poison the scheduler's whole
+    page-strict history fetch (aleph-rs#386). aleph-message enforces serde
+    parity for V-PROGRAM scalars; this pins the behavior at the ingestion
+    entry point.
+    """
+    content: Dict[str, Any] = json.loads(json.dumps(VPROGRAM_CONTENT))
+    target: Any = content
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+    with pytest.raises(ValidationError):
+        validate_message_content(MessageType.v_program, content)
+
+
+def test_ingestion_accepts_integer_vprogram_time():
+    # serde parses an integer JSON number into f64: an integral time is valid
+    content: Dict[str, Any] = json.loads(json.dumps(VPROGRAM_CONTENT))
+    content["time"] = 1719502000
+    parsed = validate_message_content(MessageType.v_program, content)
+    assert parsed.time == 1719502000.0


### PR DESCRIPTION
Consumer side of aleph-im/aleph-message#160.

## Problem

The node validates V-PROGRAM content with the aleph-message models but stores and serves the **raw** `item_content` dict (`MessageDb.from_pending_message` keeps `content=content_dict`). Any coercion pydantic performs during validation (`"vcpus": "1"` -> `1`, `"policy": 196608.0` -> `196608`, `"internet": "true"` -> `True`) therefore produces a *processed* message whose served content strict decoders (the aleph-rs SDK) cannot parse. One such message poisons the scheduler's page-strict history fetch on every poll (mitigated read-side by aleph-im/aleph-rs#386); this closes the gap at the network acceptance boundary.

Found by differential-fuzzing aleph-message 1.3.0 against aleph-rs v0.17.0. All V-PROGRAM messages ever published already conform, so nothing grandfathered breaks. Scoped to V-PROGRAM (PROGRAM/INSTANCE history may contain coerced legacy messages that must keep re-validating during sync).

## Change

- Bump `aleph-message` to the git rev carrying serde-strict V-PROGRAM scalars.
- Ingestion-level regression tests: coerced scalars raise through `validate_message_content`, integral `time` stays accepted (serde parses integer JSON into f64).

**Merge gate:** swap the git pin for the released aleph-message version once aleph-im/aleph-message#160 is released (same flow as #1220).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkaSkidXtLL63prnqo7NS5