### PR TITLE
fix(cron): stop metrics partition drops from deadlocking with message inserts

### DIFF
--- a/src/aleph/jobs/cron/metrics_partition_job.py
+++ b/src/aleph/jobs/cron/metrics_partition_job.py
@@ -18,11 +18,26 @@ already present and nothing past the cutoff is a no-op.
 
 The DEFAULT partition is left untouched. If it ever contains rows the
 cron logs a warning (operational signal that the lookahead is too
-short or that out-of-range data is arriving)."""
+short or that out-of-range data is arriving).
+
+Locking. The metrics tables carry a foreign key to ``messages``, and every
+partition inherits it, so partition DDL locks ``messages`` too: CREATE
+PARTITION and DETACH create referential-integrity triggers on it (SHARE ROW
+EXCLUSIVE) and DROP removes them (ACCESS EXCLUSIVE). The message processor
+reads ``messages`` (ACCESS SHARE) and then upserts into it (ROW EXCLUSIVE)
+within one transaction. A cron transaction that escalates its own lock on
+``messages`` mid-way therefore forms a lock-upgrade cycle with any in-flight
+processor transaction, and PostgreSQL aborts one of the two. To rule that
+out, partition creation and each partition drop run in their own
+transaction, and the drop transaction takes ACCESS EXCLUSIVE on ``messages``
+as its first statement: a processor transaction that already holds a lock on
+``messages`` is allowed to upgrade past the queued request and commit, after
+which the cron proceeds. Every wait is bounded by ``PARTITION_LOCK_TIMEOUT``."""
 
 import datetime as dt
 import logging
-from typing import Iterable, List, Tuple
+from contextlib import contextmanager
+from typing import Iterable, Iterator, List, Tuple
 
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
@@ -42,12 +57,17 @@ LOGGER = logging.getLogger(__name__)
 
 PARTITIONED_TABLES = ("crn_metrics", "ccn_metrics")
 
-# Bound how long partition DDL may wait for the parent table's ACCESS EXCLUSIVE
-# lock. DETACH/CREATE PARTITION need that lock, and a scoring-metrics INSERT
-# holds ROW EXCLUSIVE; without a cap the maintenance job can queue ahead of — and
-# block — the message-processing INSERT path for a long time, stalling the whole
-# message-processing event loop. If the lock is contended the job defers this
-# table and retries next run (partition maintenance is idempotent).
+# Table the metrics partitions reference through their foreign key. See the
+# module docstring for why partition DDL has to lock it.
+REFERENCED_TABLE = "messages"
+
+# Bound how long partition DDL may wait for a contended lock: the parent
+# table's ACCESS EXCLUSIVE (held off by a scoring-metrics INSERT) or the
+# referenced table's ACCESS EXCLUSIVE (held off by any message-processing
+# transaction). Without a cap the maintenance job can queue ahead of, and
+# block, the message-processing INSERT path for a long time, stalling the
+# whole message-processing event loop. If a lock is contended the job defers
+# this table and retries next run (partition maintenance is idempotent).
 PARTITION_LOCK_TIMEOUT = "5s"
 
 
@@ -78,27 +98,29 @@ class MetricsPartitionCronJob(BaseCronJob):
         # exists, so range becomes [..., now_month + N + 1).
         lookahead_upper = add_months(now_month, self.lookahead_months + 1)
 
-        # One transaction per table so a lock timeout on one does not undo the
-        # other, and each runs under a bounded lock_timeout so maintenance never
-        # blocks the message-processing INSERT path.
+        # Partition creation and each partition drop get their own transaction
+        # so a lock timeout on one does not undo the others, and so no
+        # transaction ever escalates a lock it already holds on the referenced
+        # table (see the module docstring). Each runs under a bounded
+        # lock_timeout so maintenance never blocks the message-processing
+        # INSERT path.
         deferred = False
         for table in PARTITIONED_TABLES:
             try:
-                with self.session_factory() as session:
-                    session.execute(
-                        text(f"SET LOCAL lock_timeout = '{PARTITION_LOCK_TIMEOUT}'")
-                    )
+                with self._maintenance_transaction() as session:
                     self._ensure_partitions(session, table, now_month, lookahead_upper)
-                    self._drop_past_cutoff(session, table, cutoff)
                     self._warn_if_default_has_rows(session, table)
