### PR TITLE
Fix sync stall caused by Infura getLogs error code change

### DIFF
--- a/src/aleph/chains/ethereum.py
+++ b/src/aleph/chains/ethereum.py
@@ -37,6 +37,11 @@ LOGGER = logging.getLogger("chains.ethereum")
 LOGGER.setLevel(logging.INFO)
 CHAIN_NAME = "ETH"
 
+# JSON-RPC error codes indicating that a getLogs request exceeds the
+# provider's block range limit. Infura used to return -32005 but now
+# returns -32602, and may return -32600 on some endpoints/networks.
+BLOCK_RANGE_LIMIT_ERROR_CODES = frozenset({-32005, -32602, -32600})
+
 
 class GetLogsException(Exception): ...
 
@@ -181,7 +186,7 @@ class EthereumConnector(ChainWriter):
         except Web3RPCError as e:
             # Handle limit exceptions
             if rpc_response := e.rpc_response:
-                if rpc_response["error"]["code"] == -32005:
+                if rpc_response["error"]["code"] in BLOCK_RANGE_LIMIT_ERROR_CODES:
                     raise TooManyLogsInRange(start_block, end_block) from e
 
             # Unexpected issue, pass the exception to the caller


### PR DESCRIPTION
## Problem

Infura changed the JSON-RPC error code it returns when a `getLogs` request exceeds the block range limit: it previously returned `-32005` and now returns `-32602` (with `-32600` also possible on some endpoints/networks, per their deprecation email).

The halving backoff in the Ethereum chain client only triggered on `-32005`, so nodes using Infura would no longer detect oversized `getLogs` requests and would stall permanently on sync.

## Fix

Trigger the block-range halving backoff in `_get_logs_in_block_range` on any of `-32005`, `-32602`, or `-32600`, via a small `frozenset` of error codes (`BLOCK_RANGE_LIMIT_ERROR_CODES`).

## Notes

- Tests could not be run in the sandbox (web3/anvil unavailable); CI should cover it.