-                    session.commit()
+                    to_drop = _partitions_past_cutoff(session, table, cutoff)
+                for name, upper in to_drop:
+                    with self._maintenance_transaction() as session:
+                        self._drop_partition(session, table, name, upper, cutoff)
             except OperationalError as err:
-                # The parent lock is contended (a scoring INSERT is in flight)
-                # and lock_timeout fired -- or another transient operational
-                # error occurred. Either way, defer this table rather than
-                # blocking the write path. Returning False keeps last_run
-                # unadvanced so the next cron tick retries, instead of waiting a
-                # full interval.
+                # A lock is contended (a scoring INSERT or a message-processing
+                # transaction is in flight) and lock_timeout fired -- or another
+                # transient operational error occurred. Either way, defer this
+                # table rather than blocking the write path. Returning False
+                # keeps last_run unadvanced so the next cron tick retries,
+                # instead of waiting a full interval.
                 deferred = True
                 LOGGER.warning(
                     "Partition maintenance for %s deferred (%s); will retry next run",
@@ -107,6 +129,16 @@ class MetricsPartitionCronJob(BaseCronJob):
                 )
 
         return not deferred
+
+    @contextmanager
+    def _maintenance_transaction(self) -> Iterator[DbSession]:
+        """One committed transaction with the bounded lock_timeout applied."""
+        with self.session_factory() as session:
+            session.execute(
+                text(f"SET LOCAL lock_timeout = '{PARTITION_LOCK_TIMEOUT}'")
+            )
+            yield session
+            session.commit()
 
     @staticmethod
     def _ensure_partitions(
@@ -138,28 +170,36 @@ class MetricsPartitionCronJob(BaseCronJob):
             )
 
     @staticmethod
-    def _drop_past_cutoff(session: DbSession, table: str, cutoff: dt.datetime) -> None:
-        """DETACH + DROP partitions whose upper bound is <= cutoff.
+    def _drop_partition(
+        session: DbSession,
+        table: str,
+        name: str,
+        upper: dt.datetime,
+        cutoff: dt.datetime,
+    ) -> None:
+        """DETACH + DROP one partition, in the caller's transaction.
 
         DETACH briefly takes ACCESS EXCLUSIVE on the parent, then the
         DROP only touches the now-standalone child. Metrics tables are
         not on a latency-sensitive read path so plain DETACH is fine;
         CONCURRENTLY would require autocommit, which the cron's
-        transactional session doesn't offer."""
-        for name, lower, upper in _list_partitions(session, table):
-            if upper is None or lower is None:
-                # The DEFAULT partition has no bounds. Skip.
-                continue
-            if upper <= cutoff:
-                LOGGER.info(
-                    "Dropping partition %s on %s (upper=%s <= cutoff=%s)",
-                    name,
-                    table,
-                    upper.isoformat(),
-                    cutoff.isoformat(),
-                )
-                session.execute(text(f"ALTER TABLE {table} DETACH PARTITION {name}"))
-                session.execute(text(f"DROP TABLE {name}"))
+        transactional session doesn't offer.
+
+        Both statements also lock the referenced table through the
+        partition's foreign key (DETACH: SHARE ROW EXCLUSIVE, DROP: ACCESS
+        EXCLUSIVE). Take the strongest mode first so this transaction never
+        escalates a lock it already holds on it, which would deadlock with
+        the message processor's own read-then-upsert escalation."""
+        LOGGER.info(
+            "Dropping partition %s on %s (upper=%s <= cutoff=%s)",
+            name,
+            table,
+            upper.isoformat(),
+            cutoff.isoformat(),
+        )
+        session.execute(text(f"LOCK TABLE {REFERENCED_TABLE} IN ACCESS EXCLUSIVE MODE"))
+        session.execute(text(f"ALTER TABLE {table} DETACH PARTITION {name}"))
+        session.execute(text(f"DROP TABLE {name}"))
 
     @staticmethod
     def _warn_if_default_has_rows(session: DbSession, table: str) -> None:
@@ -172,6 +212,19 @@ class MetricsPartitionCronJob(BaseCronJob):
                 default_name,
                 result,
             )
+
+
+def _partitions_past_cutoff(
+    session: DbSession, parent: str, cutoff: dt.datetime
+) -> List[Tuple[str, dt.datetime]]:
+    """Return (child_name, upper_bound) for every bounded partition of
+    `parent` whose upper bound is <= cutoff. The DEFAULT partition has no
+    bounds and is never returned."""
+    return [
+        (name, upper)
+        for name, lower, upper in _list_partitions(session, parent)
+        if lower is not None and upper is not None and upper <= cutoff
+    ]
 
 
 def _list_partitions(

--- a/tests/jobs/test_metrics_partition_job.py
+++ b/tests/jobs/test_metrics_partition_job.py
@@ -6,8 +6,11 @@ We test the moving parts by passing custom retention/lookahead values
 that force the job to either create or drop partitions.
 """
 
+import asyncio
 import datetime as dt
 import logging
+import threading
+import time
 
 import pytest
 from aleph_message.models import Chain, ItemType, MessageType
@@ -312,3 +315,120 @@ async def test_cron_defers_table_when_parent_lock_is_contended(
     assert await job.run(now=now, job=_make_cron_row()) is True
     with session_factory() as session:
         assert crn_expected in {n for n, _, _ in _list(session, "crn_metrics")}
+
+
+def _scoring_message(item_hash: str) -> MessageDb:
+    return MessageDb(
+        item_hash=item_hash,
+        type=MessageType.post,
+        chain=Chain.ETH,
+        sender="0x4D52380D3191274a04846c89c069E6C3F2Ed94e4",
+        channel=Channel("aleph-scoring"),
+        signature=None,
+        item_type=ItemType.inline,
+        item_content="{}",
+        content={
+            "type": "aleph-network-metrics",
+            "address": "0x4D52380D3191274a04846c89c069E6C3F2Ed94e4",
+            "content": {},
+            "time": 0.0,
+        },
+        time=dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc),
+        size=2,
+    )
+
+
+def _wait_for_lock_request(session, relation: str, mode: str, timeout: float) -> bool:
+    """Poll pg_locks until some backend is waiting (not granted) for `mode`
+    on `relation`."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        waiting = session.execute(
+            text(
+                "SELECT count(*) FROM pg_locks "
+                "WHERE NOT granted AND mode = :mode "
+                "AND relation = CAST(:relation AS regclass)"
+            ),
+            {"mode": mode, "relation": relation},
+        ).scalar()
+        if waiting:
+            return True
+        time.sleep(0.05)
+    return False
+
+
+@pytest.mark.asyncio
+async def test_partition_drop_does_not_deadlock_with_message_insert(
+    session_factory: DbSessionFactory,
+):
+    """The metrics partitions carry a FK to `messages`, so dropping one takes
+    an ACCESS EXCLUSIVE lock on `messages` (to remove the RI triggers). The
+    message processor reads `messages` (ACCESS SHARE) before it inserts (ROW
+    EXCLUSIVE) in the same transaction. If the cron takes a weaker lock on
+    `messages` earlier in the same transaction (DETACH creates RI triggers
+    under SHARE ROW EXCLUSIVE), the two lock upgrades form a cycle and
+    PostgreSQL aborts one side. Both sides must succeed."""
+    now = dt.datetime.now(tz=dt.timezone.utc)
+    cutoff = add_months(month_floor(now), -1)
+    with session_factory() as session:
+        to_drop = [
+            name
+            for name, _, upper in _list(session, "crn_metrics")
+            if upper is not None and upper <= cutoff
+        ]
+    assert to_drop, "Expected at least one partition past the new cutoff"
+
+    job = MetricsPartitionCronJob(
+        session_factory=session_factory,
+        retention_months=1,
+        lookahead_months=1,
+    )
+
+    insert_result: dict = {}
+
+    def message_processor():
+        # Same shape as MessageHandler.process(): existence check, then upsert,
+        # in one transaction.
+        with session_factory() as processor:
+            processor.execute(
+                text("SELECT 1 FROM messages WHERE item_hash = :h"),
+                {"h": "msg-deadlock"},
+            )
+            try:
+                # Dropping a partition needs ACCESS EXCLUSIVE on messages (RI
+                # trigger removal). Wait until the cron is queued behind our
+                # ACCESS SHARE before we upgrade to ROW EXCLUSIVE.
+                with session_factory() as watcher:
+                    blocked = _wait_for_lock_request(
+                        watcher, "messages", "AccessExclusiveLock", timeout=10
+                    )
+                insert_result["cron_blocked"] = blocked
+                processor.add(_scoring_message("msg-deadlock"))
+                processor.commit()
+                insert_result["ok"] = True
+            except Exception as err:  # noqa: BLE001 - recorded for the assertion
+                processor.rollback()
+                insert_result["error"] = repr(err)
+
+    thread = threading.Thread(target=message_processor)
+    thread.start()
+    try:
+        result = await asyncio.get_running_loop().run_in_executor(
+            None, lambda: asyncio.run(job.run(now=now, job=_make_cron_row()))
+        )
+    finally:
+        thread.join(timeout=30)
+    assert not thread.is_alive(), "message processor thread hung"
+
+    assert insert_result.get("cron_blocked") is True, "cron never reached DROP"
+    assert insert_result.get("ok") is True, insert_result.get("error")
+    assert result is True
+
+    with session_factory() as session:
+        remaining = {n for n, _, _ in _list(session, "crn_metrics")}
+        inserted = session.execute(
+            text("SELECT count(*) FROM messages WHERE item_hash = 'msg-deadlock'")
+        ).scalar()
+    assert inserted == 1
+    for name in to_drop:
+        assert name not in remaining


### PR DESCRIPTION
## Problem

Nodes started logging this on 2026-09-01:

```
aleph.jobs.job_utils: Unexpected error while fetching message
psycopg2.errors.DeadlockDetected: deadlock detected
LINE 1: INSERT INTO messages (item_hash, type, chain, sender, signat...
DETAIL:  Process 8802 waits for RowExclusiveLock on relation 16454 of database 16384; blocked by process 8798.
Process 8798 waits for AccessExclusiveLock on relation 16454 of database 16384; blocked by process 8802.
```

Relation 16454 is `messages`. Process 8798 is the `metrics_partition` cron job.

The metrics tables carry a foreign key to `messages` (migration 0059), and every monthly partition inherits it. Dropping a partition therefore locks `messages` twice inside one cron transaction:

1. `ALTER TABLE ... DETACH PARTITION` creates standalone RI triggers on `messages`: **SHARE ROW EXCLUSIVE**.
2. `DROP TABLE` removes those triggers: **ACCESS EXCLUSIVE**.

The message processor escalates on `messages` the same way in one transaction: the existence check in `MessageHandler.process` takes ACCESS SHARE, then the upsert asks for ROW EXCLUSIVE. ROW EXCLUSIVE conflicts with the cron's SHARE ROW EXCLUSIVE, and ACCESS EXCLUSIVE conflicts with the processor's ACCESS SHARE. Each side holds what the other needs and PostgreSQL aborts one of them. Which one dies is arbitrary.

Retention drops only fire on the first cron tick of a new month (a partition's upper bound has to cross the 12 month cutoff), which is why this surfaced on September 1 and not during the month. The `lock_timeout` from #1247 does not cover it: the deadlock detector fires after `deadlock_timeout` (1s by default), long before the 5s cap.

Impact is limited: the message is retried, and when the cron is the victim it already catches the `OperationalError` and retries next tick. But it fires on every node twice a month (once per metrics table) whenever a drop coincides with an insert, and it looks alarming in the logs.

## Fix

- Partition creation and each partition drop now run in their own transaction.
- The drop transaction takes `LOCK TABLE messages IN ACCESS EXCLUSIVE MODE` as its first statement, before DETACH and DROP. The cron never escalates a lock it already holds on `messages`, so PostgreSQL lets an in-flight processor transaction upgrade past the queued request and commit, after which the cron proceeds. No cycle can form.
- The wait stays bounded by `PARTITION_LOCK_TIMEOUT` (5s). A timeout still defers the table to the next tick, as before.

The cost is one brief ACCESS EXCLUSIVE on `messages` per dropped partition, once a month per metrics table, held for the duration of DETACH + DROP (milliseconds). That lock was already being taken by DROP TABLE before this change; it is just taken first now. Removing it entirely would mean dropping the FK from the metrics tables, which is out of scope here.

## Test

`test_partition_drop_does_not_deadlock_with_message_insert` reproduces the production interleaving through the real job: a thread holds an open read on `messages`, waits (via `pg_locks`) until the cron is queued for ACCESS EXCLUSIVE on `messages`, then inserts a message and commits. Without the fix it fails with the exact `DeadlockDetected` error from the report; with the fix both the insert and the partition drop succeed.

The existing `test_cron_defers_table_when_parent_lock_is_contended` still passes, so the lock_timeout deferral from #1247 is preserved.

## Verification

```
PYTHONPATH=src pytest tests/jobs/test_metrics_partition_job.py -q
10 passed
```

black, isort and ruff are clean on both files. mypy reports no errors in the changed module (the remaining output is the pre-existing missing-stubs noise from other modules).
